### PR TITLE
enabled reference version to run without intrinsics implementation

### DIFF
--- a/src/clusterpair/force.h
+++ b/src/clusterpair/force.h
@@ -42,6 +42,8 @@ extern double computeForceLJCUDA(Parameter*, Atom*, Neighbor*, Stats*);
 #else
 #ifdef USE_REFERENCE_VERSION
 #define KERNEL_NAME "Reference"
+#define CLUSTER_M    1
+#define CLUSTER_N    VECTOR_WIDTH
 #else
 #define CLUSTER_M 4
 // Simd2xNN (here used for single-precision)

--- a/src/clusterpair/force_lj.c
+++ b/src/clusterpair/force_lj.c
@@ -163,6 +163,7 @@ double computeForceLJRef(Parameter* param, Atom* atom, Neighbor* neighbor, Stats
     return E - S;
 }
 
+#ifndef USE_REFERENCE_VERSION
 double computeForceLJ2xnnHalfNeigh(
     Parameter* param, Atom* atom, Neighbor* neighbor, Stats* stats)
 {
@@ -427,7 +428,13 @@ double computeForceLJ2xnnHalfNeigh(
     DEBUG_MESSAGE("computeForceLJ_2xnn end\n");
     return E - S;
 }
+#else
+double computeForceLJ2xnnHalfNeigh(
+    Parameter* param, Atom* atom, Neighbor* neighbor, Stats* stats) {}
+#endif
 
+
+#ifndef USE_REFERENCE_VERSION
 double computeForceLJ2xnnFullNeigh(
     Parameter* param, Atom* atom, Neighbor* neighbor, Stats* stats)
 {
@@ -608,7 +615,12 @@ double computeForceLJ2xnnFullNeigh(
     DEBUG_MESSAGE("computeForceLJ_2xnn end\n");
     return E - S;
 }
+#else
+double computeForceLJ2xnnFullNeigh(
+    Parameter* param, Atom* atom, Neighbor* neighbor, Stats* stats) {}
+#endif
 
+#ifndef USE_REFERENCE_VERSION
 double computeForceLJ4xnHalfNeigh(
     Parameter* param, Atom* atom, Neighbor* neighbor, Stats* stats)
 {
@@ -933,7 +945,12 @@ double computeForceLJ4xnHalfNeigh(
     DEBUG_MESSAGE("computeForceLJ_4xn end\n");
     return E - S;
 }
+#else
+double computeForceLJ4xnHalfNeigh(
+    Parameter* param, Atom* atom, Neighbor* neighbor, Stats* stats) {}
+#endif
 
+#ifndef USE_REFERENCE_VERSION
 double computeForceLJ4xnFullNeigh(
     Parameter* param, Atom* atom, Neighbor* neighbor, Stats* stats)
 {
@@ -1195,3 +1212,7 @@ double computeForceLJ4xnFullNeigh(
     DEBUG_MESSAGE("computeForceLJ_4xn end\n");
     return E - S;
 }
+#else
+double computeForceLJ4xnFullNeigh(
+    Parameter* param, Atom* atom, Neighbor* neighbor, Stats* stats) {}
+#endif

--- a/src/common/parameter.h
+++ b/src/common/parameter.h
@@ -7,12 +7,21 @@
 #ifndef __PARAMETER_H_
 #define __PARAMETER_H_
 
+#include <stdint.h>
 #if PRECISION == 1
 #define MD_FLOAT float
 #define MD_UINT  unsigned int
+#ifdef USE_REFERENCE_VERSION
+#define MD_SIMD_FLOAT float
+#define MD_SIMD_MASK uint16_t
+#endif
 #else
 #define MD_FLOAT double
 #define MD_UINT  unsigned long long int
+#ifdef USE_REFERENCE_VERSION
+#define MD_SIMD_FLOAT double
+#define MD_SIMD_MASK uint8_t
+#endif
 #endif
 
 typedef struct {

--- a/src/common/simd.h
+++ b/src/common/simd.h
@@ -62,6 +62,8 @@
 #define SIMD_PRINT_REAL(a) simd_print_real(#a, a);
 #define SIMD_PRINT_MASK(a) simd_print_mask(#a, a);
 
+extern unsigned int simd_mask_to_u32(MD_SIMD_MASK a);
+
 static inline void simd_print_real(const char* ref, MD_SIMD_FLOAT a)
 {
     double x[VECTOR_WIDTH];


### PR DESCRIPTION
This version allows users to run the reference version of Clusterpair even without an existing SIMD intrinsics implementation.

Please check if the `CLUSTER_M`/`CLUSTER_N` variables have the right values in `force.h`:

```c
#define CLUSTER_M    1
#define CLUSTER_N    VECTOR_WIDTH
```