### PR TITLE
Cluster Pair - SIMD Vectorized Neighbor Build and Support for Multiple Atom Types

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ options are available:
 SIMD other than NONE.
 - **SIMD:** Instruction set (available options: NONE, SSE, AVX, AVX\_FMA, AVX2, AVX512).
 - **MASK\_REGISTERS:** Use AVX512 mask registers (always true when ISA is set to AVX512).
-- **OPT\_SCHEME:** Optimization algorithm (available options: lammps, gromacs).
+- **OPT\_SCHEME:** Optimization algorithm (available options: verletlist, clusterpair).
 - **ENABLE\_LIKWID:** Enable likwid to make use of HPM counters.
 - **DATA\_TYPE:** Floating-point precision (available options: SP, DP).
 - **DATA\_LAYOUT:** Data layout for atom vector properties (available options: AOS, SOA).
@@ -87,7 +87,14 @@ Wellein: MD-Bench: A generic proxy-app toolbox for state-of-the-art molecular
 dynamics algorithms. Accepted for [PPAM](https://ppam.edu.pl/) 2022, the 14th
 International Conference on Parallel Processing and Applied Mathematics, Gdansk,
 Poland, September 11-14, 2022. PPAM 2022 Best Paper Award. Preprint:
-[arXiv:2207.13094](https://arxiv.org/abs/2207.13094)
+[arXiv:2207.13094](https://arxiv.org/abs/2207.13094), DOI:
+[https://dl.acm.org/doi/10.1007/978-3-031-30442-2_24](https://dl.acm.org/doi/10.1007/978-3-031-30442-2_24)
+
+Rafael Ravedutti Lucio Machado, Jan Eitzinger, Jan Laukemann, Georg Hager, Harald
+Köstler, Gerhard Wellein: MD-Bench: A performance-focused prototyping harness fo
+ state-of-the-art short-range molecular dynamics algorithms. Future Generation
+Computer Systems, Volume 149, 2023, Pages 25-38, ISSN 0167-739X, DOI:
+[https://doi.org/10.1016/j.future.2023.06.023](https://doi.org/10.1016/j.future.2023.06.023)
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -91,9 +91,9 @@ Poland, September 11-14, 2022. PPAM 2022 Best Paper Award. Preprint:
 [https://dl.acm.org/doi/10.1007/978-3-031-30442-2_24](https://dl.acm.org/doi/10.1007/978-3-031-30442-2_24)
 
 Rafael Ravedutti Lucio Machado, Jan Eitzinger, Jan Laukemann, Georg Hager, Harald
-Köstler, Gerhard Wellein: MD-Bench: A performance-focused prototyping harness fo
+Köstler and Gerhard Wellein: MD-Bench: A performance-focused prototyping harness fo
  state-of-the-art short-range molecular dynamics algorithms. Future Generation
-Computer Systems, Volume 149, 2023, Pages 25-38, ISSN 0167-739X, DOI:
+Computer Systems ([FGCS](https://www.sciencedirect.com/journal/future-generation-computer-systems)), Volume 149, 2023, Pages 25-38, ISSN 0167-739X, DOI:
 [https://doi.org/10.1016/j.future.2023.06.023](https://doi.org/10.1016/j.future.2023.06.023)
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -82,6 +82,12 @@ TBD
 
 ## Citations
 
+Rafael Ravedutti Lucio Machado, Jan Eitzinger, Jan Laukemann, Georg Hager, Harald
+Köstler and Gerhard Wellein: MD-Bench: A performance-focused prototyping harness fr
+ state-of-the-art short-range molecular dynamics algorithms. Future Generation
+Computer Systems ([FGCS](https://www.sciencedirect.com/journal/future-generation-computer-systems)), Volume 149, 2023, Pages 25-38, ISSN 0167-739X, DOI:
+[https://doi.org/10.1016/j.future.2023.06.023](https://doi.org/10.1016/j.future.2023.06.023)
+
 Rafael Ravedutti Lucio Machado, Jan Eitzinger, Harald Köstler, and Gerhard
 Wellein: MD-Bench: A generic proxy-app toolbox for state-of-the-art molecular
 dynamics algorithms. Accepted for [PPAM](https://ppam.edu.pl/) 2022, the 14th
@@ -89,12 +95,6 @@ International Conference on Parallel Processing and Applied Mathematics, Gdansk,
 Poland, September 11-14, 2022. PPAM 2022 Best Paper Award. Preprint:
 [arXiv:2207.13094](https://arxiv.org/abs/2207.13094), DOI:
 [https://dl.acm.org/doi/10.1007/978-3-031-30442-2_24](https://dl.acm.org/doi/10.1007/978-3-031-30442-2_24)
-
-Rafael Ravedutti Lucio Machado, Jan Eitzinger, Jan Laukemann, Georg Hager, Harald
-Köstler and Gerhard Wellein: MD-Bench: A performance-focused prototyping harness fo
- state-of-the-art short-range molecular dynamics algorithms. Future Generation
-Computer Systems ([FGCS](https://www.sciencedirect.com/journal/future-generation-computer-systems)), Volume 149, 2023, Pages 25-38, ISSN 0167-739X, DOI:
-[https://doi.org/10.1016/j.future.2023.06.023](https://doi.org/10.1016/j.future.2023.06.023)
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ TBD
 ## Citations
 
 Rafael Ravedutti Lucio Machado, Jan Eitzinger, Jan Laukemann, Georg Hager, Harald
-Köstler and Gerhard Wellein: MD-Bench: A performance-focused prototyping harness fr
- state-of-the-art short-range molecular dynamics algorithms. Future Generation
+Köstler and Gerhard Wellein: MD-Bench: A performance-focused prototyping harness for
+state-of-the-art short-range molecular dynamics algorithms. Future Generation
 Computer Systems ([FGCS](https://www.sciencedirect.com/journal/future-generation-computer-systems)), Volume 149, 2023, Pages 25-38, ISSN 0167-739X, DOI:
 [https://doi.org/10.1016/j.future.2023.06.023](https://doi.org/10.1016/j.future.2023.06.023)
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ SIMD other than NONE.
 - **DATA\_LAYOUT:** Data layout for atom vector properties (available options: AOS, SOA).
 - **ASM\_SYNTAX:** Assembly syntax to use when generating assembly files (available options: ATT, INTEL).
 - **DEBUG:** Toggle debug mode.
-- **EXPLICIT\_TYPES:** Explicitly store and load atom types.
+- **ONE\_ATOM\_TYPE:** Simulate only one atom type and do not perform table lookup for parameters.
 - **MEM\_TRACER:** Trace memory addresses for cache simulator.
 - **INDEX\_TRACER:** Trace indexes and distances for gather-md.
 - **COMPUTE\_STATS:** Compute statistics.
@@ -38,7 +38,6 @@ Configurations for GROMACS MxN optimization scheme:
 
 - **USE\_REFERENCE\_VERSION:** Use reference version (only for correction purposes).
 - **XTC\_OUTPUT:** Enable XTC output.
-- **HALF\_NEIGHBOR\_LISTS\_CHECK\_CJ:** Check if j-clusters are local when decreasing the reaction force.
 
 Configurations for CUDA:
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,3 @@
-- Cluster Pair: avx\_float and avx2\_float should not use _mmask types
-
 - Allow to resort atoms at a separate frequency independent of the neighboring
 frequency
 - Integrate and fix Super-Cluster GPU code

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,7 @@
 - Cluster Pair
     - Use SIMD for distance calculation when building neighbor lists
     - More than one atom type
+    - avx\_float and avx2\_float should not use _mmask types
 
 - By default, use several atom types (change EXPLICIT\_TYPES option to ONE\_ATOM\_TYPE and set it to false by default)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,4 @@
-- Cluster Pair
-    - Use SIMD for distance calculation when building neighbor lists
-    - More than one atom type
-    - avx\_float and avx2\_float should not use _mmask types
-
-- By default, use several atom types (change EXPLICIT\_TYPES option to ONE\_ATOM\_TYPE and set it to false by default)
+- Cluster Pair: avx\_float and avx2\_float should not use _mmask types
 
 - Allow to resort atoms at a separate frequency independent of the neighboring
 frequency

--- a/config.mk
+++ b/config.mk
@@ -39,8 +39,6 @@ ENABLE_OMP_SIMD ?= false
 USE_REFERENCE_VERSION ?= false
 # Enable XTC output (a GROMACS file format for trajectories)
 XTC_OUTPUT ?= false
-# Check if cj is local when decreasing reaction force
-HALF_NEIGHBOR_LISTS_CHECK_CJ ?= true
 
 # Configurations for CUDA
 # Use CUDA pinned memory to optimize transfers
@@ -142,10 +140,6 @@ endif
 
 ifeq ($(strip $(USE_REFERENCE_VERSION)),true)
     DEFINES += -DUSE_REFERENCE_VERSION
-endif
-
-ifeq ($(strip $(HALF_NEIGHBOR_LISTS_CHECK_CJ)),true)
-    DEFINES += -DHALF_NEIGHBOR_LISTS_CHECK_CJ
 endif
 
 ifeq ($(strip $(DEBUG)),true)

--- a/config.mk
+++ b/config.mk
@@ -21,8 +21,8 @@ DEBUG ?= false
 
 # Sort atoms when reneighboring (true or false)
 SORT_ATOMS ?= false
-# Explicitly store and load atom types (true or false)
-EXPLICIT_TYPES ?= false
+# Simulate only for one atom type, without table lookup for parameters (true or false)
+ONE_ATOM_TYPE ?= false
 # Trace memory addresses for cache simulator (true or false)
 MEM_TRACER ?= false
 # Trace indexes and distances for gather-md (true or false)
@@ -118,8 +118,8 @@ ifeq ($(strip $(SORT_ATOMS)),true)
     DEFINES += -DSORT_ATOMS
 endif
 
-ifeq ($(strip $(EXPLICIT_TYPES)),true)
-    DEFINES += -DEXPLICIT_TYPES
+ifeq ($(strip $(ONE_ATOM_TYPE)),true)
+    DEFINES += -DONE_ATOM_TYPE
 endif
 
 ifeq ($(strip $(MEM_TRACER)),true)

--- a/config.mk
+++ b/config.mk
@@ -1,19 +1,19 @@
 # Compiler tool chain (GCC/CLANG/ICC/ICX/ONEAPI/NVCC)
-TOOLCHAIN ?= CLANG
+TOOLCHAIN ?= ICC
 # ISA of instruction code (X86/ARM)
 ISA ?= X86
 # Instruction set for instrinsic kernels (NONE/<X86-SIMD>/<ARM-SIMD>)
 # with X86-SIMD options: NONE/SSE/AVX/AVX_FMA/AVX2/AVX512
 # with ARM-SIMD options: NONE/NEON/SVE/SVE2 (SVE not width-agnostic yet!)
-SIMD ?= AVX2
+SIMD ?= AVX512
 # Optimization scheme (verletlist/clusterpair)
-OPT_SCHEME ?= verletlist
+OPT_SCHEME ?= clusterpair
 # Enable likwid (true or false)
 ENABLE_LIKWID ?= false
 # Enable OpenMP parallelization (true or false)
-ENABLE_OPENMP ?= true
+ENABLE_OPENMP ?= false
 # SP or DP
-DATA_TYPE ?= DP
+DATA_TYPE ?= SP
 # AOS or SOA
 DATA_LAYOUT ?= AOS
 # Debug

--- a/config.mk
+++ b/config.mk
@@ -64,11 +64,15 @@ ifeq ($(strip $(SIMD)), NONE)
 else
 ifeq ($(strip $(ISA)),ARM)
     ifeq ($(strip $(SIMD)), NEON)
+        __ISA_NEON__=true
         __SIMD_WIDTH_DBL__=2
     else ifeq ($(strip $(SIMD)), SVE)
+        __ISA_SVE__=true
 		# needs further specification
         __SIMD_WIDTH_DBL__=2
     else ifeq ($(strip $(SIMD)), SVE2)
+        __ISA_SVE__=true
+        __ISA_SVE2__=true
         # needs further specification
         __SIMD_WIDTH_DBL__=2
     endif
@@ -172,6 +176,18 @@ endif
 
 ifeq ($(strip $(__ISA_AVX512__)),true)
     DEFINES += -D__ISA_AVX512__
+endif
+
+ifeq ($(strip $(__ISA_NEON__)),true)
+    DEFINES += -D__ISA_NEON__
+endif
+
+ifeq ($(strip $(__ISA_SVE__)),true)
+    DEFINES += -D__ISA_SVE__
+endif
+
+ifeq ($(strip $(__ISA_SVE2__)),true)
+    DEFINES += -D__ISA_SVE2__
 endif
 
 ifeq ($(strip $(ENABLE_OMP_SIMD)),true)

--- a/src/clusterpair/atom.c
+++ b/src/clusterpair/atom.c
@@ -25,7 +25,7 @@ void initAtom(Atom* atom)
     atom->cl_x            = NULL;
     atom->cl_v            = NULL;
     atom->cl_f            = NULL;
-    atom->cl_type         = NULL;
+    atom->cl_t            = NULL;
     atom->Natoms          = 0;
     atom->Nlocal          = 0;
     atom->Nghost          = 0;
@@ -670,7 +670,7 @@ void growClusters(Atom* atom)
         ALIGNMENT,
         atom->Nclusters_max * CLUSTER_M * 3 * sizeof(MD_FLOAT),
         nold * CLUSTER_M * 3 * sizeof(MD_FLOAT));
-    atom->cl_type      = (int*)reallocate(atom->cl_type,
+    atom->cl_t         = (int*)reallocate(atom->cl_t,
         ALIGNMENT,
         atom->Nclusters_max * CLUSTER_M * sizeof(int),
         nold * CLUSTER_M * sizeof(int));

--- a/src/clusterpair/atom.h
+++ b/src/clusterpair/atom.h
@@ -40,7 +40,7 @@ typedef struct {
     MD_FLOAT* cl_x;
     MD_FLOAT* cl_v;
     MD_FLOAT* cl_f;
-    int* cl_type;
+    int* cl_t;
     Cluster *iclusters, *jclusters;
     int* icluster_bin;
     int dummy_cj;

--- a/src/clusterpair/force.c
+++ b/src/clusterpair/force.c
@@ -26,10 +26,11 @@ void initForce(Parameter* param)
 #ifdef CUDA_TARGET
             computeForce = computeForceLJCUDA;
 #else
-            // Simd2xNN (here used for single-precision)
 #if VECTOR_WIDTH > CLUSTER_M * 2
+            // Simd2xNN (here used for single-precision)
             computeForce = computeForceLJ2xnnFullNeigh;
-#else // Simd4xN
+#else
+            // Simd4xN
             computeForce = computeForceLJ4xnFullNeigh;
 #endif
 #endif

--- a/src/clusterpair/force.c
+++ b/src/clusterpair/force.c
@@ -33,7 +33,8 @@ void initForce(Parameter* param)
         }
 #elif defined(CLUSTERPAIR_KERNEL_CUDA)
         if (param->half_neigh) {
-            fprintf(stderr, "initForce(): No CUDA implementation for half neighbor-lists available!");
+            fprintf(stderr,
+                "initForce(): No CUDA implementation for half neighbor-lists available!");
             exit(-1);
         } else {
             computeForce = computeForceLJCUDA;

--- a/src/clusterpair/force.c
+++ b/src/clusterpair/force.c
@@ -32,13 +32,7 @@ void initForce(Parameter* param)
             computeForce = computeForceLJ2xnnFullNeigh;
         }
 #elif defined(CLUSTERPAIR_KERNEL_CUDA)
-        if (param->half_neigh) {
-            fprintf(stderr,
-                "initForce(): No CUDA implementation for half neighbor-lists available!");
-            exit(-1);
-        } else {
-            computeForce = computeForceLJCUDA;
-        }
+        computeForce = computeForceLJCUDA;
 #endif
     }
 }

--- a/src/clusterpair/force.c
+++ b/src/clusterpair/force.c
@@ -17,23 +17,26 @@ void initForce(Parameter* param)
         computeForce = computeForceEam;
         break;
     case FF_LJ:
-#ifdef USE_REFERENCE_VERSION
+#if defined(CLUSTERPAIR_KERNEL_REF)
         computeForce = computeForceLJRef;
-#else
+#elif defined(CLUSTERPAIR_KERNEL_4XN)
         if (param->half_neigh) {
             computeForce = computeForceLJ4xnHalfNeigh;
         } else {
-#ifdef CUDA_TARGET
-            computeForce = computeForceLJCUDA;
-#else
-#if VECTOR_WIDTH > CLUSTER_M * 2
-            // Simd2xNN (here used for single-precision)
-            computeForce = computeForceLJ2xnnFullNeigh;
-#else
-            // Simd4xN
             computeForce = computeForceLJ4xnFullNeigh;
-#endif
-#endif
+        }
+#elif defined(CLUSTERPAIR_KERNEL_2XNN)
+        if (param->half_neigh) {
+            computeForce = computeForceLJ2xnnHalfNeigh;
+        } else {
+            computeForce = computeForceLJ2xnnFullNeigh;
+        }
+#elif defined(CLUSTERPAIR_KERNEL_CUDA)
+        if (param->half_neigh) {
+            fprintf(stderr, "initForce(): No CUDA implementation for half neighbor-lists available!");
+            exit(-1);
+        } else {
+            computeForce = computeForceLJCUDA;
         }
 #endif
     }

--- a/src/clusterpair/force.h
+++ b/src/clusterpair/force.h
@@ -36,16 +36,16 @@ extern double computeForceLJCUDA(Parameter*, Atom*, Neighbor*, Stats*);
 #undef VECTOR_WIDTH
 #define VECTOR_WIDTH 8
 #define CLUSTERPAIR_KERNEL_CUDA
-#define KERNEL_NAME  "CUDA"
-#define CLUSTER_M    8
-#define CLUSTER_N    VECTOR_WIDTH
-#define UNROLL_J     1
+#define KERNEL_NAME "CUDA"
+#define CLUSTER_M   8
+#define CLUSTER_N   VECTOR_WIDTH
+#define UNROLL_J    1
 #else
 #ifdef USE_REFERENCE_VERSION
 #define CLUSTERPAIR_KERNEL_REF
 #define KERNEL_NAME "Reference"
-#define CLUSTER_M    1
-#define CLUSTER_N    VECTOR_WIDTH
+#define CLUSTER_M   1
+#define CLUSTER_N   VECTOR_WIDTH
 #else
 #define CLUSTER_M 4
 // Simd2xNN (here used for single-precision)

--- a/src/clusterpair/force.h
+++ b/src/clusterpair/force.h
@@ -35,12 +35,14 @@ extern double computeForceEam(Parameter*, Atom*, Neighbor*, Stats*);
 extern double computeForceLJCUDA(Parameter*, Atom*, Neighbor*, Stats*);
 #undef VECTOR_WIDTH
 #define VECTOR_WIDTH 8
+#define CLUSTERPAIR_KERNEL_CUDA
 #define KERNEL_NAME  "CUDA"
 #define CLUSTER_M    8
 #define CLUSTER_N    VECTOR_WIDTH
 #define UNROLL_J     1
 #else
 #ifdef USE_REFERENCE_VERSION
+#define CLUSTERPAIR_KERNEL_REF
 #define KERNEL_NAME "Reference"
 #define CLUSTER_M    1
 #define CLUSTER_N    VECTOR_WIDTH
@@ -48,11 +50,13 @@ extern double computeForceLJCUDA(Parameter*, Atom*, Neighbor*, Stats*);
 #define CLUSTER_M 4
 // Simd2xNN (here used for single-precision)
 #if VECTOR_WIDTH > CLUSTER_M * 2
+#define CLUSTERPAIR_KERNEL_2XNN
 #define KERNEL_NAME "Simd2xNN"
 #define CLUSTER_N   (VECTOR_WIDTH / 2)
 #define UNROLL_I    4
 #define UNROLL_J    2
 #else // Simd4xN
+#define CLUSTERPAIR_KERNEL_4XN
 #define KERNEL_NAME "Simd4xN"
 #define CLUSTER_N   VECTOR_WIDTH
 #define UNROLL_I    4

--- a/src/clusterpair/force.h
+++ b/src/clusterpair/force.h
@@ -31,6 +31,31 @@ extern double computeForceEam(Parameter*, Atom*, Neighbor*, Stats*);
 // Simd2xNN: M=4, N=(VECTOR_WIDTH/2)
 // Cuda: M=8, N=VECTOR_WIDTH
 
+/* Comments from GROMACS:
+ *
+ * We need to choose if we want 2x(N+N) or 4xN kernels.
+ * This is based on the SIMD acceleration choice and CPU information
+ * detected at runtime.
+ *
+ * 4xN calculates more (zero) interactions, but has less pair-search
+ * work and much better kernel instruction scheduling.
+ *
+ * Up till now we have only seen that on Intel Sandy/Ivy Bridge,
+ * which doesn't have FMA, both the analytical and tabulated Ewald
+ * kernels have similar pair rates for 4x8 and 2x(4+4), so we choose
+ * 2x(4+4) because it results in significantly fewer pairs.
+ * For RF, the raw pair rate of the 4x8 kernel is higher than 2x(4+4),
+ * 10% with HT, 50% without HT. As we currently don't detect the actual
+ * use of HT, use 4x8 to avoid a potential performance hit.
+ * On Intel Haswell 4x8 is always faster.
+ *
+ *
+ * The nbnxn SIMD 4xN and 2x(N+N) kernels can be added independently.
+ * Currently the 2xNN SIMD kernels only make sense with:
+ *  8-way SIMD: 4x4 setup, performance wise only useful on CPUs without FMA or on AMD Zen1
+ * 16-way SIMD: 4x8 setup, used in single precision with 512 bit wide SIMD
+ */
+
 #ifdef CUDA_TARGET
 extern double computeForceLJCUDA(Parameter*, Atom*, Neighbor*, Stats*);
 #undef VECTOR_WIDTH

--- a/src/clusterpair/forceCuda.cu
+++ b/src/clusterpair/forceCuda.cu
@@ -34,7 +34,6 @@ int* ngatoms;
 int* cuda_border_map;
 int* cuda_jclusters_natoms;
 int *cuda_PBCx, *cuda_PBCy, *cuda_PBCz;
-int isReneighboured;
 
 #ifndef ONE_ATOM_TYPE
 int* cuda_cl_t;
@@ -83,7 +82,6 @@ extern "C" void initDevice(Atom* atom, Neighbor* neighbor)
         atom->Nclusters_max * neighbor->maxneighs * sizeof(int));
     natoms          = (int*)malloc(atom->Nclusters_max * sizeof(int));
     ngatoms         = (int*)malloc(atom->Nclusters_max * sizeof(int));
-    isReneighboured = 1;
 }
 
 extern "C" void copyDataToCUDADevice(Atom* atom, Neighbor* neighbor)
@@ -478,9 +476,11 @@ extern "C" void updatePbcCUDA(Atom* atom, Parameter* param)
 extern "C" double computeForceLJCUDA(
     Parameter* param, Atom* atom, Neighbor* neighbor, Stats* stats)
 {
+#ifdef ONE_ATOM_TYPE
     MD_FLOAT cutforcesq = param->cutforce * param->cutforce;
     MD_FLOAT sigma6     = param->sigma6;
     MD_FLOAT epsilon    = param->epsilon;
+#endif
 
     memsetGPU(cuda_cl_f, 0, atom->Nclusters_local * CLUSTER_M * 3 * sizeof(MD_FLOAT));
     const int threads_num = 1;

--- a/src/clusterpair/forceCuda.cu
+++ b/src/clusterpair/forceCuda.cu
@@ -44,6 +44,7 @@ extern "C" void initDevice(Atom* atom, Neighbor* neighbor)
 {
     cuda_assert("cudaDeviceSetup", cudaDeviceReset());
     cuda_assert("cudaDeviceSetup", cudaSetDevice(0));
+
     cuda_cl_x = (MD_FLOAT*)allocateGPU(
         atom->Nclusters_max * CLUSTER_M * 3 * sizeof(MD_FLOAT));
     cuda_cl_v = (MD_FLOAT*)allocateGPU(
@@ -71,9 +72,6 @@ extern "C" void copyDataToCUDADevice(Atom* atom)
         atom->Nclusters_max * CLUSTER_M * 3 * sizeof(MD_FLOAT));
     memcpyToGPU(cuda_cl_v,
         atom->cl_v,
-        atom->Nclusters_max * CLUSTER_M * 3 * sizeof(MD_FLOAT));
-    memcpyToGPU(cuda_cl_f,
-        atom->cl_f,
         atom->Nclusters_max * CLUSTER_M * 3 * sizeof(MD_FLOAT));
 
     for (int ci = 0; ci < atom->Nclusters_local; ci++) {
@@ -104,9 +102,6 @@ extern "C" void copyDataFromCUDADevice(Atom* atom)
     memcpyFromGPU(atom->cl_v,
         cuda_cl_v,
         atom->Nclusters_max * CLUSTER_M * 3 * sizeof(MD_FLOAT));
-    memcpyFromGPU(atom->cl_f,
-        cuda_cl_f,
-        atom->Nclusters_max * CLUSTER_M * 3 * sizeof(MD_FLOAT));
 }
 
 extern "C" void cudaDeviceFree(void)
@@ -135,15 +130,15 @@ __global__ void cudaInitialIntegrate_warp(MD_FLOAT* cuda_cl_x,
     MD_FLOAT dt)
 {
 
-    unsigned int ci_pos = blockDim.x * blockIdx.x + threadIdx.x;
-    if (ci_pos >= Nclusters_local) return;
+    unsigned int ci = blockDim.x * blockIdx.x + threadIdx.x;
+    if (ci >= Nclusters_local) return;
 
-    int ci_vec_base = CI_VECTOR_BASE_INDEX(ci_pos);
+    int ci_vec_base = CI_VECTOR_BASE_INDEX(ci);
     MD_FLOAT* ci_x  = &cuda_cl_x[ci_vec_base];
     MD_FLOAT* ci_v  = &cuda_cl_v[ci_vec_base];
     MD_FLOAT* ci_f  = &cuda_cl_f[ci_vec_base];
 
-    for (int cii = 0; cii < cuda_natoms[ci_pos]; cii++) {
+    for (int cii = 0; cii < cuda_natoms[ci]; cii++) {
         ci_v[CL_X_OFFSET + cii] += dtforce * ci_f[CL_X_OFFSET + cii];
         ci_v[CL_Y_OFFSET + cii] += dtforce * ci_f[CL_Y_OFFSET + cii];
         ci_v[CL_Z_OFFSET + cii] += dtforce * ci_f[CL_Z_OFFSET + cii];
@@ -187,77 +182,141 @@ __global__ void cudaUpdatePbc_warp(MD_FLOAT* cuda_cl_x,
     }
 }
 
-__global__ void computeForceLJ_cuda_warp(MD_FLOAT* cuda_cl_x,
+__global__ void computeForceLJCudaFullNeigh(MD_FLOAT* cuda_cl_x,
     MD_FLOAT* cuda_cl_f,
     int Nclusters_local,
     int Nclusters_max,
     int* cuda_numneigh,
     int* cuda_neighs,
-    int half_neigh,
     int maxneighs,
     MD_FLOAT cutforcesq,
     MD_FLOAT sigma6,
     MD_FLOAT epsilon)
 {
 
-    unsigned int ci_pos  = blockDim.x * blockIdx.x + threadIdx.x;
-    unsigned int cii_pos = blockDim.y * blockIdx.y + threadIdx.y;
-    unsigned int cjj_pos = blockDim.z * blockIdx.z + threadIdx.z;
-    if ((ci_pos >= Nclusters_local) || (cii_pos >= CLUSTER_M) || (cjj_pos >= CLUSTER_N))
+    int ci  = blockDim.x * blockIdx.x + threadIdx.x;
+    if (ci >= Nclusters_local)
         return;
 
-    int ci_cj0      = CJ0_FROM_CI(ci_pos);
-    int ci_vec_base = CI_VECTOR_BASE_INDEX(ci_pos);
+    int cii = blockDim.y * blockIdx.y + threadIdx.y;
+    int cjj = blockDim.z * blockIdx.z + threadIdx.z;
+    int ci_cj0      = CJ0_FROM_CI(ci);
+    int ci_vec_base = CI_VECTOR_BASE_INDEX(ci);
     MD_FLOAT* ci_x  = &cuda_cl_x[ci_vec_base];
     MD_FLOAT* ci_f  = &cuda_cl_f[ci_vec_base];
-    int numneighs   = cuda_numneigh[ci_pos];
+    int* neighs     = &cuda_neighs[ci * maxneighs];
+    int numneighs   = cuda_numneigh[ci];
+
     for (int k = 0; k < numneighs; k++) {
-        int cj          = (&cuda_neighs[ci_pos * maxneighs])[k];
+        int cj          = neighs[k];
         int cj_vec_base = CJ_VECTOR_BASE_INDEX(cj);
         MD_FLOAT* cj_x  = &cuda_cl_x[cj_vec_base];
-        MD_FLOAT* cj_f  = &cuda_cl_f[cj_vec_base];
-
-        MD_FLOAT xtmp = ci_x[CL_X_OFFSET + cii_pos];
-        MD_FLOAT ytmp = ci_x[CL_Y_OFFSET + cii_pos];
-        MD_FLOAT ztmp = ci_x[CL_Z_OFFSET + cii_pos];
-        MD_FLOAT fix  = 0;
-        MD_FLOAT fiy  = 0;
-        MD_FLOAT fiz  = 0;
+        MD_FLOAT xtmp   = ci_x[CL_X_OFFSET + cii];
+        MD_FLOAT ytmp   = ci_x[CL_Y_OFFSET + cii];
+        MD_FLOAT ztmp   = ci_x[CL_Z_OFFSET + cii];
+        MD_FLOAT fix    = 0;
+        MD_FLOAT fiy    = 0;
+        MD_FLOAT fiz    = 0;
 
         int cond;
 #if CLUSTER_M == CLUSTER_N
-        cond = half_neigh ? (ci_cj0 != cj || cii_pos < cjj_pos)
-                          : (ci_cj0 != cj || cii_pos != cjj_pos);
+        cond = ci_cj0 != cj || cii != cjj;
 #elif CLUSTER_M < CLUSTER_N
-        cond = half_neigh
-                   ? (ci_cj0 != cj || cii_pos + CLUSTER_M * (ci_pos & 0x1) < cjj_pos)
-                   : (ci_cj0 != cj || cii_pos + CLUSTER_M * (ci_pos & 0x1) != cjj_pos);
+        cond = ci_cj0 != cj || cii + CLUSTER_M * (ci & 0x1) != cjj;
 #endif
         if (cond) {
-            MD_FLOAT delx = xtmp - cj_x[CL_X_OFFSET + cjj_pos];
-            MD_FLOAT dely = ytmp - cj_x[CL_Y_OFFSET + cjj_pos];
-            MD_FLOAT delz = ztmp - cj_x[CL_Z_OFFSET + cjj_pos];
+            MD_FLOAT delx = xtmp - cj_x[CL_X_OFFSET + cjj];
+            MD_FLOAT dely = ytmp - cj_x[CL_Y_OFFSET + cjj];
+            MD_FLOAT delz = ztmp - cj_x[CL_Z_OFFSET + cjj];
             MD_FLOAT rsq  = delx * delx + dely * dely + delz * delz;
+
             if (rsq < cutforcesq) {
                 MD_FLOAT sr2   = 1.0 / rsq;
                 MD_FLOAT sr6   = sr2 * sr2 * sr2 * sigma6;
                 MD_FLOAT force = 48.0 * sr6 * (sr6 - 0.5) * sr2 * epsilon;
 
-                if (half_neigh) {
-                    atomicAdd(&cj_f[CL_X_OFFSET + cjj_pos], -delx * force);
-                    atomicAdd(&cj_f[CL_Y_OFFSET + cjj_pos], -dely * force);
-                    atomicAdd(&cj_f[CL_Z_OFFSET + cjj_pos], -delz * force);
-                }
-
                 fix += delx * force;
                 fiy += dely * force;
                 fiz += delz * force;
-
-                atomicAdd(&ci_f[CL_X_OFFSET + cii_pos], fix);
-                atomicAdd(&ci_f[CL_Y_OFFSET + cii_pos], fiy);
-                atomicAdd(&ci_f[CL_Z_OFFSET + cii_pos], fiz);
             }
         }
+
+        atomicAdd(&ci_f[CL_X_OFFSET + cii], fix);
+        atomicAdd(&ci_f[CL_Y_OFFSET + cii], fiy);
+        atomicAdd(&ci_f[CL_Z_OFFSET + cii], fiz);
+    }
+}
+
+__global__ void computeForceLJCudaHalfNeigh(MD_FLOAT* cuda_cl_x,
+    MD_FLOAT* cuda_cl_f,
+    int Nclusters_local,
+    int Nclusters_max,
+    int* cuda_numneigh,
+    int* cuda_neighs,
+    int maxneighs,
+    MD_FLOAT cutforcesq,
+    MD_FLOAT sigma6,
+    MD_FLOAT epsilon)
+{
+
+    int ci  = blockDim.x * blockIdx.x + threadIdx.x;
+    if (ci >= Nclusters_local)
+        return;
+
+    int cii = blockDim.y * blockIdx.y + threadIdx.y;
+    int cjj = blockDim.z * blockIdx.z + threadIdx.z;
+    int ci_cj0      = CJ0_FROM_CI(ci);
+    int ci_vec_base = CI_VECTOR_BASE_INDEX(ci);
+    MD_FLOAT* ci_x  = &cuda_cl_x[ci_vec_base];
+    MD_FLOAT* ci_f  = &cuda_cl_f[ci_vec_base];
+    int* neighs     = &cuda_neighs[ci * maxneighs];
+    int numneighs   = cuda_numneigh[ci];
+
+    for (int k = 0; k < numneighs; k++) {
+        int cj          = neighs[k];
+        int cj_vec_base = CJ_VECTOR_BASE_INDEX(cj);
+        MD_FLOAT* cj_x  = &cuda_cl_x[cj_vec_base];
+        MD_FLOAT* cj_f  = &cuda_cl_f[cj_vec_base];
+        MD_FLOAT xtmp   = ci_x[CL_X_OFFSET + cii];
+        MD_FLOAT ytmp   = ci_x[CL_Y_OFFSET + cii];
+        MD_FLOAT ztmp   = ci_x[CL_Z_OFFSET + cii];
+        MD_FLOAT fix    = 0;
+        MD_FLOAT fiy    = 0;
+        MD_FLOAT fiz    = 0;
+
+        int cond;
+#if CLUSTER_M == CLUSTER_N
+        cond = ci_cj0 != cj || cii < cjj;
+#elif CLUSTER_M < CLUSTER_N
+        cond = ci_cj0 != cj || cii + CLUSTER_M * (ci & 0x1) < cjj;
+#endif
+        if (cond) {
+            MD_FLOAT delx = xtmp - cj_x[CL_X_OFFSET + cjj];
+            MD_FLOAT dely = ytmp - cj_x[CL_Y_OFFSET + cjj];
+            MD_FLOAT delz = ztmp - cj_x[CL_Z_OFFSET + cjj];
+            MD_FLOAT rsq  = delx * delx + dely * dely + delz * delz;
+
+            if (rsq < cutforcesq) {
+                MD_FLOAT sr2             = 1.0 / rsq;
+                MD_FLOAT sr6             = sr2 * sr2 * sr2 * sigma6;
+                MD_FLOAT force           = 48.0 * sr6 * (sr6 - 0.5) * sr2 * epsilon;
+                MD_FLOAT partial_force_x = delx * force;
+                MD_FLOAT partial_force_y = dely * force;
+                MD_FLOAT partial_force_z = delz * force;
+
+                atomicAdd(&cj_f[CL_X_OFFSET + cjj], -partial_force_x);
+                atomicAdd(&cj_f[CL_Y_OFFSET + cjj], -partial_force_y);
+                atomicAdd(&cj_f[CL_Z_OFFSET + cjj], -partial_force_z);
+
+                fix += partial_force_x;
+                fiy += partial_force_y;
+                fiz += partial_force_z;
+            }
+        }
+
+        atomicAdd(&ci_f[CL_X_OFFSET + cii], fix);
+        atomicAdd(&ci_f[CL_Y_OFFSET + cii], fiy);
+        atomicAdd(&ci_f[CL_Z_OFFSET + cii], fiz);
     }
 }
 
@@ -268,14 +327,14 @@ __global__ void cudaFinalIntegrate_warp(MD_FLOAT* cuda_cl_v,
     MD_FLOAT dtforce)
 {
 
-    unsigned int ci_pos = blockDim.x * blockIdx.x + threadIdx.x;
-    if (ci_pos >= Nclusters_local) return;
+    unsigned int ci = blockDim.x * blockIdx.x + threadIdx.x;
+    if (ci >= Nclusters_local) return;
 
-    int ci_vec_base = CI_VECTOR_BASE_INDEX(ci_pos);
+    int ci_vec_base = CI_VECTOR_BASE_INDEX(ci);
     MD_FLOAT* ci_v  = &cuda_cl_v[ci_vec_base];
     MD_FLOAT* ci_f  = &cuda_cl_f[ci_vec_base];
 
-    for (int cii = 0; cii < cuda_natoms[ci_pos]; cii++) {
+    for (int cii = 0; cii < cuda_natoms[ci]; cii++) {
         ci_v[CL_X_OFFSET + cii] += dtforce * ci_f[CL_X_OFFSET + cii];
         ci_v[CL_Y_OFFSET + cii] += dtforce * ci_f[CL_Y_OFFSET + cii];
         ci_v[CL_Z_OFFSET + cii] += dtforce * ci_f[CL_Z_OFFSET + cii];
@@ -284,9 +343,10 @@ __global__ void cudaFinalIntegrate_warp(MD_FLOAT* cuda_cl_v,
 
 extern "C" void initialIntegrateCUDA(Parameter* param, Atom* atom)
 {
-    const int threads_num = 16;
+    const int threads_num = 64;
     dim3 block_size       = dim3(threads_num, 1, 1);
-    dim3 grid_size        = dim3(atom->Nclusters_local / (threads_num) + 1, 1, 1);
+    dim3 grid_size = dim3((atom->Nclusters_local + threads_num - 1) / threads_num, 1, 1);
+
     cudaInitialIntegrate_warp<<<grid_size, block_size>>>(cuda_cl_x,
         cuda_cl_v,
         cuda_cl_f,
@@ -294,6 +354,7 @@ extern "C" void initialIntegrateCUDA(Parameter* param, Atom* atom)
         atom->Nclusters_local,
         param->dtforce,
         param->dt);
+
     cuda_assert("cudaInitialIntegrate", cudaPeekAtLastError());
     cuda_assert("cudaInitialIntegrate", cudaDeviceSynchronize());
 }
@@ -302,11 +363,10 @@ extern "C" void initialIntegrateCUDA(Parameter* param, Atom* atom)
 /* uses mapping created in setupPbc */
 extern "C" void updatePbcCUDA(Atom* atom, Parameter* param)
 {
-    const int threads_num = 512;
+    const int threads_num = 64;
     dim3 block_size       = dim3(threads_num, 1, 1);
-    ;
-    dim3 grid_size = dim3(atom->Nclusters_ghost / (threads_num) + 1, 1, 1);
-    ;
+    dim3 grid_size = dim3((atom->Nclusters_ghost + threads_num - 1) / threads_num, 1, 1);
+
     cudaUpdatePbc_warp<<<grid_size, block_size>>>(cuda_cl_x,
         cuda_border_map,
         cuda_jclusters_natoms,
@@ -318,6 +378,7 @@ extern "C" void updatePbcCUDA(Atom* atom, Parameter* param)
         param->xprd,
         param->yprd,
         param->zprd);
+
     cuda_assert("cudaUpdatePbc", cudaPeekAtLastError());
     cuda_assert("cudaUpdatePbc", cudaDeviceSynchronize());
 }
@@ -329,7 +390,7 @@ extern "C" double computeForceLJCUDA(
     MD_FLOAT sigma6     = param->sigma6;
     MD_FLOAT epsilon    = param->epsilon;
 
-    memsetGPU(cuda_cl_f, 0, atom->Nclusters_max * CLUSTER_M * 3 * sizeof(MD_FLOAT));
+    memsetGPU(cuda_cl_f, 0, atom->Nclusters_local * CLUSTER_M * 3 * sizeof(MD_FLOAT));
     if (isReneighboured) {
         for (int ci = 0; ci < atom->Nclusters_local; ci++) {
             memcpyToGPU(&cuda_numneigh[ci], &neighbor->numneigh[ci], sizeof(int));
@@ -343,20 +404,34 @@ extern "C" double computeForceLJCUDA(
 
     const int threads_num = 1;
     dim3 block_size       = dim3(threads_num, CLUSTER_M, CLUSTER_N);
-    dim3 grid_size        = dim3(atom->Nclusters_local / threads_num + 1, 1, 1);
-    double S              = getTimeStamp();
+    dim3 grid_size = dim3((atom->Nclusters_local + threads_num - 1) / threads_num, 1, 1);
+    double S       = getTimeStamp();
     LIKWID_MARKER_START("force");
-    computeForceLJ_cuda_warp<<<grid_size, block_size>>>(cuda_cl_x,
-        cuda_cl_f,
-        atom->Nclusters_local,
-        atom->Nclusters_max,
-        cuda_numneigh,
-        cuda_neighbors,
-        neighbor->half_neigh,
-        neighbor->maxneighs,
-        cutforcesq,
-        sigma6,
-        epsilon);
+
+    if (neighbor->half_neigh) {
+        computeForceLJCudaHalfNeigh<<<grid_size, block_size>>>(cuda_cl_x,
+            cuda_cl_f,
+            atom->Nclusters_local,
+            atom->Nclusters_max,
+            cuda_numneigh,
+            cuda_neighbors,
+            neighbor->maxneighs,
+            cutforcesq,
+            sigma6,
+            epsilon);
+    } else {
+        computeForceLJCudaFullNeigh<<<grid_size, block_size>>>(cuda_cl_x,
+            cuda_cl_f,
+            atom->Nclusters_local,
+            atom->Nclusters_max,
+            cuda_numneigh,
+            cuda_neighbors,
+            neighbor->maxneighs,
+            cutforcesq,
+            sigma6,
+            epsilon);
+    }
+
     cuda_assert("computeForceLJ_cuda", cudaPeekAtLastError());
     cuda_assert("computeForceLJ_cuda", cudaDeviceSynchronize());
     LIKWID_MARKER_STOP("force");
@@ -366,14 +441,17 @@ extern "C" double computeForceLJCUDA(
 
 extern "C" void finalIntegrateCUDA(Parameter* param, Atom* atom)
 {
-    const int threads_num = 16;
+    const int threads_num = 64;
     dim3 block_size       = dim3(threads_num, 1, 1);
-    dim3 grid_size        = dim3(atom->Nclusters_local / (threads_num) + 1, 1, 1);
+    dim3 grid_size = dim3((atom->Nclusters_local + threads_num - 1) / threads_num, 1, 1);
+
     cudaFinalIntegrate_warp<<<grid_size, block_size>>>(cuda_cl_v,
         cuda_cl_f,
         cuda_natoms,
         atom->Nclusters_local,
         param->dt);
+
+
     cuda_assert("cudaFinalIntegrate", cudaPeekAtLastError());
     cuda_assert("cudaFinalIntegrate", cudaDeviceSynchronize());
 }

--- a/src/clusterpair/forceCuda.cu
+++ b/src/clusterpair/forceCuda.cu
@@ -33,9 +33,6 @@ int* natoms;
 int* ngatoms;
 int* cuda_border_map;
 int* cuda_jclusters_natoms;
-MD_FLOAT *cuda_bbminx, *cuda_bbmaxx;
-MD_FLOAT *cuda_bbminy, *cuda_bbmaxy;
-MD_FLOAT *cuda_bbminz, *cuda_bbmaxz;
 int *cuda_PBCx, *cuda_PBCy, *cuda_PBCz;
 int isReneighboured;
 }
@@ -241,9 +238,9 @@ __global__ void computeForceLJCudaFullNeigh(MD_FLOAT* cuda_cl_x,
         }
     }
 
-    // ci_f[CL_X_OFFSET + cii] += fix;
-    // ci_f[CL_Y_OFFSET + cii] += fiy;
-    // ci_f[CL_Z_OFFSET + cii] += fiz;
+    //ci_f[CL_X_OFFSET + cii] = fix;
+    //ci_f[CL_Y_OFFSET + cii] = fiy;
+    //ci_f[CL_Z_OFFSET + cii] = fiz;
     atomicAdd(&ci_f[CL_X_OFFSET + cii], fix);
     atomicAdd(&ci_f[CL_Y_OFFSET + cii], fiy);
     atomicAdd(&ci_f[CL_Z_OFFSET + cii], fiz);

--- a/src/clusterpair/forceCuda.cu
+++ b/src/clusterpair/forceCuda.cu
@@ -80,8 +80,8 @@ extern "C" void initDevice(Atom* atom, Neighbor* neighbor)
     cuda_numneigh         = (int*)allocateGPU(atom->Nclusters_max * sizeof(int));
     cuda_neighbors        = (int*)allocateGPU(
         atom->Nclusters_max * neighbor->maxneighs * sizeof(int));
-    natoms          = (int*)malloc(atom->Nclusters_max * sizeof(int));
-    ngatoms         = (int*)malloc(atom->Nclusters_max * sizeof(int));
+    natoms  = (int*)malloc(atom->Nclusters_max * sizeof(int));
+    ngatoms = (int*)malloc(atom->Nclusters_max * sizeof(int));
 }
 
 extern "C" void copyDataToCUDADevice(Atom* atom, Neighbor* neighbor)
@@ -283,7 +283,8 @@ __global__ void computeForceLJCudaFullNeigh(
             if (rsq < cutforcesq) {
                 MD_FLOAT sr2   = (MD_FLOAT)(1.0) / rsq;
                 MD_FLOAT sr6   = sr2 * sr2 * sr2 * sigma6;
-                MD_FLOAT force = (MD_FLOAT)(48.0) * sr6 * (sr6 - (MD_FLOAT)(0.5)) * sr2 * epsilon;
+                MD_FLOAT force = (MD_FLOAT)(48.0) * sr6 * (sr6 - (MD_FLOAT)(0.5)) * sr2 *
+                                 epsilon;
 
                 fix += delx * force;
                 fiy += dely * force;
@@ -387,9 +388,10 @@ __global__ void computeForceLJCudaHalfNeigh(
 #endif
 
             if (rsq < cutforcesq) {
-                MD_FLOAT sr2             = 1.0 / rsq;
-                MD_FLOAT sr6             = sr2 * sr2 * sr2 * sigma6;
-                MD_FLOAT force           = 48.0 * sr6 * (sr6 - 0.5) * sr2 * epsilon;
+                MD_FLOAT sr2   = (MD_FLOAT)(1.0) / rsq;
+                MD_FLOAT sr6   = sr2 * sr2 * sr2 * sigma6;
+                MD_FLOAT force = (MD_FLOAT)(48.0) * sr6 * (sr6 - (MD_FLOAT)(0.5)) * sr2 *
+                                 epsilon;
                 MD_FLOAT partial_force_x = delx * force;
                 MD_FLOAT partial_force_y = dely * force;
                 MD_FLOAT partial_force_z = delz * force;

--- a/src/clusterpair/forceCuda.cu
+++ b/src/clusterpair/forceCuda.cu
@@ -281,9 +281,9 @@ __global__ void computeForceLJCudaFullNeigh(
 #endif
 
             if (rsq < cutforcesq) {
-                MD_FLOAT sr2   = 1.0 / rsq;
+                MD_FLOAT sr2   = (MD_FLOAT)(1.0) / rsq;
                 MD_FLOAT sr6   = sr2 * sr2 * sr2 * sigma6;
-                MD_FLOAT force = 48.0 * sr6 * (sr6 - 0.5) * sr2 * epsilon;
+                MD_FLOAT force = (MD_FLOAT)(48.0) * sr6 * (sr6 - (MD_FLOAT)(0.5)) * sr2 * epsilon;
 
                 fix += delx * force;
                 fiy += dely * force;

--- a/src/clusterpair/forceCuda.cu
+++ b/src/clusterpair/forceCuda.cu
@@ -194,12 +194,11 @@ __global__ void computeForceLJCudaFullNeigh(MD_FLOAT* cuda_cl_x,
     MD_FLOAT epsilon)
 {
 
-    int ci  = blockDim.x * blockIdx.x + threadIdx.x;
-    if (ci >= Nclusters_local)
-        return;
+    int ci = blockDim.x * blockIdx.x + threadIdx.x;
+    if (ci >= Nclusters_local) return;
 
-    int cii = blockDim.y * blockIdx.y + threadIdx.y;
-    int cjj = blockDim.z * blockIdx.z + threadIdx.z;
+    int cii         = blockDim.y * blockIdx.y + threadIdx.y;
+    int cjj         = blockDim.z * blockIdx.z + threadIdx.z;
     int ci_cj0      = CJ0_FROM_CI(ci);
     int ci_vec_base = CI_VECTOR_BASE_INDEX(ci);
     MD_FLOAT* ci_x  = &cuda_cl_x[ci_vec_base];
@@ -259,12 +258,11 @@ __global__ void computeForceLJCudaHalfNeigh(MD_FLOAT* cuda_cl_x,
     MD_FLOAT epsilon)
 {
 
-    int ci  = blockDim.x * blockIdx.x + threadIdx.x;
-    if (ci >= Nclusters_local)
-        return;
+    int ci = blockDim.x * blockIdx.x + threadIdx.x;
+    if (ci >= Nclusters_local) return;
 
-    int cii = blockDim.y * blockIdx.y + threadIdx.y;
-    int cjj = blockDim.z * blockIdx.z + threadIdx.z;
+    int cii         = blockDim.y * blockIdx.y + threadIdx.y;
+    int cjj         = blockDim.z * blockIdx.z + threadIdx.z;
     int ci_cj0      = CJ0_FROM_CI(ci);
     int ci_vec_base = CI_VECTOR_BASE_INDEX(ci);
     MD_FLOAT* ci_x  = &cuda_cl_x[ci_vec_base];
@@ -450,7 +448,6 @@ extern "C" void finalIntegrateCUDA(Parameter* param, Atom* atom)
         cuda_natoms,
         atom->Nclusters_local,
         param->dt);
-
 
     cuda_assert("cudaFinalIntegrate", cudaPeekAtLastError());
     cuda_assert("cudaFinalIntegrate", cudaDeviceSynchronize());

--- a/src/clusterpair/force_eam.c
+++ b/src/clusterpair/force_eam.c
@@ -46,7 +46,7 @@ double computeForceEam(Parameter* param, Atom* atom, Neighbor* neighbor, Stats* 
         MD_FLOAT ytmp = atom_y(i);
         MD_FLOAT ztmp = atom_z(i);
         MD_FLOAT rhoi = 0;
-#ifdef EXPLICIT_TYPES
+#ifndef ONE_ATOM_TYPE
         const int type_i = atom->type[i];
 #endif
         #pragma ivdep
@@ -56,7 +56,7 @@ double computeForceEam(Parameter* param, Atom* atom, Neighbor* neighbor, Stats* 
             MD_FLOAT dely = ytmp - atom_y(j);
             MD_FLOAT delz = ztmp - atom_z(j);
             MD_FLOAT rsq = delx * delx + dely * dely + delz * delz;
-#ifdef EXPLICIT_TYPES
+#ifndef ONE_ATOM_TYPE
             const int type_j = atom->type[j];
             const int type_ij = type_i * ntypes + type_j;
             const MD_FLOAT cutforcesq = atom->cutforcesq[type_ij];
@@ -69,7 +69,7 @@ double computeForceEam(Parameter* param, Atom* atom, Neighbor* neighbor, Stats* 
                 m = m < nr - 1 ? m : nr - 1;
                 p -= m;
                 p = p < 1.0 ? p : 1.0;
-#ifdef EXPLICIT_TYPES
+#ifndef ONE_ATOM_TYPE
                 rhoi += ((rhor_spline[type_ij * nr_tot + m * 7 + 3] * p +
                           rhor_spline[type_ij * nr_tot + m * 7 + 4]) * p +
                           rhor_spline[type_ij * nr_tot + m * 7 + 5]) * p +
@@ -83,7 +83,7 @@ double computeForceEam(Parameter* param, Atom* atom, Neighbor* neighbor, Stats* 
             }
         }
 
-#ifdef EXPLICIT_TYPES
+#ifndef ONE_ATOM_TYPE
         const int type_ii = type_i * type_i;
 #endif
         MD_FLOAT p = 1.0 * rhoi * rdrho + 1.0;
@@ -91,7 +91,7 @@ double computeForceEam(Parameter* param, Atom* atom, Neighbor* neighbor, Stats* 
         m = MAX(1, MIN(m, nrho - 1));
         p -= m;
         p = MIN(p, 1.0);
-#ifdef EXPLICIT_TYPES
+#ifndef ONE_ATOM_TYPE
         fp[i] = (frho_spline[type_ii * nrho_tot + m * 7 + 0] * p +
                  frho_spline[type_ii * nrho_tot + m * 7 + 1]) * p +
                  frho_spline[type_ii * nrho_tot + m * 7 + 2];
@@ -117,7 +117,7 @@ double computeForceEam(Parameter* param, Atom* atom, Neighbor* neighbor, Stats* 
         MD_FLOAT fix = 0;
         MD_FLOAT fiy = 0;
         MD_FLOAT fiz = 0;
-#ifdef EXPLICIT_TYPES
+#ifndef ONE_ATOM_TYPE
         const int type_i = atom->type[i];
 #endif
 
@@ -128,7 +128,7 @@ double computeForceEam(Parameter* param, Atom* atom, Neighbor* neighbor, Stats* 
             MD_FLOAT dely = ytmp - atom_y(j);
             MD_FLOAT delz = ztmp - atom_z(j);
             MD_FLOAT rsq = delx * delx + dely * dely + delz * delz;
-#ifdef EXPLICIT_TYPES
+#ifndef ONE_ATOM_TYPE
             const int type_j = atom->type[j];
             const int type_ij = type_i * ntypes + type_j;
             const MD_FLOAT cutforcesq = atom->cutforcesq[type_ij];
@@ -155,7 +155,7 @@ double computeForceEam(Parameter* param, Atom* atom, Neighbor* neighbor, Stats* 
                 //   terms of embed eng: Fi(sum rho_ij) and Fj(sum rho_ji)
                 //   hence embed' = Fi(sum rho_ij) rhojp + Fj(sum rho_ji) rhoip
 
-#ifdef EXPLICIT_TYPES
+#ifndef ONE_ATOM_TYPE
                 MD_FLOAT rhoip = (rhor_spline[type_ij * nr_tot + m * 7 + 0] * p +
                                   rhor_spline[type_ij * nr_tot + m * 7 + 1]) * p +
                                   rhor_spline[type_ij * nr_tot + m * 7 + 2];

--- a/src/clusterpair/force_lj.c
+++ b/src/clusterpair/force_lj.c
@@ -280,9 +280,8 @@ double computeForceLJ2xnnHalfNeigh(
 #ifndef ONE_ATOM_TYPE
             int ci_sca_base        = CI_SCALAR_BASE_INDEX(ci);
             int* ci_t              = &atom->cl_t[ci_sca_base];
-            MD_SIMD_INT ntypes_vec = simd_int_broadcast(atom->ntypes);
-            MD_SIMD_INT tbase0     = simd_int_load_h_dual(&ci_t[0]) * ntypes_vec;
-            MD_SIMD_INT tbase2     = simd_int_load_h_dual(&ci_t[2]) * ntypes_vec;
+            MD_SIMD_INT tbase0     = simd_int_load_h_dual_scaled(&ci_t[0], atom->ntypes);
+            MD_SIMD_INT tbase2     = simd_int_load_h_dual_scaled(&ci_t[2], atom->ntypes);
 #endif
 
             for (int k = 0; k < numneighs_masked; k++) {
@@ -340,8 +339,8 @@ double computeForceLJ2xnnHalfNeigh(
 
 #ifndef ONE_ATOM_TYPE
                 MD_SIMD_INT tj_tmp = simd_int_load_h_duplicate(cj_t);
-                MD_SIMD_INT tvec0  = tbase0 + tj_tmp;
-                MD_SIMD_INT tvec2  = tbase2 + tj_tmp;
+                MD_SIMD_INT tvec0  = simd_int_add(tbase0, tj_tmp);
+                MD_SIMD_INT tvec2  = simd_int_add(tbase2, tj_tmp);
 
                 MD_SIMD_FLOAT cutforcesq0 = simd_gather(tvec0, atom->cutforcesq, sizeof(MD_FLOAT));
                 MD_SIMD_FLOAT cutforcesq2 = simd_gather(tvec2, atom->cutforcesq, sizeof(MD_FLOAT));
@@ -435,8 +434,8 @@ double computeForceLJ2xnnHalfNeigh(
 
 #ifndef ONE_ATOM_TYPE
                 MD_SIMD_INT tj_tmp = simd_int_load_h_duplicate(cj_t);
-                MD_SIMD_INT tvec0  = tbase0 + tj_tmp;
-                MD_SIMD_INT tvec2  = tbase2 + tj_tmp;
+                MD_SIMD_INT tvec0  = simd_int_add(tbase0, tj_tmp);
+                MD_SIMD_INT tvec2  = simd_int_add(tbase2, tj_tmp);
 
                 MD_SIMD_FLOAT cutforcesq0 = simd_gather(tvec0, atom->cutforcesq, sizeof(MD_FLOAT));
                 MD_SIMD_FLOAT cutforcesq2 = simd_gather(tvec2, atom->cutforcesq, sizeof(MD_FLOAT));
@@ -563,9 +562,8 @@ double computeForceLJ2xnnFullNeigh(
 #ifndef ONE_ATOM_TYPE
             int ci_sca_base        = CI_SCALAR_BASE_INDEX(ci);
             int* ci_t              = &atom->cl_t[ci_sca_base];
-            MD_SIMD_INT ntypes_vec = simd_int_broadcast(atom->ntypes);
-            MD_SIMD_INT tbase0     = simd_int_load_h_dual(&ci_t[0]) * ntypes_vec;
-            MD_SIMD_INT tbase2     = simd_int_load_h_dual(&ci_t[2]) * ntypes_vec;
+            MD_SIMD_INT tbase0     = simd_int_load_h_dual_scaled(&ci_t[0], atom->ntypes);
+            MD_SIMD_INT tbase2     = simd_int_load_h_dual_scaled(&ci_t[2], atom->ntypes);
 #endif
 
             for (int k = 0; k < numneighs_masked; k++) {
@@ -617,8 +615,8 @@ double computeForceLJ2xnnFullNeigh(
 
 #ifndef ONE_ATOM_TYPE
                 MD_SIMD_INT tj_tmp = simd_int_load_h_duplicate(cj_t);
-                MD_SIMD_INT tvec0  = tbase0 + tj_tmp;
-                MD_SIMD_INT tvec2  = tbase2 + tj_tmp;
+                MD_SIMD_INT tvec0  = simd_int_add(tbase0, tj_tmp);
+                MD_SIMD_INT tvec2  = simd_int_add(tbase2, tj_tmp);
 
                 MD_SIMD_FLOAT cutforcesq0 = simd_gather(tvec0, atom->cutforcesq, sizeof(MD_FLOAT));
                 MD_SIMD_FLOAT cutforcesq2 = simd_gather(tvec2, atom->cutforcesq, sizeof(MD_FLOAT));
@@ -683,8 +681,8 @@ double computeForceLJ2xnnFullNeigh(
 
 #ifndef ONE_ATOM_TYPE
                 MD_SIMD_INT tj_tmp = simd_int_load_h_duplicate(cj_t);
-                MD_SIMD_INT tvec0  = tbase0 + tj_tmp;
-                MD_SIMD_INT tvec2  = tbase2 + tj_tmp;
+                MD_SIMD_INT tvec0  = simd_int_add(tbase0, tj_tmp);
+                MD_SIMD_INT tvec2  = simd_int_add(tbase2, tj_tmp);
 
                 MD_SIMD_FLOAT cutforcesq0 = simd_gather(tvec0, atom->cutforcesq, sizeof(MD_FLOAT));
                 MD_SIMD_FLOAT cutforcesq2 = simd_gather(tvec2, atom->cutforcesq, sizeof(MD_FLOAT));
@@ -813,11 +811,10 @@ double computeForceLJ4xnHalfNeigh(
 #ifndef ONE_ATOM_TYPE
             int ci_sca_base        = CI_SCALAR_BASE_INDEX(ci);
             int* ci_t              = &atom->cl_t[ci_sca_base];
-            MD_SIMD_INT ntypes_vec = simd_int_broadcast(atom->ntypes);
-            MD_SIMD_INT tbase0     = simd_int_broadcast(ci_t[0]) * ntypes_vec;
-            MD_SIMD_INT tbase1     = simd_int_broadcast(ci_t[1]) * ntypes_vec;
-            MD_SIMD_INT tbase2     = simd_int_broadcast(ci_t[2]) * ntypes_vec;
-            MD_SIMD_INT tbase3     = simd_int_broadcast(ci_t[3]) * ntypes_vec;
+            MD_SIMD_INT tbase0     = simd_int_broadcast(ci_t[0] * atom->ntypes);
+            MD_SIMD_INT tbase1     = simd_int_broadcast(ci_t[1] * atom->ntypes);
+            MD_SIMD_INT tbase2     = simd_int_broadcast(ci_t[2] * atom->ntypes);
+            MD_SIMD_INT tbase3     = simd_int_broadcast(ci_t[3] * atom->ntypes);
 #endif
 
             for (int k = 0; k < numneighs_masked; k++) {
@@ -890,10 +887,10 @@ double computeForceLJ4xnHalfNeigh(
 
 #ifndef ONE_ATOM_TYPE
                 MD_SIMD_INT tj_tmp = simd_int_load(cj_t);
-                MD_SIMD_INT tvec0  = tbase0 + tj_tmp;
-                MD_SIMD_INT tvec1  = tbase1 + tj_tmp;
-                MD_SIMD_INT tvec2  = tbase2 + tj_tmp;
-                MD_SIMD_INT tvec3  = tbase3 + tj_tmp;
+                MD_SIMD_INT tvec0  = simd_int_add(tbase0, tj_tmp);
+                MD_SIMD_INT tvec1  = simd_int_add(tbase1, tj_tmp);
+                MD_SIMD_INT tvec2  = simd_int_add(tbase2, tj_tmp);
+                MD_SIMD_INT tvec3  = simd_int_add(tbase3, tj_tmp);
 
                 MD_SIMD_FLOAT cutforcesq0 = simd_gather(tvec0, atom->cutforcesq, sizeof(MD_FLOAT));
                 MD_SIMD_FLOAT cutforcesq1 = simd_gather(tvec1, atom->cutforcesq, sizeof(MD_FLOAT));
@@ -1028,10 +1025,10 @@ double computeForceLJ4xnHalfNeigh(
 
 #ifndef ONE_ATOM_TYPE
                 MD_SIMD_INT tj_tmp = simd_int_load(cj_t);
-                MD_SIMD_INT tvec0  = tbase0 + tj_tmp;
-                MD_SIMD_INT tvec1  = tbase1 + tj_tmp;
-                MD_SIMD_INT tvec2  = tbase2 + tj_tmp;
-                MD_SIMD_INT tvec3  = tbase3 + tj_tmp;
+                MD_SIMD_INT tvec0  = simd_int_add(tbase0, tj_tmp);
+                MD_SIMD_INT tvec1  = simd_int_add(tbase1, tj_tmp);
+                MD_SIMD_INT tvec2  = simd_int_add(tbase2, tj_tmp);
+                MD_SIMD_INT tvec3  = simd_int_add(tbase3, tj_tmp);
 
                 MD_SIMD_FLOAT cutforcesq0 = simd_gather(tvec0, atom->cutforcesq, sizeof(MD_FLOAT));
                 MD_SIMD_FLOAT cutforcesq1 = simd_gather(tvec1, atom->cutforcesq, sizeof(MD_FLOAT));
@@ -1213,11 +1210,10 @@ double computeForceLJ4xnFullNeigh(
 #ifndef ONE_ATOM_TYPE
             int ci_sca_base        = CI_SCALAR_BASE_INDEX(ci);
             int* ci_t              = &atom->cl_t[ci_sca_base];
-            MD_SIMD_INT ntypes_vec = simd_int_broadcast(atom->ntypes);
-            MD_SIMD_INT tbase0     = simd_int_broadcast(ci_t[0]) * ntypes_vec;
-            MD_SIMD_INT tbase1     = simd_int_broadcast(ci_t[1]) * ntypes_vec;
-            MD_SIMD_INT tbase2     = simd_int_broadcast(ci_t[2]) * ntypes_vec;
-            MD_SIMD_INT tbase3     = simd_int_broadcast(ci_t[3]) * ntypes_vec;
+            MD_SIMD_INT tbase0     = simd_int_broadcast(ci_t[0] * atom->ntypes);
+            MD_SIMD_INT tbase1     = simd_int_broadcast(ci_t[1] * atom->ntypes);
+            MD_SIMD_INT tbase2     = simd_int_broadcast(ci_t[2] * atom->ntypes);
+            MD_SIMD_INT tbase3     = simd_int_broadcast(ci_t[3] * atom->ntypes);
 #endif
 
             for (int k = 0; k < numneighs_masked; k++) {
@@ -1289,10 +1285,10 @@ double computeForceLJ4xnFullNeigh(
 
 #ifndef ONE_ATOM_TYPE
                 MD_SIMD_INT tj_tmp = simd_int_load(cj_t);
-                MD_SIMD_INT tvec0  = tbase0 + tj_tmp;
-                MD_SIMD_INT tvec1  = tbase1 + tj_tmp;
-                MD_SIMD_INT tvec2  = tbase2 + tj_tmp;
-                MD_SIMD_INT tvec3  = tbase3 + tj_tmp;
+                MD_SIMD_INT tvec0  = simd_int_add(tbase0, tj_tmp);
+                MD_SIMD_INT tvec1  = simd_int_add(tbase1, tj_tmp);
+                MD_SIMD_INT tvec2  = simd_int_add(tbase2, tj_tmp);
+                MD_SIMD_INT tvec3  = simd_int_add(tbase3, tj_tmp);
 
                 MD_SIMD_FLOAT cutforcesq0 = simd_gather(tvec0, atom->cutforcesq, sizeof(MD_FLOAT));
                 MD_SIMD_FLOAT cutforcesq1 = simd_gather(tvec1, atom->cutforcesq, sizeof(MD_FLOAT));
@@ -1404,10 +1400,10 @@ double computeForceLJ4xnFullNeigh(
 
 #ifndef ONE_ATOM_TYPE
                 MD_SIMD_INT tj_tmp = simd_int_load(cj_t);
-                MD_SIMD_INT tvec0  = tbase0 + tj_tmp;
-                MD_SIMD_INT tvec1  = tbase1 + tj_tmp;
-                MD_SIMD_INT tvec2  = tbase2 + tj_tmp;
-                MD_SIMD_INT tvec3  = tbase3 + tj_tmp;
+                MD_SIMD_INT tvec0  = simd_int_add(tbase0, tj_tmp);
+                MD_SIMD_INT tvec1  = simd_int_add(tbase1, tj_tmp);
+                MD_SIMD_INT tvec2  = simd_int_add(tbase2, tj_tmp);
+                MD_SIMD_INT tvec3  = simd_int_add(tbase3, tj_tmp);
 
                 MD_SIMD_FLOAT cutforcesq0 = simd_gather(tvec0, atom->cutforcesq, sizeof(MD_FLOAT));
                 MD_SIMD_FLOAT cutforcesq1 = simd_gather(tvec1, atom->cutforcesq, sizeof(MD_FLOAT));

--- a/src/clusterpair/force_lj.c
+++ b/src/clusterpair/force_lj.c
@@ -83,7 +83,7 @@ double computeForceLJRef(Parameter* param, Atom* atom, Neighbor* neighbor, Stats
 
 #ifndef ONE_ATOM_TYPE
             int ci_sca_base = CI_SCALAR_BASE_INDEX(ci);
-            int *ci_t       = &atom->cl_t[ci_sca_base];
+            int* ci_t       = &atom->cl_t[ci_sca_base];
 #endif
 
             for (int k = 0; k < numneighs; k++) {
@@ -95,7 +95,7 @@ double computeForceLJRef(Parameter* param, Atom* atom, Neighbor* neighbor, Stats
 
 #ifndef ONE_ATOM_TYPE
                 int cj_sca_base = CJ_SCALAR_BASE_INDEX(cj);
-                int *cj_t       = &atom->cl_t[cj_sca_base];
+                int* cj_t       = &atom->cl_t[cj_sca_base];
 #endif
 
                 for (int cii = 0; cii < CLUSTER_M; cii++) {
@@ -253,9 +253,9 @@ double computeForceLJ2xnnHalfNeigh(
 
 #pragma omp for schedule(runtime)
         for (int ci = 0; ci < atom->Nclusters_local; ci++) {
-            int ci_cj0 = CJ0_FROM_CI(ci);
+            int ci_cj0           = CJ0_FROM_CI(ci);
 #if CLUSTER_M > CLUSTER_N
-            int ci_cj1 = CJ1_FROM_CI(ci);
+            int ci_cj1           = CJ1_FROM_CI(ci);
 #endif
             int ci_vec_base      = CI_VECTOR_BASE_INDEX(ci);
             MD_FLOAT* ci_x       = &atom->cl_x[ci_vec_base];
@@ -278,10 +278,10 @@ double computeForceLJ2xnnHalfNeigh(
             MD_SIMD_FLOAT fiz2    = simd_zero();
 
 #ifndef ONE_ATOM_TYPE
-            int ci_sca_base        = CI_SCALAR_BASE_INDEX(ci);
-            int* ci_t              = &atom->cl_t[ci_sca_base];
-            MD_SIMD_INT tbase0     = simd_int_load_h_dual_scaled(&ci_t[0], atom->ntypes);
-            MD_SIMD_INT tbase2     = simd_int_load_h_dual_scaled(&ci_t[2], atom->ntypes);
+            int ci_sca_base       = CI_SCALAR_BASE_INDEX(ci);
+            int* ci_t             = &atom->cl_t[ci_sca_base];
+            MD_SIMD_INT tbase0    = simd_int_load_h_dual_scaled(&ci_t[0], atom->ntypes);
+            MD_SIMD_INT tbase2    = simd_int_load_h_dual_scaled(&ci_t[2], atom->ntypes);
 #endif
 
             for (int k = 0; k < numneighs_masked; k++) {
@@ -298,22 +298,22 @@ double computeForceLJ2xnnHalfNeigh(
 
 #ifndef ONE_ATOM_TYPE
                 int cj_sca_base = CJ_SCALAR_BASE_INDEX(cj);
-                int *cj_t       = &atom->cl_t[cj_sca_base];
+                int* cj_t       = &atom->cl_t[cj_sca_base];
 #endif
 
-                MD_SIMD_FLOAT xj_tmp = simd_load_h_duplicate(&cj_x[CL_X_OFFSET]);
-                MD_SIMD_FLOAT yj_tmp = simd_load_h_duplicate(&cj_x[CL_Y_OFFSET]);
-                MD_SIMD_FLOAT zj_tmp = simd_load_h_duplicate(&cj_x[CL_Z_OFFSET]);
-                MD_SIMD_FLOAT delx0  = xi0_tmp - xj_tmp;
-                MD_SIMD_FLOAT dely0  = yi0_tmp - yj_tmp;
-                MD_SIMD_FLOAT delz0  = zi0_tmp - zj_tmp;
-                MD_SIMD_FLOAT delx2  = xi2_tmp - xj_tmp;
-                MD_SIMD_FLOAT dely2  = yi2_tmp - yj_tmp;
-                MD_SIMD_FLOAT delz2  = zi2_tmp - zj_tmp;
-                MD_SIMD_FLOAT rsq0   = simd_fma(delx0,
+                MD_SIMD_FLOAT xj_tmp    = simd_load_h_duplicate(&cj_x[CL_X_OFFSET]);
+                MD_SIMD_FLOAT yj_tmp    = simd_load_h_duplicate(&cj_x[CL_Y_OFFSET]);
+                MD_SIMD_FLOAT zj_tmp    = simd_load_h_duplicate(&cj_x[CL_Z_OFFSET]);
+                MD_SIMD_FLOAT delx0     = xi0_tmp - xj_tmp;
+                MD_SIMD_FLOAT dely0     = yi0_tmp - yj_tmp;
+                MD_SIMD_FLOAT delz0     = zi0_tmp - zj_tmp;
+                MD_SIMD_FLOAT delx2     = xi2_tmp - xj_tmp;
+                MD_SIMD_FLOAT dely2     = yi2_tmp - yj_tmp;
+                MD_SIMD_FLOAT delz2     = zi2_tmp - zj_tmp;
+                MD_SIMD_FLOAT rsq0      = simd_fma(delx0,
                     delx0,
                     simd_fma(dely0, dely0, delz0 * delz0));
-                MD_SIMD_FLOAT rsq2   = simd_fma(delx2,
+                MD_SIMD_FLOAT rsq2      = simd_fma(delx2,
                     delx2,
                     simd_fma(dely2, dely2, delz2 * delz2));
 
@@ -325,8 +325,8 @@ double computeForceLJ2xnnHalfNeigh(
                     atom->masks_2xnn_hn[cond0 * 2 + 1]);
 #else
 #if CLUSTER_M < CLUSTER_N
-                unsigned int cond0 = (unsigned int)((cj << 1) + 0 == ci);
-                unsigned int cond1 = (unsigned int)((cj << 1) + 1 == ci);
+                unsigned int cond0      = (unsigned int)((cj << 1) + 0 == ci);
+                unsigned int cond1      = (unsigned int)((cj << 1) + 1 == ci);
 #else
                 unsigned int cond0 = (unsigned int)(cj == ci_cj0);
                 unsigned int cond1 = (unsigned int)(cj == ci_cj1);
@@ -342,12 +342,20 @@ double computeForceLJ2xnnHalfNeigh(
                 MD_SIMD_INT tvec0  = simd_int_add(tbase0, tj_tmp);
                 MD_SIMD_INT tvec2  = simd_int_add(tbase2, tj_tmp);
 
-                MD_SIMD_FLOAT cutforcesq0 = simd_gather(tvec0, atom->cutforcesq, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT cutforcesq2 = simd_gather(tvec2, atom->cutforcesq, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT sigma6_0    = simd_gather(tvec0, atom->sigma6, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT sigma6_2    = simd_gather(tvec2, atom->sigma6, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT eps0        = simd_gather(tvec0, atom->epsilon, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT eps2        = simd_gather(tvec2, atom->epsilon, sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT cutforcesq0 = simd_gather(tvec0,
+                    atom->cutforcesq,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT cutforcesq2 = simd_gather(tvec2,
+                    atom->cutforcesq,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT sigma6_0    = simd_gather(tvec0,
+                    atom->sigma6,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT sigma6_2    = simd_gather(tvec2,
+                    atom->sigma6,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT eps0 = simd_gather(tvec0, atom->epsilon, sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT eps2 = simd_gather(tvec2, atom->epsilon, sizeof(MD_FLOAT));
 #else
                 MD_SIMD_FLOAT cutforcesq0 = cutforcesq_vec;
                 MD_SIMD_FLOAT cutforcesq2 = cutforcesq_vec;
@@ -413,7 +421,7 @@ double computeForceLJ2xnnHalfNeigh(
 
 #ifndef ONE_ATOM_TYPE
                 int cj_sca_base = CJ_SCALAR_BASE_INDEX(cj);
-                int *cj_t       = &atom->cl_t[cj_sca_base];
+                int* cj_t       = &atom->cl_t[cj_sca_base];
 #endif
 
                 MD_SIMD_FLOAT xj_tmp = simd_load_h_duplicate(&cj_x[CL_X_OFFSET]);
@@ -433,16 +441,24 @@ double computeForceLJ2xnnHalfNeigh(
                     simd_fma(dely2, dely2, delz2 * delz2));
 
 #ifndef ONE_ATOM_TYPE
-                MD_SIMD_INT tj_tmp = simd_int_load_h_duplicate(cj_t);
-                MD_SIMD_INT tvec0  = simd_int_add(tbase0, tj_tmp);
-                MD_SIMD_INT tvec2  = simd_int_add(tbase2, tj_tmp);
+                MD_SIMD_INT tj_tmp   = simd_int_load_h_duplicate(cj_t);
+                MD_SIMD_INT tvec0    = simd_int_add(tbase0, tj_tmp);
+                MD_SIMD_INT tvec2    = simd_int_add(tbase2, tj_tmp);
 
-                MD_SIMD_FLOAT cutforcesq0 = simd_gather(tvec0, atom->cutforcesq, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT cutforcesq2 = simd_gather(tvec2, atom->cutforcesq, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT sigma6_0    = simd_gather(tvec0, atom->sigma6, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT sigma6_2    = simd_gather(tvec2, atom->sigma6, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT eps0        = simd_gather(tvec0, atom->epsilon, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT eps2        = simd_gather(tvec2, atom->epsilon, sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT cutforcesq0 = simd_gather(tvec0,
+                    atom->cutforcesq,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT cutforcesq2 = simd_gather(tvec2,
+                    atom->cutforcesq,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT sigma6_0    = simd_gather(tvec0,
+                    atom->sigma6,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT sigma6_2    = simd_gather(tvec2,
+                    atom->sigma6,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT eps0 = simd_gather(tvec0, atom->epsilon, sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT eps2 = simd_gather(tvec2, atom->epsilon, sizeof(MD_FLOAT));
 #else
                 MD_SIMD_FLOAT cutforcesq0 = cutforcesq_vec;
                 MD_SIMD_FLOAT cutforcesq2 = cutforcesq_vec;
@@ -535,9 +551,9 @@ double computeForceLJ2xnnFullNeigh(
 
 #pragma omp for schedule(runtime)
         for (int ci = 0; ci < atom->Nclusters_local; ci++) {
-            int ci_cj0 = CJ0_FROM_CI(ci);
+            int ci_cj0           = CJ0_FROM_CI(ci);
 #if CLUSTER_M > CLUSTER_N
-            int ci_cj1 = CJ1_FROM_CI(ci);
+            int ci_cj1           = CJ1_FROM_CI(ci);
 #endif
             int ci_vec_base      = CI_VECTOR_BASE_INDEX(ci);
             MD_FLOAT* ci_x       = &atom->cl_x[ci_vec_base];
@@ -560,10 +576,10 @@ double computeForceLJ2xnnFullNeigh(
             MD_SIMD_FLOAT fiz2    = simd_zero();
 
 #ifndef ONE_ATOM_TYPE
-            int ci_sca_base        = CI_SCALAR_BASE_INDEX(ci);
-            int* ci_t              = &atom->cl_t[ci_sca_base];
-            MD_SIMD_INT tbase0     = simd_int_load_h_dual_scaled(&ci_t[0], atom->ntypes);
-            MD_SIMD_INT tbase2     = simd_int_load_h_dual_scaled(&ci_t[2], atom->ntypes);
+            int ci_sca_base       = CI_SCALAR_BASE_INDEX(ci);
+            int* ci_t             = &atom->cl_t[ci_sca_base];
+            MD_SIMD_INT tbase0    = simd_int_load_h_dual_scaled(&ci_t[0], atom->ntypes);
+            MD_SIMD_INT tbase2    = simd_int_load_h_dual_scaled(&ci_t[2], atom->ntypes);
 #endif
 
             for (int k = 0; k < numneighs_masked; k++) {
@@ -574,22 +590,22 @@ double computeForceLJ2xnnFullNeigh(
 
 #ifndef ONE_ATOM_TYPE
                 int cj_sca_base = CJ_SCALAR_BASE_INDEX(cj);
-                int *cj_t       = &atom->cl_t[cj_sca_base];
+                int* cj_t       = &atom->cl_t[cj_sca_base];
 #endif
 
-                MD_SIMD_FLOAT xj_tmp = simd_load_h_duplicate(&cj_x[CL_X_OFFSET]);
-                MD_SIMD_FLOAT yj_tmp = simd_load_h_duplicate(&cj_x[CL_Y_OFFSET]);
-                MD_SIMD_FLOAT zj_tmp = simd_load_h_duplicate(&cj_x[CL_Z_OFFSET]);
-                MD_SIMD_FLOAT delx0  = xi0_tmp - xj_tmp;
-                MD_SIMD_FLOAT dely0  = yi0_tmp - yj_tmp;
-                MD_SIMD_FLOAT delz0  = zi0_tmp - zj_tmp;
-                MD_SIMD_FLOAT delx2  = xi2_tmp - xj_tmp;
-                MD_SIMD_FLOAT dely2  = yi2_tmp - yj_tmp;
-                MD_SIMD_FLOAT delz2  = zi2_tmp - zj_tmp;
-                MD_SIMD_FLOAT rsq0   = simd_fma(delx0,
+                MD_SIMD_FLOAT xj_tmp    = simd_load_h_duplicate(&cj_x[CL_X_OFFSET]);
+                MD_SIMD_FLOAT yj_tmp    = simd_load_h_duplicate(&cj_x[CL_Y_OFFSET]);
+                MD_SIMD_FLOAT zj_tmp    = simd_load_h_duplicate(&cj_x[CL_Z_OFFSET]);
+                MD_SIMD_FLOAT delx0     = xi0_tmp - xj_tmp;
+                MD_SIMD_FLOAT dely0     = yi0_tmp - yj_tmp;
+                MD_SIMD_FLOAT delz0     = zi0_tmp - zj_tmp;
+                MD_SIMD_FLOAT delx2     = xi2_tmp - xj_tmp;
+                MD_SIMD_FLOAT dely2     = yi2_tmp - yj_tmp;
+                MD_SIMD_FLOAT delz2     = zi2_tmp - zj_tmp;
+                MD_SIMD_FLOAT rsq0      = simd_fma(delx0,
                     delx0,
                     simd_fma(dely0, dely0, delz0 * delz0));
-                MD_SIMD_FLOAT rsq2   = simd_fma(delx2,
+                MD_SIMD_FLOAT rsq2      = simd_fma(delx2,
                     delx2,
                     simd_fma(dely2, dely2, delz2 * delz2));
 
@@ -601,13 +617,13 @@ double computeForceLJ2xnnFullNeigh(
                     atom->masks_2xnn_fn[cond0 * 2 + 1]);
 #else
 #if CLUSTER_M < CLUSTER_N
-                unsigned int cond0 = (unsigned int)((cj << 1) + 0 == ci);
-                unsigned int cond1 = (unsigned int)((cj << 1) + 1 == ci);
+                unsigned int cond0        = (unsigned int)((cj << 1) + 0 == ci);
+                unsigned int cond1        = (unsigned int)((cj << 1) + 1 == ci);
 #else
                 unsigned int cond0 = (unsigned int)(cj == ci_cj0);
                 unsigned int cond1 = (unsigned int)(cj == ci_cj1);
 #endif
-                MD_SIMD_MASK excl_mask0 = simd_mask_from_u32(
+                MD_SIMD_MASK excl_mask0   = simd_mask_from_u32(
                     atom->masks_2xnn_fn[cond0 * 4 + cond1 * 2 + 0]);
                 MD_SIMD_MASK excl_mask2 = simd_mask_from_u32(
                     atom->masks_2xnn_fn[cond0 * 4 + cond1 * 2 + 1]);
@@ -618,12 +634,20 @@ double computeForceLJ2xnnFullNeigh(
                 MD_SIMD_INT tvec0  = simd_int_add(tbase0, tj_tmp);
                 MD_SIMD_INT tvec2  = simd_int_add(tbase2, tj_tmp);
 
-                MD_SIMD_FLOAT cutforcesq0 = simd_gather(tvec0, atom->cutforcesq, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT cutforcesq2 = simd_gather(tvec2, atom->cutforcesq, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT sigma6_0    = simd_gather(tvec0, atom->sigma6, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT sigma6_2    = simd_gather(tvec2, atom->sigma6, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT eps0        = simd_gather(tvec0, atom->epsilon, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT eps2        = simd_gather(tvec2, atom->epsilon, sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT cutforcesq0 = simd_gather(tvec0,
+                    atom->cutforcesq,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT cutforcesq2 = simd_gather(tvec2,
+                    atom->cutforcesq,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT sigma6_0    = simd_gather(tvec0,
+                    atom->sigma6,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT sigma6_2    = simd_gather(tvec2,
+                    atom->sigma6,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT eps0 = simd_gather(tvec0, atom->epsilon, sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT eps2 = simd_gather(tvec2, atom->epsilon, sizeof(MD_FLOAT));
 #else
                 MD_SIMD_FLOAT cutforcesq0 = cutforcesq_vec;
                 MD_SIMD_FLOAT cutforcesq2 = cutforcesq_vec;
@@ -660,7 +684,7 @@ double computeForceLJ2xnnFullNeigh(
 
 #ifndef ONE_ATOM_TYPE
                 int cj_sca_base = CJ_SCALAR_BASE_INDEX(cj);
-                int *cj_t       = &atom->cl_t[cj_sca_base];
+                int* cj_t       = &atom->cl_t[cj_sca_base];
 #endif
 
                 MD_SIMD_FLOAT xj_tmp = simd_load_h_duplicate(&cj_x[CL_X_OFFSET]);
@@ -680,16 +704,24 @@ double computeForceLJ2xnnFullNeigh(
                     simd_fma(dely2, dely2, delz2 * delz2));
 
 #ifndef ONE_ATOM_TYPE
-                MD_SIMD_INT tj_tmp = simd_int_load_h_duplicate(cj_t);
-                MD_SIMD_INT tvec0  = simd_int_add(tbase0, tj_tmp);
-                MD_SIMD_INT tvec2  = simd_int_add(tbase2, tj_tmp);
+                MD_SIMD_INT tj_tmp   = simd_int_load_h_duplicate(cj_t);
+                MD_SIMD_INT tvec0    = simd_int_add(tbase0, tj_tmp);
+                MD_SIMD_INT tvec2    = simd_int_add(tbase2, tj_tmp);
 
-                MD_SIMD_FLOAT cutforcesq0 = simd_gather(tvec0, atom->cutforcesq, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT cutforcesq2 = simd_gather(tvec2, atom->cutforcesq, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT sigma6_0    = simd_gather(tvec0, atom->sigma6, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT sigma6_2    = simd_gather(tvec2, atom->sigma6, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT eps0        = simd_gather(tvec0, atom->epsilon, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT eps2        = simd_gather(tvec2, atom->epsilon, sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT cutforcesq0 = simd_gather(tvec0,
+                    atom->cutforcesq,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT cutforcesq2 = simd_gather(tvec2,
+                    atom->cutforcesq,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT sigma6_0    = simd_gather(tvec0,
+                    atom->sigma6,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT sigma6_2    = simd_gather(tvec2,
+                    atom->sigma6,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT eps0 = simd_gather(tvec0, atom->epsilon, sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT eps2 = simd_gather(tvec2, atom->epsilon, sizeof(MD_FLOAT));
 #else
                 MD_SIMD_FLOAT cutforcesq0 = cutforcesq_vec;
                 MD_SIMD_FLOAT cutforcesq2 = cutforcesq_vec;
@@ -772,9 +804,9 @@ double computeForceLJ4xnHalfNeigh(
 
 #pragma omp for schedule(runtime)
         for (int ci = 0; ci < atom->Nclusters_local; ci++) {
-            int ci_cj0 = CJ0_FROM_CI(ci);
+            int ci_cj0           = CJ0_FROM_CI(ci);
 #if CLUSTER_M > CLUSTER_N
-            int ci_cj1 = CJ1_FROM_CI(ci);
+            int ci_cj1           = CJ1_FROM_CI(ci);
 #endif
             int ci_vec_base      = CI_VECTOR_BASE_INDEX(ci);
             MD_FLOAT* ci_x       = &atom->cl_x[ci_vec_base];
@@ -809,40 +841,40 @@ double computeForceLJ4xnHalfNeigh(
             MD_SIMD_FLOAT fiz3    = simd_zero();
 
 #ifndef ONE_ATOM_TYPE
-            int ci_sca_base        = CI_SCALAR_BASE_INDEX(ci);
-            int* ci_t              = &atom->cl_t[ci_sca_base];
-            MD_SIMD_INT tbase0     = simd_int_broadcast(ci_t[0] * atom->ntypes);
-            MD_SIMD_INT tbase1     = simd_int_broadcast(ci_t[1] * atom->ntypes);
-            MD_SIMD_INT tbase2     = simd_int_broadcast(ci_t[2] * atom->ntypes);
-            MD_SIMD_INT tbase3     = simd_int_broadcast(ci_t[3] * atom->ntypes);
+            int ci_sca_base       = CI_SCALAR_BASE_INDEX(ci);
+            int* ci_t             = &atom->cl_t[ci_sca_base];
+            MD_SIMD_INT tbase0    = simd_int_broadcast(ci_t[0] * atom->ntypes);
+            MD_SIMD_INT tbase1    = simd_int_broadcast(ci_t[1] * atom->ntypes);
+            MD_SIMD_INT tbase2    = simd_int_broadcast(ci_t[2] * atom->ntypes);
+            MD_SIMD_INT tbase3    = simd_int_broadcast(ci_t[3] * atom->ntypes);
 #endif
 
             for (int k = 0; k < numneighs_masked; k++) {
-                int cj               = neighs[k];
-                int cj_vec_base      = CJ_VECTOR_BASE_INDEX(cj);
-                MD_FLOAT* cj_x       = &atom->cl_x[cj_vec_base];
-                MD_FLOAT* cj_f       = &atom->cl_f[cj_vec_base];
+                int cj          = neighs[k];
+                int cj_vec_base = CJ_VECTOR_BASE_INDEX(cj);
+                MD_FLOAT* cj_x  = &atom->cl_x[cj_vec_base];
+                MD_FLOAT* cj_f  = &atom->cl_f[cj_vec_base];
 
 #ifndef ONE_ATOM_TYPE
                 int cj_sca_base = CJ_SCALAR_BASE_INDEX(cj);
-                int *cj_t       = &atom->cl_t[cj_sca_base];
+                int* cj_t       = &atom->cl_t[cj_sca_base];
 #endif
 
-                MD_SIMD_FLOAT xj_tmp = simd_load(&cj_x[CL_X_OFFSET]);
-                MD_SIMD_FLOAT yj_tmp = simd_load(&cj_x[CL_Y_OFFSET]);
-                MD_SIMD_FLOAT zj_tmp = simd_load(&cj_x[CL_Z_OFFSET]);
-                MD_SIMD_FLOAT delx0  = xi0_tmp - xj_tmp;
-                MD_SIMD_FLOAT dely0  = yi0_tmp - yj_tmp;
-                MD_SIMD_FLOAT delz0  = zi0_tmp - zj_tmp;
-                MD_SIMD_FLOAT delx1  = xi1_tmp - xj_tmp;
-                MD_SIMD_FLOAT dely1  = yi1_tmp - yj_tmp;
-                MD_SIMD_FLOAT delz1  = zi1_tmp - zj_tmp;
-                MD_SIMD_FLOAT delx2  = xi2_tmp - xj_tmp;
-                MD_SIMD_FLOAT dely2  = yi2_tmp - yj_tmp;
-                MD_SIMD_FLOAT delz2  = zi2_tmp - zj_tmp;
-                MD_SIMD_FLOAT delx3  = xi3_tmp - xj_tmp;
-                MD_SIMD_FLOAT dely3  = yi3_tmp - yj_tmp;
-                MD_SIMD_FLOAT delz3  = zi3_tmp - zj_tmp;
+                MD_SIMD_FLOAT xj_tmp    = simd_load(&cj_x[CL_X_OFFSET]);
+                MD_SIMD_FLOAT yj_tmp    = simd_load(&cj_x[CL_Y_OFFSET]);
+                MD_SIMD_FLOAT zj_tmp    = simd_load(&cj_x[CL_Z_OFFSET]);
+                MD_SIMD_FLOAT delx0     = xi0_tmp - xj_tmp;
+                MD_SIMD_FLOAT dely0     = yi0_tmp - yj_tmp;
+                MD_SIMD_FLOAT delz0     = zi0_tmp - zj_tmp;
+                MD_SIMD_FLOAT delx1     = xi1_tmp - xj_tmp;
+                MD_SIMD_FLOAT dely1     = yi1_tmp - yj_tmp;
+                MD_SIMD_FLOAT delz1     = zi1_tmp - zj_tmp;
+                MD_SIMD_FLOAT delx2     = xi2_tmp - xj_tmp;
+                MD_SIMD_FLOAT dely2     = yi2_tmp - yj_tmp;
+                MD_SIMD_FLOAT delz2     = zi2_tmp - zj_tmp;
+                MD_SIMD_FLOAT delx3     = xi3_tmp - xj_tmp;
+                MD_SIMD_FLOAT dely3     = yi3_tmp - yj_tmp;
+                MD_SIMD_FLOAT delz3     = zi3_tmp - zj_tmp;
 
 #if CLUSTER_M == CLUSTER_N
                 unsigned int cond0      = (unsigned int)(cj == ci_cj0);
@@ -856,13 +888,13 @@ double computeForceLJ4xnHalfNeigh(
                     atom->masks_4xn_hn[cond0 * 4 + 3]);
 #else
 #if CLUSTER_M < CLUSTER_N
-                unsigned int cond0 = (unsigned int)((cj << 1) + 0 == ci);
-                unsigned int cond1 = (unsigned int)((cj << 1) + 1 == ci);
+                unsigned int cond0        = (unsigned int)((cj << 1) + 0 == ci);
+                unsigned int cond1        = (unsigned int)((cj << 1) + 1 == ci);
 #else
                 unsigned int cond0 = (unsigned int)(cj == ci_cj0);
                 unsigned int cond1 = (unsigned int)(cj == ci_cj1);
 #endif
-                MD_SIMD_MASK excl_mask0 = simd_mask_from_u32(
+                MD_SIMD_MASK excl_mask0   = simd_mask_from_u32(
                     atom->masks_4xn_hn[cond0 * 8 + cond1 * 4 + 0]);
                 MD_SIMD_MASK excl_mask1 = simd_mask_from_u32(
                     atom->masks_4xn_hn[cond0 * 8 + cond1 * 4 + 1]);
@@ -892,15 +924,31 @@ double computeForceLJ4xnHalfNeigh(
                 MD_SIMD_INT tvec2  = simd_int_add(tbase2, tj_tmp);
                 MD_SIMD_INT tvec3  = simd_int_add(tbase3, tj_tmp);
 
-                MD_SIMD_FLOAT cutforcesq0 = simd_gather(tvec0, atom->cutforcesq, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT cutforcesq1 = simd_gather(tvec1, atom->cutforcesq, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT cutforcesq2 = simd_gather(tvec2, atom->cutforcesq, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT cutforcesq3 = simd_gather(tvec3, atom->cutforcesq, sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT cutforcesq0 = simd_gather(tvec0,
+                    atom->cutforcesq,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT cutforcesq1 = simd_gather(tvec1,
+                    atom->cutforcesq,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT cutforcesq2 = simd_gather(tvec2,
+                    atom->cutforcesq,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT cutforcesq3 = simd_gather(tvec3,
+                    atom->cutforcesq,
+                    sizeof(MD_FLOAT));
 
-                MD_SIMD_FLOAT sigma6_0 = simd_gather(tvec0, atom->sigma6, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT sigma6_1 = simd_gather(tvec1, atom->sigma6, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT sigma6_2 = simd_gather(tvec2, atom->sigma6, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT sigma6_3 = simd_gather(tvec3, atom->sigma6, sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT sigma6_0 = simd_gather(tvec0,
+                    atom->sigma6,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT sigma6_1 = simd_gather(tvec1,
+                    atom->sigma6,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT sigma6_2 = simd_gather(tvec2,
+                    atom->sigma6,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT sigma6_3 = simd_gather(tvec3,
+                    atom->sigma6,
+                    sizeof(MD_FLOAT));
 
                 MD_SIMD_FLOAT eps0 = simd_gather(tvec0, atom->epsilon, sizeof(MD_FLOAT));
                 MD_SIMD_FLOAT eps1 = simd_gather(tvec1, atom->epsilon, sizeof(MD_FLOAT));
@@ -917,10 +965,10 @@ double computeForceLJ4xnHalfNeigh(
                 MD_SIMD_FLOAT sigma6_2 = sigma6_vec;
                 MD_SIMD_FLOAT sigma6_3 = sigma6_vec;
 
-                MD_SIMD_FLOAT eps0 = eps_vec;
-                MD_SIMD_FLOAT eps1 = eps_vec;
-                MD_SIMD_FLOAT eps2 = eps_vec;
-                MD_SIMD_FLOAT eps3 = eps_vec;
+                MD_SIMD_FLOAT eps0        = eps_vec;
+                MD_SIMD_FLOAT eps1        = eps_vec;
+                MD_SIMD_FLOAT eps2        = eps_vec;
+                MD_SIMD_FLOAT eps3        = eps_vec;
 #endif
 
                 MD_SIMD_MASK cutoff_mask0 = simd_mask_and(excl_mask0,
@@ -984,14 +1032,14 @@ double computeForceLJ4xnHalfNeigh(
             }
 
             for (int k = numneighs_masked; k < numneighs; k++) {
-                int cj               = neighs[k];
-                int cj_vec_base      = CJ_VECTOR_BASE_INDEX(cj);
-                MD_FLOAT* cj_x       = &atom->cl_x[cj_vec_base];
-                MD_FLOAT* cj_f       = &atom->cl_f[cj_vec_base];
+                int cj          = neighs[k];
+                int cj_vec_base = CJ_VECTOR_BASE_INDEX(cj);
+                MD_FLOAT* cj_x  = &atom->cl_x[cj_vec_base];
+                MD_FLOAT* cj_f  = &atom->cl_f[cj_vec_base];
 
 #ifndef ONE_ATOM_TYPE
                 int cj_sca_base = CJ_SCALAR_BASE_INDEX(cj);
-                int *cj_t       = &atom->cl_t[cj_sca_base];
+                int* cj_t       = &atom->cl_t[cj_sca_base];
 #endif
 
                 MD_SIMD_FLOAT xj_tmp = simd_load(&cj_x[CL_X_OFFSET]);
@@ -1030,15 +1078,31 @@ double computeForceLJ4xnHalfNeigh(
                 MD_SIMD_INT tvec2  = simd_int_add(tbase2, tj_tmp);
                 MD_SIMD_INT tvec3  = simd_int_add(tbase3, tj_tmp);
 
-                MD_SIMD_FLOAT cutforcesq0 = simd_gather(tvec0, atom->cutforcesq, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT cutforcesq1 = simd_gather(tvec1, atom->cutforcesq, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT cutforcesq2 = simd_gather(tvec2, atom->cutforcesq, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT cutforcesq3 = simd_gather(tvec3, atom->cutforcesq, sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT cutforcesq0 = simd_gather(tvec0,
+                    atom->cutforcesq,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT cutforcesq1 = simd_gather(tvec1,
+                    atom->cutforcesq,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT cutforcesq2 = simd_gather(tvec2,
+                    atom->cutforcesq,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT cutforcesq3 = simd_gather(tvec3,
+                    atom->cutforcesq,
+                    sizeof(MD_FLOAT));
 
-                MD_SIMD_FLOAT sigma6_0 = simd_gather(tvec0, atom->sigma6, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT sigma6_1 = simd_gather(tvec1, atom->sigma6, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT sigma6_2 = simd_gather(tvec2, atom->sigma6, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT sigma6_3 = simd_gather(tvec3, atom->sigma6, sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT sigma6_0 = simd_gather(tvec0,
+                    atom->sigma6,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT sigma6_1 = simd_gather(tvec1,
+                    atom->sigma6,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT sigma6_2 = simd_gather(tvec2,
+                    atom->sigma6,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT sigma6_3 = simd_gather(tvec3,
+                    atom->sigma6,
+                    sizeof(MD_FLOAT));
 
                 MD_SIMD_FLOAT eps0 = simd_gather(tvec0, atom->epsilon, sizeof(MD_FLOAT));
                 MD_SIMD_FLOAT eps1 = simd_gather(tvec1, atom->epsilon, sizeof(MD_FLOAT));
@@ -1055,10 +1119,10 @@ double computeForceLJ4xnHalfNeigh(
                 MD_SIMD_FLOAT sigma6_2 = sigma6_vec;
                 MD_SIMD_FLOAT sigma6_3 = sigma6_vec;
 
-                MD_SIMD_FLOAT eps0 = eps_vec;
-                MD_SIMD_FLOAT eps1 = eps_vec;
-                MD_SIMD_FLOAT eps2 = eps_vec;
-                MD_SIMD_FLOAT eps3 = eps_vec;
+                MD_SIMD_FLOAT eps0      = eps_vec;
+                MD_SIMD_FLOAT eps1      = eps_vec;
+                MD_SIMD_FLOAT eps2      = eps_vec;
+                MD_SIMD_FLOAT eps3      = eps_vec;
 #endif
 
                 MD_SIMD_MASK cutoff_mask0 = simd_mask_cond_lt(rsq0, cutforcesq0);
@@ -1171,9 +1235,9 @@ double computeForceLJ4xnFullNeigh(
 
 #pragma omp for schedule(runtime)
         for (int ci = 0; ci < atom->Nclusters_local; ci++) {
-            int ci_cj0 = CJ0_FROM_CI(ci);
+            int ci_cj0           = CJ0_FROM_CI(ci);
 #if CLUSTER_M > CLUSTER_N
-            int ci_cj1 = CJ1_FROM_CI(ci);
+            int ci_cj1           = CJ1_FROM_CI(ci);
 #endif
             int ci_vec_base      = CI_VECTOR_BASE_INDEX(ci);
             MD_FLOAT* ci_x       = &atom->cl_x[ci_vec_base];
@@ -1208,39 +1272,39 @@ double computeForceLJ4xnFullNeigh(
             MD_SIMD_FLOAT fiz3    = simd_zero();
 
 #ifndef ONE_ATOM_TYPE
-            int ci_sca_base        = CI_SCALAR_BASE_INDEX(ci);
-            int* ci_t              = &atom->cl_t[ci_sca_base];
-            MD_SIMD_INT tbase0     = simd_int_broadcast(ci_t[0] * atom->ntypes);
-            MD_SIMD_INT tbase1     = simd_int_broadcast(ci_t[1] * atom->ntypes);
-            MD_SIMD_INT tbase2     = simd_int_broadcast(ci_t[2] * atom->ntypes);
-            MD_SIMD_INT tbase3     = simd_int_broadcast(ci_t[3] * atom->ntypes);
+            int ci_sca_base       = CI_SCALAR_BASE_INDEX(ci);
+            int* ci_t             = &atom->cl_t[ci_sca_base];
+            MD_SIMD_INT tbase0    = simd_int_broadcast(ci_t[0] * atom->ntypes);
+            MD_SIMD_INT tbase1    = simd_int_broadcast(ci_t[1] * atom->ntypes);
+            MD_SIMD_INT tbase2    = simd_int_broadcast(ci_t[2] * atom->ntypes);
+            MD_SIMD_INT tbase3    = simd_int_broadcast(ci_t[3] * atom->ntypes);
 #endif
 
             for (int k = 0; k < numneighs_masked; k++) {
-                int cj               = neighs[k];
-                int cj_vec_base      = CJ_VECTOR_BASE_INDEX(cj);
-                MD_FLOAT* cj_x       = &atom->cl_x[cj_vec_base];
+                int cj          = neighs[k];
+                int cj_vec_base = CJ_VECTOR_BASE_INDEX(cj);
+                MD_FLOAT* cj_x  = &atom->cl_x[cj_vec_base];
 
 #ifndef ONE_ATOM_TYPE
                 int cj_sca_base = CJ_SCALAR_BASE_INDEX(cj);
-                int *cj_t       = &atom->cl_t[cj_sca_base];
+                int* cj_t       = &atom->cl_t[cj_sca_base];
 #endif
 
-                MD_SIMD_FLOAT xj_tmp = simd_load(&cj_x[CL_X_OFFSET]);
-                MD_SIMD_FLOAT yj_tmp = simd_load(&cj_x[CL_Y_OFFSET]);
-                MD_SIMD_FLOAT zj_tmp = simd_load(&cj_x[CL_Z_OFFSET]);
-                MD_SIMD_FLOAT delx0  = xi0_tmp - xj_tmp;
-                MD_SIMD_FLOAT dely0  = yi0_tmp - yj_tmp;
-                MD_SIMD_FLOAT delz0  = zi0_tmp - zj_tmp;
-                MD_SIMD_FLOAT delx1  = xi1_tmp - xj_tmp;
-                MD_SIMD_FLOAT dely1  = yi1_tmp - yj_tmp;
-                MD_SIMD_FLOAT delz1  = zi1_tmp - zj_tmp;
-                MD_SIMD_FLOAT delx2  = xi2_tmp - xj_tmp;
-                MD_SIMD_FLOAT dely2  = yi2_tmp - yj_tmp;
-                MD_SIMD_FLOAT delz2  = zi2_tmp - zj_tmp;
-                MD_SIMD_FLOAT delx3  = xi3_tmp - xj_tmp;
-                MD_SIMD_FLOAT dely3  = yi3_tmp - yj_tmp;
-                MD_SIMD_FLOAT delz3  = zi3_tmp - zj_tmp;
+                MD_SIMD_FLOAT xj_tmp    = simd_load(&cj_x[CL_X_OFFSET]);
+                MD_SIMD_FLOAT yj_tmp    = simd_load(&cj_x[CL_Y_OFFSET]);
+                MD_SIMD_FLOAT zj_tmp    = simd_load(&cj_x[CL_Z_OFFSET]);
+                MD_SIMD_FLOAT delx0     = xi0_tmp - xj_tmp;
+                MD_SIMD_FLOAT dely0     = yi0_tmp - yj_tmp;
+                MD_SIMD_FLOAT delz0     = zi0_tmp - zj_tmp;
+                MD_SIMD_FLOAT delx1     = xi1_tmp - xj_tmp;
+                MD_SIMD_FLOAT dely1     = yi1_tmp - yj_tmp;
+                MD_SIMD_FLOAT delz1     = zi1_tmp - zj_tmp;
+                MD_SIMD_FLOAT delx2     = xi2_tmp - xj_tmp;
+                MD_SIMD_FLOAT dely2     = yi2_tmp - yj_tmp;
+                MD_SIMD_FLOAT delz2     = zi2_tmp - zj_tmp;
+                MD_SIMD_FLOAT delx3     = xi3_tmp - xj_tmp;
+                MD_SIMD_FLOAT dely3     = yi3_tmp - yj_tmp;
+                MD_SIMD_FLOAT delz3     = zi3_tmp - zj_tmp;
 
 #if CLUSTER_M == CLUSTER_N
                 unsigned int cond0      = (unsigned int)(cj == ci_cj0);
@@ -1254,8 +1318,8 @@ double computeForceLJ4xnFullNeigh(
                     atom->masks_4xn_fn[cond0 * 4 + 3]);
 #else
 #if CLUSTER_M < CLUSTER_N
-                unsigned int cond0 = (unsigned int)((cj << 1) + 0 == ci);
-                unsigned int cond1 = (unsigned int)((cj << 1) + 1 == ci);
+                unsigned int cond0      = (unsigned int)((cj << 1) + 0 == ci);
+                unsigned int cond1      = (unsigned int)((cj << 1) + 1 == ci);
 #else
                 unsigned int cond0 = (unsigned int)(cj == ci_cj0);
                 unsigned int cond1 = (unsigned int)(cj == ci_cj1);
@@ -1290,15 +1354,31 @@ double computeForceLJ4xnFullNeigh(
                 MD_SIMD_INT tvec2  = simd_int_add(tbase2, tj_tmp);
                 MD_SIMD_INT tvec3  = simd_int_add(tbase3, tj_tmp);
 
-                MD_SIMD_FLOAT cutforcesq0 = simd_gather(tvec0, atom->cutforcesq, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT cutforcesq1 = simd_gather(tvec1, atom->cutforcesq, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT cutforcesq2 = simd_gather(tvec2, atom->cutforcesq, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT cutforcesq3 = simd_gather(tvec3, atom->cutforcesq, sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT cutforcesq0 = simd_gather(tvec0,
+                    atom->cutforcesq,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT cutforcesq1 = simd_gather(tvec1,
+                    atom->cutforcesq,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT cutforcesq2 = simd_gather(tvec2,
+                    atom->cutforcesq,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT cutforcesq3 = simd_gather(tvec3,
+                    atom->cutforcesq,
+                    sizeof(MD_FLOAT));
 
-                MD_SIMD_FLOAT sigma6_0 = simd_gather(tvec0, atom->sigma6, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT sigma6_1 = simd_gather(tvec1, atom->sigma6, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT sigma6_2 = simd_gather(tvec2, atom->sigma6, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT sigma6_3 = simd_gather(tvec3, atom->sigma6, sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT sigma6_0 = simd_gather(tvec0,
+                    atom->sigma6,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT sigma6_1 = simd_gather(tvec1,
+                    atom->sigma6,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT sigma6_2 = simd_gather(tvec2,
+                    atom->sigma6,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT sigma6_3 = simd_gather(tvec3,
+                    atom->sigma6,
+                    sizeof(MD_FLOAT));
 
                 MD_SIMD_FLOAT eps0 = simd_gather(tvec0, atom->epsilon, sizeof(MD_FLOAT));
                 MD_SIMD_FLOAT eps1 = simd_gather(tvec1, atom->epsilon, sizeof(MD_FLOAT));
@@ -1315,10 +1395,10 @@ double computeForceLJ4xnFullNeigh(
                 MD_SIMD_FLOAT sigma6_2 = sigma6_vec;
                 MD_SIMD_FLOAT sigma6_3 = sigma6_vec;
 
-                MD_SIMD_FLOAT eps0 = eps_vec;
-                MD_SIMD_FLOAT eps1 = eps_vec;
-                MD_SIMD_FLOAT eps2 = eps_vec;
-                MD_SIMD_FLOAT eps3 = eps_vec;
+                MD_SIMD_FLOAT eps0        = eps_vec;
+                MD_SIMD_FLOAT eps1        = eps_vec;
+                MD_SIMD_FLOAT eps2        = eps_vec;
+                MD_SIMD_FLOAT eps3        = eps_vec;
 #endif
 
                 MD_SIMD_MASK cutoff_mask0 = simd_mask_and(excl_mask0,
@@ -1360,13 +1440,13 @@ double computeForceLJ4xnFullNeigh(
             }
 
             for (int k = numneighs_masked; k < numneighs; k++) {
-                int cj               = neighs[k];
-                int cj_vec_base      = CJ_VECTOR_BASE_INDEX(cj);
-                MD_FLOAT* cj_x       = &atom->cl_x[cj_vec_base];
+                int cj          = neighs[k];
+                int cj_vec_base = CJ_VECTOR_BASE_INDEX(cj);
+                MD_FLOAT* cj_x  = &atom->cl_x[cj_vec_base];
 
 #ifndef ONE_ATOM_TYPE
                 int cj_sca_base = CJ_SCALAR_BASE_INDEX(cj);
-                int *cj_t       = &atom->cl_t[cj_sca_base];
+                int* cj_t       = &atom->cl_t[cj_sca_base];
 #endif
 
                 MD_SIMD_FLOAT xj_tmp = simd_load(&cj_x[CL_X_OFFSET]);
@@ -1405,15 +1485,31 @@ double computeForceLJ4xnFullNeigh(
                 MD_SIMD_INT tvec2  = simd_int_add(tbase2, tj_tmp);
                 MD_SIMD_INT tvec3  = simd_int_add(tbase3, tj_tmp);
 
-                MD_SIMD_FLOAT cutforcesq0 = simd_gather(tvec0, atom->cutforcesq, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT cutforcesq1 = simd_gather(tvec1, atom->cutforcesq, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT cutforcesq2 = simd_gather(tvec2, atom->cutforcesq, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT cutforcesq3 = simd_gather(tvec3, atom->cutforcesq, sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT cutforcesq0 = simd_gather(tvec0,
+                    atom->cutforcesq,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT cutforcesq1 = simd_gather(tvec1,
+                    atom->cutforcesq,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT cutforcesq2 = simd_gather(tvec2,
+                    atom->cutforcesq,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT cutforcesq3 = simd_gather(tvec3,
+                    atom->cutforcesq,
+                    sizeof(MD_FLOAT));
 
-                MD_SIMD_FLOAT sigma6_0 = simd_gather(tvec0, atom->sigma6, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT sigma6_1 = simd_gather(tvec1, atom->sigma6, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT sigma6_2 = simd_gather(tvec2, atom->sigma6, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT sigma6_3 = simd_gather(tvec3, atom->sigma6, sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT sigma6_0 = simd_gather(tvec0,
+                    atom->sigma6,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT sigma6_1 = simd_gather(tvec1,
+                    atom->sigma6,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT sigma6_2 = simd_gather(tvec2,
+                    atom->sigma6,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT sigma6_3 = simd_gather(tvec3,
+                    atom->sigma6,
+                    sizeof(MD_FLOAT));
 
                 MD_SIMD_FLOAT eps0 = simd_gather(tvec0, atom->epsilon, sizeof(MD_FLOAT));
                 MD_SIMD_FLOAT eps1 = simd_gather(tvec1, atom->epsilon, sizeof(MD_FLOAT));

--- a/src/clusterpair/force_lj.c
+++ b/src/clusterpair/force_lj.c
@@ -345,13 +345,9 @@ double computeForceLJ2xnnHalfNeigh(
                 fiy2 += ty2;
                 fiz2 += tz2;
 
-#ifdef HALF_NEIGHBOR_LISTS_CHECK_CJ
                 if (cj < CJ1_FROM_CI(atom->Nlocal)) {
                     simd_h_decr3(cj_f, tx0 + tx2, ty0 + ty2, tz0 + tz2);
                 }
-#else
-                simd_h_decr3(cj_f, tx0 + tx2, ty0 + ty2, tz0 + tz2);
-#endif
             }
 
             for (int k = numneighs_masked; k < numneighs; k++) {
@@ -402,13 +398,9 @@ double computeForceLJ2xnnHalfNeigh(
                 fiy2 += ty2;
                 fiz2 += tz2;
 
-#ifdef HALF_NEIGHBOR_LISTS_CHECK_CJ
                 if (cj < CJ1_FROM_CI(atom->Nlocal)) {
                     simd_h_decr3(cj_f, tx0 + tx2, ty0 + ty2, tz0 + tz2);
                 }
-#else
-                simd_h_decr3(cj_f, tx0 + tx2, ty0 + ty2, tz0 + tz2);
-#endif
             }
 
             simd_h_dual_incr_reduced_sum(&ci_f[CL_X_OFFSET], fix0, fix2);
@@ -795,7 +787,6 @@ double computeForceLJ4xnHalfNeigh(
                 fiy3 = simd_add(fiy3, ty3);
                 fiz3 = simd_add(fiz3, tz3);
 
-#ifdef HALF_NEIGHBOR_LISTS_CHECK_CJ
                 if (cj < CJ1_FROM_CI(atom->Nlocal)) {
                     simd_store(&cj_f[CL_X_OFFSET],
                         simd_load(&cj_f[CL_X_OFFSET]) - (tx0 + tx1 + tx2 + tx3));
@@ -804,14 +795,6 @@ double computeForceLJ4xnHalfNeigh(
                     simd_store(&cj_f[CL_Z_OFFSET],
                         simd_load(&cj_f[CL_Z_OFFSET]) - (tz0 + tz1 + tz2 + tz3));
                 }
-#else
-                simd_store(&cj_f[CL_X_OFFSET],
-                    simd_load(&cj_f[CL_X_OFFSET]) - (tx0 + tx1 + tx2 + tx3));
-                simd_store(&cj_f[CL_Y_OFFSET],
-                    simd_load(&cj_f[CL_Y_OFFSET]) - (ty0 + ty1 + ty2 + ty3));
-                simd_store(&cj_f[CL_Z_OFFSET],
-                    simd_load(&cj_f[CL_Z_OFFSET]) - (tz0 + tz1 + tz2 + tz3));
-#endif
             }
 
             for (int k = numneighs_masked; k < numneighs; k++) {
@@ -898,7 +881,6 @@ double computeForceLJ4xnHalfNeigh(
                 fiy3 = simd_add(fiy3, ty3);
                 fiz3 = simd_add(fiz3, tz3);
 
-#ifdef HALF_NEIGHBOR_LISTS_CHECK_CJ
                 if (cj < CJ1_FROM_CI(atom->Nlocal)) {
                     simd_store(&cj_f[CL_X_OFFSET],
                         simd_load(&cj_f[CL_X_OFFSET]) - (tx0 + tx1 + tx2 + tx3));
@@ -907,14 +889,6 @@ double computeForceLJ4xnHalfNeigh(
                     simd_store(&cj_f[CL_Z_OFFSET],
                         simd_load(&cj_f[CL_Z_OFFSET]) - (tz0 + tz1 + tz2 + tz3));
                 }
-#else
-                simd_store(&cj_f[CL_X_OFFSET],
-                    simd_load(&cj_f[CL_X_OFFSET]) - (tx0 + tx1 + tx2 + tx3));
-                simd_store(&cj_f[CL_Y_OFFSET],
-                    simd_load(&cj_f[CL_Y_OFFSET]) - (ty0 + ty1 + ty2 + ty3));
-                simd_store(&cj_f[CL_Z_OFFSET],
-                    simd_load(&cj_f[CL_Z_OFFSET]) - (tz0 + tz1 + tz2 + tz3));
-#endif
             }
 
             simd_incr_reduced_sum(&ci_f[CL_X_OFFSET], fix0, fix1, fix2, fix3);

--- a/src/clusterpair/force_lj.c
+++ b/src/clusterpair/force_lj.c
@@ -99,7 +99,9 @@ double computeForceLJRef(Parameter* param, Atom* atom, Neighbor* neighbor, Stats
 #endif
 
                 for (int cii = 0; cii < CLUSTER_M; cii++) {
-                    int type_i    = ci_t[cii];
+#ifndef ONE_ATOM_TYPE
+                    int type_i = ci_t[cii];
+#endif
                     MD_FLOAT xtmp = ci_x[CL_X_OFFSET + cii];
                     MD_FLOAT ytmp = ci_x[CL_Y_OFFSET + cii];
                     MD_FLOAT ztmp = ci_x[CL_Z_OFFSET + cii];

--- a/src/clusterpair/force_lj.c
+++ b/src/clusterpair/force_lj.c
@@ -23,7 +23,7 @@ static inline void gmx_load_simd_2xnn_interactions(
     MD_SIMD_MASK *interact0, MD_SIMD_MASK *interact2) {
 
     //SimdInt32 mask_pr_S(excl);
-    MD_SIMD_INT32 mask_pr_S = simd_int32_broadcast(excl);
+    MD_SIMD_INT32 mask_pr_S = simd_i32_broadcast(excl);
     *interact0 = cvtIB2B(simd_test_bits(mask_pr_S & filter0));
     *interact2 = cvtIB2B(simd_test_bits(mask_pr_S & filter2));
 }
@@ -35,7 +35,7 @@ MD_SIMD_BITMASK filter3, MD_SIMD_MASK *interact0, MD_SIMD_MASK *interact1, MD_SI
 *interact2, MD_SIMD_MASK *interact3) {
 
     //SimdInt32 mask_pr_S(excl);
-    MD_SIMD_INT32 mask_pr_S = simd_int32_broadcast(excl);
+    MD_SIMD_INT32 mask_pr_S = simd_i32_broadcast(excl);
     *interact0 = cvtIB2B(simd_test_bits(mask_pr_S & filter0));
     *interact1 = cvtIB2B(simd_test_bits(mask_pr_S & filter1));
     *interact2 = cvtIB2B(simd_test_bits(mask_pr_S & filter2));
@@ -197,13 +197,13 @@ double computeForceLJ2xnnHalfNeigh(
     MD_FLOAT cutforcesq          = param->cutforce * param->cutforce;
     MD_FLOAT sigma6              = param->sigma6;
     MD_FLOAT epsilon             = param->epsilon;
-    MD_SIMD_FLOAT c48_vec        = simd_broadcast(48.0);
-    MD_SIMD_FLOAT c05_vec        = simd_broadcast(0.5);
+    MD_SIMD_FLOAT c48_vec        = simd_real_broadcast(48.0);
+    MD_SIMD_FLOAT c05_vec        = simd_real_broadcast(0.5);
 
 #ifdef ONE_ATOM_TYPE
-    MD_SIMD_FLOAT cutforcesq_vec = simd_broadcast(cutforcesq);
-    MD_SIMD_FLOAT sigma6_vec     = simd_broadcast(sigma6);
-    MD_SIMD_FLOAT eps_vec        = simd_broadcast(epsilon);
+    MD_SIMD_FLOAT cutforcesq_vec = simd_real_broadcast(cutforcesq);
+    MD_SIMD_FLOAT sigma6_vec     = simd_real_broadcast(sigma6);
+    MD_SIMD_FLOAT eps_vec        = simd_real_broadcast(epsilon);
 #endif
 
     for (int ci = 0; ci < atom->Nclusters_local; ci++) {
@@ -223,14 +223,14 @@ double computeForceLJ2xnnHalfNeigh(
         LIKWID_MARKER_START("force");
 
         /*
-        MD_SIMD_BITMASK filter0 = simd_load_bitmask((const int *)
+        MD_SIMD_BITMASK filter0 = simd_real_load_bitmask((const int *)
         &atom->exclusion_filter[0 * (VECTOR_WIDTH / UNROLL_J)]); MD_SIMD_BITMASK filter2 =
-        simd_load_bitmask((const int *) &atom->exclusion_filter[2 * (VECTOR_WIDTH /
+        simd_real_load_bitmask((const int *) &atom->exclusion_filter[2 * (VECTOR_WIDTH /
         UNROLL_J)]);
 
-        MD_SIMD_FLOAT diagonal_jmi_S = simd_load(atom->diagonal_2xnn_j_minus_i);
-        MD_SIMD_FLOAT zero_S = simd_broadcast(0.0);
-        MD_SIMD_FLOAT one_S = simd_broadcast(1.0);
+        MD_SIMD_FLOAT diagonal_jmi_S = simd_real_load(atom->diagonal_2xnn_j_minus_i);
+        MD_SIMD_FLOAT zero_S = simd_real_broadcast(0.0);
+        MD_SIMD_FLOAT one_S = simd_real_broadcast(1.0);
 
         #if CLUSTER_M <= CLUSTER_N
         MD_SIMD_MASK diagonal_mask0, diagonal_mask2;
@@ -266,24 +266,24 @@ double computeForceLJ2xnnHalfNeigh(
             int numneighs        = neighbor->numneigh[ci];
             int numneighs_masked = neighbor->numneigh_masked[ci];
 
-            MD_SIMD_FLOAT xi0_tmp = simd_load_h_dual(&ci_x[CL_X_OFFSET + 0]);
-            MD_SIMD_FLOAT xi2_tmp = simd_load_h_dual(&ci_x[CL_X_OFFSET + 2]);
-            MD_SIMD_FLOAT yi0_tmp = simd_load_h_dual(&ci_x[CL_Y_OFFSET + 0]);
-            MD_SIMD_FLOAT yi2_tmp = simd_load_h_dual(&ci_x[CL_Y_OFFSET + 2]);
-            MD_SIMD_FLOAT zi0_tmp = simd_load_h_dual(&ci_x[CL_Z_OFFSET + 0]);
-            MD_SIMD_FLOAT zi2_tmp = simd_load_h_dual(&ci_x[CL_Z_OFFSET + 2]);
-            MD_SIMD_FLOAT fix0    = simd_zero();
-            MD_SIMD_FLOAT fiy0    = simd_zero();
-            MD_SIMD_FLOAT fiz0    = simd_zero();
-            MD_SIMD_FLOAT fix2    = simd_zero();
-            MD_SIMD_FLOAT fiy2    = simd_zero();
-            MD_SIMD_FLOAT fiz2    = simd_zero();
+            MD_SIMD_FLOAT xi0_tmp = simd_real_load_h_dual(&ci_x[CL_X_OFFSET + 0]);
+            MD_SIMD_FLOAT xi2_tmp = simd_real_load_h_dual(&ci_x[CL_X_OFFSET + 2]);
+            MD_SIMD_FLOAT yi0_tmp = simd_real_load_h_dual(&ci_x[CL_Y_OFFSET + 0]);
+            MD_SIMD_FLOAT yi2_tmp = simd_real_load_h_dual(&ci_x[CL_Y_OFFSET + 2]);
+            MD_SIMD_FLOAT zi0_tmp = simd_real_load_h_dual(&ci_x[CL_Z_OFFSET + 0]);
+            MD_SIMD_FLOAT zi2_tmp = simd_real_load_h_dual(&ci_x[CL_Z_OFFSET + 2]);
+            MD_SIMD_FLOAT fix0    = simd_real_zero();
+            MD_SIMD_FLOAT fiy0    = simd_real_zero();
+            MD_SIMD_FLOAT fiz0    = simd_real_zero();
+            MD_SIMD_FLOAT fix2    = simd_real_zero();
+            MD_SIMD_FLOAT fiy2    = simd_real_zero();
+            MD_SIMD_FLOAT fiz2    = simd_real_zero();
 
 #ifndef ONE_ATOM_TYPE
             int ci_sca_base       = CI_SCALAR_BASE_INDEX(ci);
             int* ci_t             = &atom->cl_t[ci_sca_base];
-            MD_SIMD_INT tbase0    = simd_int_load_h_dual_scaled(&ci_t[0], atom->ntypes);
-            MD_SIMD_INT tbase2    = simd_int_load_h_dual_scaled(&ci_t[2], atom->ntypes);
+            MD_SIMD_INT tbase0    = simd_i32_load_h_dual_scaled(&ci_t[0], atom->ntypes);
+            MD_SIMD_INT tbase2    = simd_i32_load_h_dual_scaled(&ci_t[2], atom->ntypes);
 #endif
 
             for (int k = 0; k < numneighs_masked; k++) {
@@ -303,21 +303,21 @@ double computeForceLJ2xnnHalfNeigh(
                 int* cj_t       = &atom->cl_t[cj_sca_base];
 #endif
 
-                MD_SIMD_FLOAT xj_tmp    = simd_load_h_duplicate(&cj_x[CL_X_OFFSET]);
-                MD_SIMD_FLOAT yj_tmp    = simd_load_h_duplicate(&cj_x[CL_Y_OFFSET]);
-                MD_SIMD_FLOAT zj_tmp    = simd_load_h_duplicate(&cj_x[CL_Z_OFFSET]);
-                MD_SIMD_FLOAT delx0     = xi0_tmp - xj_tmp;
-                MD_SIMD_FLOAT dely0     = yi0_tmp - yj_tmp;
-                MD_SIMD_FLOAT delz0     = zi0_tmp - zj_tmp;
-                MD_SIMD_FLOAT delx2     = xi2_tmp - xj_tmp;
-                MD_SIMD_FLOAT dely2     = yi2_tmp - yj_tmp;
-                MD_SIMD_FLOAT delz2     = zi2_tmp - zj_tmp;
-                MD_SIMD_FLOAT rsq0      = simd_fma(delx0,
+                MD_SIMD_FLOAT xj_tmp    = simd_real_load_h_duplicate(&cj_x[CL_X_OFFSET]);
+                MD_SIMD_FLOAT yj_tmp    = simd_real_load_h_duplicate(&cj_x[CL_Y_OFFSET]);
+                MD_SIMD_FLOAT zj_tmp    = simd_real_load_h_duplicate(&cj_x[CL_Z_OFFSET]);
+                MD_SIMD_FLOAT delx0     = simd_real_sub(xi0_tmp, xj_tmp);
+                MD_SIMD_FLOAT dely0     = simd_real_sub(yi0_tmp, yj_tmp);
+                MD_SIMD_FLOAT delz0     = simd_real_sub(zi0_tmp, zj_tmp);
+                MD_SIMD_FLOAT delx2     = simd_real_sub(xi2_tmp, xj_tmp);
+                MD_SIMD_FLOAT dely2     = simd_real_sub(yi2_tmp, yj_tmp);
+                MD_SIMD_FLOAT delz2     = simd_real_sub(zi2_tmp, zj_tmp);
+                MD_SIMD_FLOAT rsq0      = simd_real_fma(delx0,
                     delx0,
-                    simd_fma(dely0, dely0, delz0 * delz0));
-                MD_SIMD_FLOAT rsq2      = simd_fma(delx2,
+                    simd_real_fma(dely0, dely0, simd_real_mul(delz0, delz0)));
+                MD_SIMD_FLOAT rsq2      = simd_real_fma(delx2,
                     delx2,
-                    simd_fma(dely2, dely2, delz2 * delz2));
+                    simd_real_fma(dely2, dely2, simd_real_mul(delz2, delz2)));
 
 #if CLUSTER_M == CLUSTER_N
                 unsigned int cond0      = (unsigned int)(cj == ci_cj0);
@@ -340,24 +340,28 @@ double computeForceLJ2xnnHalfNeigh(
 #endif
 
 #ifndef ONE_ATOM_TYPE
-                MD_SIMD_INT tj_tmp = simd_int_load_h_duplicate(cj_t);
-                MD_SIMD_INT tvec0  = simd_int_add(tbase0, tj_tmp);
-                MD_SIMD_INT tvec2  = simd_int_add(tbase2, tj_tmp);
+                MD_SIMD_INT tj_tmp = simd_i32_load_h_duplicate(cj_t);
+                MD_SIMD_INT tvec0  = simd_i32_add(tbase0, tj_tmp);
+                MD_SIMD_INT tvec2  = simd_i32_add(tbase2, tj_tmp);
 
-                MD_SIMD_FLOAT cutforcesq0 = simd_gather(tvec0,
+                MD_SIMD_FLOAT cutforcesq0 = simd_real_gather(tvec0,
                     atom->cutforcesq,
                     sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT cutforcesq2 = simd_gather(tvec2,
+                MD_SIMD_FLOAT cutforcesq2 = simd_real_gather(tvec2,
                     atom->cutforcesq,
                     sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT sigma6_0    = simd_gather(tvec0,
+                MD_SIMD_FLOAT sigma6_0    = simd_real_gather(tvec0,
                     atom->sigma6,
                     sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT sigma6_2    = simd_gather(tvec2,
+                MD_SIMD_FLOAT sigma6_2    = simd_real_gather(tvec2,
                     atom->sigma6,
                     sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT eps0 = simd_gather(tvec0, atom->epsilon, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT eps2 = simd_gather(tvec2, atom->epsilon, sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT eps0        = simd_real_gather(tvec0,
+                    atom->epsilon,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT eps2        = simd_real_gather(tvec2,
+                    atom->epsilon,
+                    sizeof(MD_FLOAT));
 #else
                 MD_SIMD_FLOAT cutforcesq0 = cutforcesq_vec;
                 MD_SIMD_FLOAT cutforcesq2 = cutforcesq_vec;
@@ -389,29 +393,48 @@ double computeForceLJ2xnnHalfNeigh(
                 #endif
                 */
 
-                MD_SIMD_FLOAT sr2_0  = simd_reciprocal(rsq0);
-                MD_SIMD_FLOAT sr2_2  = simd_reciprocal(rsq2);
-                MD_SIMD_FLOAT sr6_0  = sr2_0 * sr2_0 * sr2_0 * sigma6_0;
-                MD_SIMD_FLOAT sr6_2  = sr2_2 * sr2_2 * sr2_2 * sigma6_2;
-                MD_SIMD_FLOAT force0 = c48_vec * sr6_0 * (sr6_0 - c05_vec) * sr2_0 * eps0;
-                MD_SIMD_FLOAT force2 = c48_vec * sr6_2 * (sr6_2 - c05_vec) * sr2_2 * eps2;
+                MD_SIMD_FLOAT sr2_0 = simd_real_reciprocal(rsq0);
+                MD_SIMD_FLOAT sr2_2 = simd_real_reciprocal(rsq2);
 
-                MD_SIMD_FLOAT tx0 = select_by_mask(delx0 * force0, cutoff_mask0);
-                MD_SIMD_FLOAT ty0 = select_by_mask(dely0 * force0, cutoff_mask0);
-                MD_SIMD_FLOAT tz0 = select_by_mask(delz0 * force0, cutoff_mask0);
-                MD_SIMD_FLOAT tx2 = select_by_mask(delx2 * force2, cutoff_mask2);
-                MD_SIMD_FLOAT ty2 = select_by_mask(dely2 * force2, cutoff_mask2);
-                MD_SIMD_FLOAT tz2 = select_by_mask(delz2 * force2, cutoff_mask2);
+                MD_SIMD_FLOAT sr6_0 = simd_real_mul(sr2_0,
+                    simd_real_mul(sr2_0, simd_real_mul(sr2_0, sigma6_0)));
+                MD_SIMD_FLOAT sr6_2 = simd_real_mul(sr2_2,
+                    simd_real_mul(sr2_2, simd_real_mul(sr2_2, sigma6_2)));
 
-                fix0 += tx0;
-                fiy0 += ty0;
-                fiz0 += tz0;
-                fix2 += tx2;
-                fiy2 += ty2;
-                fiz2 += tz2;
+                MD_SIMD_FLOAT force0 = simd_real_mul(c48_vec,
+                    simd_real_mul(sr6_0,
+                        simd_real_mul(simd_real_sub(sr6_0, c05_vec),
+                            simd_real_mul(sr2_0, eps0))));
+                MD_SIMD_FLOAT force2 = simd_real_mul(c48_vec,
+                    simd_real_mul(sr6_2,
+                        simd_real_mul(simd_real_sub(sr6_2, c05_vec),
+                            simd_real_mul(sr2_2, eps2))));
+
+                MD_SIMD_FLOAT tx0 = simd_real_select_by_mask(simd_real_mul(delx0, force0),
+                    cutoff_mask0);
+                MD_SIMD_FLOAT ty0 = simd_real_select_by_mask(simd_real_mul(dely0, force0),
+                    cutoff_mask0);
+                MD_SIMD_FLOAT tz0 = simd_real_select_by_mask(simd_real_mul(delz0, force0),
+                    cutoff_mask0);
+                MD_SIMD_FLOAT tx2 = simd_real_select_by_mask(simd_real_mul(delx2, force2),
+                    cutoff_mask2);
+                MD_SIMD_FLOAT ty2 = simd_real_select_by_mask(simd_real_mul(dely2, force2),
+                    cutoff_mask2);
+                MD_SIMD_FLOAT tz2 = simd_real_select_by_mask(simd_real_mul(delz2, force2),
+                    cutoff_mask2);
+
+                fix0 = simd_real_add(fix0, tx0);
+                fiy0 = simd_real_add(fiy0, ty0);
+                fiz0 = simd_real_add(fiz0, tz0);
+                fix2 = simd_real_add(fix2, tx2);
+                fiy2 = simd_real_add(fiy2, ty2);
+                fiz2 = simd_real_add(fiz2, tz2);
 
                 if (cj < CJ1_FROM_CI(atom->Nlocal)) {
-                    simd_h_decr3(cj_f, tx0 + tx2, ty0 + ty2, tz0 + tz2);
+                    simd_real_h_decr3(cj_f,
+                        simd_real_add(tx0, tx2),
+                        simd_real_add(ty0, ty2),
+                        simd_real_add(tz0, tz2));
                 }
             }
 
@@ -426,41 +449,45 @@ double computeForceLJ2xnnHalfNeigh(
                 int* cj_t       = &atom->cl_t[cj_sca_base];
 #endif
 
-                MD_SIMD_FLOAT xj_tmp = simd_load_h_duplicate(&cj_x[CL_X_OFFSET]);
-                MD_SIMD_FLOAT yj_tmp = simd_load_h_duplicate(&cj_x[CL_Y_OFFSET]);
-                MD_SIMD_FLOAT zj_tmp = simd_load_h_duplicate(&cj_x[CL_Z_OFFSET]);
-                MD_SIMD_FLOAT delx0  = xi0_tmp - xj_tmp;
-                MD_SIMD_FLOAT dely0  = yi0_tmp - yj_tmp;
-                MD_SIMD_FLOAT delz0  = zi0_tmp - zj_tmp;
-                MD_SIMD_FLOAT delx2  = xi2_tmp - xj_tmp;
-                MD_SIMD_FLOAT dely2  = yi2_tmp - yj_tmp;
-                MD_SIMD_FLOAT delz2  = zi2_tmp - zj_tmp;
-                MD_SIMD_FLOAT rsq0   = simd_fma(delx0,
+                MD_SIMD_FLOAT xj_tmp = simd_real_load_h_duplicate(&cj_x[CL_X_OFFSET]);
+                MD_SIMD_FLOAT yj_tmp = simd_real_load_h_duplicate(&cj_x[CL_Y_OFFSET]);
+                MD_SIMD_FLOAT zj_tmp = simd_real_load_h_duplicate(&cj_x[CL_Z_OFFSET]);
+                MD_SIMD_FLOAT delx0  = simd_real_sub(xi0_tmp, xj_tmp);
+                MD_SIMD_FLOAT dely0  = simd_real_sub(yi0_tmp, yj_tmp);
+                MD_SIMD_FLOAT delz0  = simd_real_sub(zi0_tmp, zj_tmp);
+                MD_SIMD_FLOAT delx2  = simd_real_sub(xi2_tmp, xj_tmp);
+                MD_SIMD_FLOAT dely2  = simd_real_sub(yi2_tmp, yj_tmp);
+                MD_SIMD_FLOAT delz2  = simd_real_sub(zi2_tmp, zj_tmp);
+                MD_SIMD_FLOAT rsq0   = simd_real_fma(delx0,
                     delx0,
-                    simd_fma(dely0, dely0, delz0 * delz0));
-                MD_SIMD_FLOAT rsq2   = simd_fma(delx2,
+                    simd_real_fma(dely0, dely0, simd_real_mul(delz0, delz0)));
+                MD_SIMD_FLOAT rsq2   = simd_real_fma(delx2,
                     delx2,
-                    simd_fma(dely2, dely2, delz2 * delz2));
+                    simd_real_fma(dely2, dely2, simd_real_mul(delz2, delz2)));
 
 #ifndef ONE_ATOM_TYPE
-                MD_SIMD_INT tj_tmp   = simd_int_load_h_duplicate(cj_t);
-                MD_SIMD_INT tvec0    = simd_int_add(tbase0, tj_tmp);
-                MD_SIMD_INT tvec2    = simd_int_add(tbase2, tj_tmp);
+                MD_SIMD_INT tj_tmp   = simd_i32_load_h_duplicate(cj_t);
+                MD_SIMD_INT tvec0    = simd_i32_add(tbase0, tj_tmp);
+                MD_SIMD_INT tvec2    = simd_i32_add(tbase2, tj_tmp);
 
-                MD_SIMD_FLOAT cutforcesq0 = simd_gather(tvec0,
+                MD_SIMD_FLOAT cutforcesq0 = simd_real_gather(tvec0,
                     atom->cutforcesq,
                     sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT cutforcesq2 = simd_gather(tvec2,
+                MD_SIMD_FLOAT cutforcesq2 = simd_real_gather(tvec2,
                     atom->cutforcesq,
                     sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT sigma6_0    = simd_gather(tvec0,
+                MD_SIMD_FLOAT sigma6_0    = simd_real_gather(tvec0,
                     atom->sigma6,
                     sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT sigma6_2    = simd_gather(tvec2,
+                MD_SIMD_FLOAT sigma6_2    = simd_real_gather(tvec2,
                     atom->sigma6,
                     sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT eps0 = simd_gather(tvec0, atom->epsilon, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT eps2 = simd_gather(tvec2, atom->epsilon, sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT eps0        = simd_real_gather(tvec0,
+                    atom->epsilon,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT eps2        = simd_real_gather(tvec2,
+                    atom->epsilon,
+                    sizeof(MD_FLOAT));
 #else
                 MD_SIMD_FLOAT cutforcesq0 = cutforcesq_vec;
                 MD_SIMD_FLOAT cutforcesq2 = cutforcesq_vec;
@@ -473,35 +500,54 @@ double computeForceLJ2xnnHalfNeigh(
                 MD_SIMD_MASK cutoff_mask0 = simd_mask_cond_lt(rsq0, cutforcesq0);
                 MD_SIMD_MASK cutoff_mask2 = simd_mask_cond_lt(rsq2, cutforcesq2);
 
-                MD_SIMD_FLOAT sr2_0  = simd_reciprocal(rsq0);
-                MD_SIMD_FLOAT sr2_2  = simd_reciprocal(rsq2);
-                MD_SIMD_FLOAT sr6_0  = sr2_0 * sr2_0 * sr2_0 * sigma6_0;
-                MD_SIMD_FLOAT sr6_2  = sr2_2 * sr2_2 * sr2_2 * sigma6_2;
-                MD_SIMD_FLOAT force0 = c48_vec * sr6_0 * (sr6_0 - c05_vec) * sr2_0 * eps0;
-                MD_SIMD_FLOAT force2 = c48_vec * sr6_2 * (sr6_2 - c05_vec) * sr2_2 * eps2;
+                MD_SIMD_FLOAT sr2_0 = simd_real_reciprocal(rsq0);
+                MD_SIMD_FLOAT sr2_2 = simd_real_reciprocal(rsq2);
 
-                MD_SIMD_FLOAT tx0 = select_by_mask(delx0 * force0, cutoff_mask0);
-                MD_SIMD_FLOAT ty0 = select_by_mask(dely0 * force0, cutoff_mask0);
-                MD_SIMD_FLOAT tz0 = select_by_mask(delz0 * force0, cutoff_mask0);
-                MD_SIMD_FLOAT tx2 = select_by_mask(delx2 * force2, cutoff_mask2);
-                MD_SIMD_FLOAT ty2 = select_by_mask(dely2 * force2, cutoff_mask2);
-                MD_SIMD_FLOAT tz2 = select_by_mask(delz2 * force2, cutoff_mask2);
+                MD_SIMD_FLOAT sr6_0 = simd_real_mul(sr2_0,
+                    simd_real_mul(sr2_0, simd_real_mul(sr2_0, sigma6_0)));
+                MD_SIMD_FLOAT sr6_2 = simd_real_mul(sr2_2,
+                    simd_real_mul(sr2_2, simd_real_mul(sr2_2, sigma6_2)));
 
-                fix0 += tx0;
-                fiy0 += ty0;
-                fiz0 += tz0;
-                fix2 += tx2;
-                fiy2 += ty2;
-                fiz2 += tz2;
+                MD_SIMD_FLOAT force0 = simd_real_mul(c48_vec,
+                    simd_real_mul(sr6_0,
+                        simd_real_mul(simd_real_sub(sr6_0, c05_vec),
+                            simd_real_mul(sr2_0, eps0))));
+                MD_SIMD_FLOAT force2 = simd_real_mul(c48_vec,
+                    simd_real_mul(sr6_2,
+                        simd_real_mul(simd_real_sub(sr6_2, c05_vec),
+                            simd_real_mul(sr2_2, eps2))));
+
+                MD_SIMD_FLOAT tx0 = simd_real_select_by_mask(simd_real_mul(delx0, force0),
+                    cutoff_mask0);
+                MD_SIMD_FLOAT ty0 = simd_real_select_by_mask(simd_real_mul(dely0, force0),
+                    cutoff_mask0);
+                MD_SIMD_FLOAT tz0 = simd_real_select_by_mask(simd_real_mul(delz0, force0),
+                    cutoff_mask0);
+                MD_SIMD_FLOAT tx2 = simd_real_select_by_mask(simd_real_mul(delx2, force2),
+                    cutoff_mask2);
+                MD_SIMD_FLOAT ty2 = simd_real_select_by_mask(simd_real_mul(dely2, force2),
+                    cutoff_mask2);
+                MD_SIMD_FLOAT tz2 = simd_real_select_by_mask(simd_real_mul(delz2, force2),
+                    cutoff_mask2);
+
+                fix0 = simd_real_add(fix0, tx0);
+                fiy0 = simd_real_add(fiy0, ty0);
+                fiz0 = simd_real_add(fiz0, tz0);
+                fix2 = simd_real_add(fix2, tx2);
+                fiy2 = simd_real_add(fiy2, ty2);
+                fiz2 = simd_real_add(fiz2, tz2);
 
                 if (cj < CJ1_FROM_CI(atom->Nlocal)) {
-                    simd_h_decr3(cj_f, tx0 + tx2, ty0 + ty2, tz0 + tz2);
+                    simd_real_h_decr3(cj_f,
+                        simd_real_add(tx0, tx2),
+                        simd_real_add(ty0, ty2),
+                        simd_real_add(tz0, tz2));
                 }
             }
 
-            simd_h_dual_incr_reduced_sum(&ci_f[CL_X_OFFSET], fix0, fix2);
-            simd_h_dual_incr_reduced_sum(&ci_f[CL_Y_OFFSET], fiy0, fiy2);
-            simd_h_dual_incr_reduced_sum(&ci_f[CL_Z_OFFSET], fiz0, fiz2);
+            simd_real_h_dual_incr_reduced_sum(&ci_f[CL_X_OFFSET], fix0, fix2);
+            simd_real_h_dual_incr_reduced_sum(&ci_f[CL_Y_OFFSET], fiy0, fiy2);
+            simd_real_h_dual_incr_reduced_sum(&ci_f[CL_Z_OFFSET], fiz0, fiz2);
 
             addStat(stats->calculated_forces, 1);
             addStat(stats->num_neighs, numneighs);
@@ -526,13 +572,13 @@ double computeForceLJ2xnnFullNeigh(
     MD_FLOAT cutforcesq          = param->cutforce * param->cutforce;
     MD_FLOAT sigma6              = param->sigma6;
     MD_FLOAT epsilon             = param->epsilon;
-    MD_SIMD_FLOAT c48_vec        = simd_broadcast(48.0);
-    MD_SIMD_FLOAT c05_vec        = simd_broadcast(0.5);
+    MD_SIMD_FLOAT c48_vec        = simd_real_broadcast(48.0);
+    MD_SIMD_FLOAT c05_vec        = simd_real_broadcast(0.5);
 
 #ifdef ONE_ATOM_TYPE
-    MD_SIMD_FLOAT cutforcesq_vec = simd_broadcast(cutforcesq);
-    MD_SIMD_FLOAT sigma6_vec     = simd_broadcast(sigma6);
-    MD_SIMD_FLOAT eps_vec        = simd_broadcast(epsilon);
+    MD_SIMD_FLOAT cutforcesq_vec = simd_real_broadcast(cutforcesq);
+    MD_SIMD_FLOAT sigma6_vec     = simd_real_broadcast(sigma6);
+    MD_SIMD_FLOAT eps_vec        = simd_real_broadcast(epsilon);
 #endif
 
     for (int ci = 0; ci < atom->Nclusters_local; ci++) {
@@ -564,24 +610,24 @@ double computeForceLJ2xnnFullNeigh(
             int numneighs        = neighbor->numneigh[ci];
             int numneighs_masked = neighbor->numneigh_masked[ci];
 
-            MD_SIMD_FLOAT xi0_tmp = simd_load_h_dual(&ci_x[CL_X_OFFSET + 0]);
-            MD_SIMD_FLOAT xi2_tmp = simd_load_h_dual(&ci_x[CL_X_OFFSET + 2]);
-            MD_SIMD_FLOAT yi0_tmp = simd_load_h_dual(&ci_x[CL_Y_OFFSET + 0]);
-            MD_SIMD_FLOAT yi2_tmp = simd_load_h_dual(&ci_x[CL_Y_OFFSET + 2]);
-            MD_SIMD_FLOAT zi0_tmp = simd_load_h_dual(&ci_x[CL_Z_OFFSET + 0]);
-            MD_SIMD_FLOAT zi2_tmp = simd_load_h_dual(&ci_x[CL_Z_OFFSET + 2]);
-            MD_SIMD_FLOAT fix0    = simd_zero();
-            MD_SIMD_FLOAT fiy0    = simd_zero();
-            MD_SIMD_FLOAT fiz0    = simd_zero();
-            MD_SIMD_FLOAT fix2    = simd_zero();
-            MD_SIMD_FLOAT fiy2    = simd_zero();
-            MD_SIMD_FLOAT fiz2    = simd_zero();
+            MD_SIMD_FLOAT xi0_tmp = simd_real_load_h_dual(&ci_x[CL_X_OFFSET + 0]);
+            MD_SIMD_FLOAT xi2_tmp = simd_real_load_h_dual(&ci_x[CL_X_OFFSET + 2]);
+            MD_SIMD_FLOAT yi0_tmp = simd_real_load_h_dual(&ci_x[CL_Y_OFFSET + 0]);
+            MD_SIMD_FLOAT yi2_tmp = simd_real_load_h_dual(&ci_x[CL_Y_OFFSET + 2]);
+            MD_SIMD_FLOAT zi0_tmp = simd_real_load_h_dual(&ci_x[CL_Z_OFFSET + 0]);
+            MD_SIMD_FLOAT zi2_tmp = simd_real_load_h_dual(&ci_x[CL_Z_OFFSET + 2]);
+            MD_SIMD_FLOAT fix0    = simd_real_zero();
+            MD_SIMD_FLOAT fiy0    = simd_real_zero();
+            MD_SIMD_FLOAT fiz0    = simd_real_zero();
+            MD_SIMD_FLOAT fix2    = simd_real_zero();
+            MD_SIMD_FLOAT fiy2    = simd_real_zero();
+            MD_SIMD_FLOAT fiz2    = simd_real_zero();
 
 #ifndef ONE_ATOM_TYPE
             int ci_sca_base       = CI_SCALAR_BASE_INDEX(ci);
             int* ci_t             = &atom->cl_t[ci_sca_base];
-            MD_SIMD_INT tbase0    = simd_int_load_h_dual_scaled(&ci_t[0], atom->ntypes);
-            MD_SIMD_INT tbase2    = simd_int_load_h_dual_scaled(&ci_t[2], atom->ntypes);
+            MD_SIMD_INT tbase0    = simd_i32_load_h_dual_scaled(&ci_t[0], atom->ntypes);
+            MD_SIMD_INT tbase2    = simd_i32_load_h_dual_scaled(&ci_t[2], atom->ntypes);
 #endif
 
             for (int k = 0; k < numneighs_masked; k++) {
@@ -595,21 +641,21 @@ double computeForceLJ2xnnFullNeigh(
                 int* cj_t       = &atom->cl_t[cj_sca_base];
 #endif
 
-                MD_SIMD_FLOAT xj_tmp    = simd_load_h_duplicate(&cj_x[CL_X_OFFSET]);
-                MD_SIMD_FLOAT yj_tmp    = simd_load_h_duplicate(&cj_x[CL_Y_OFFSET]);
-                MD_SIMD_FLOAT zj_tmp    = simd_load_h_duplicate(&cj_x[CL_Z_OFFSET]);
-                MD_SIMD_FLOAT delx0     = xi0_tmp - xj_tmp;
-                MD_SIMD_FLOAT dely0     = yi0_tmp - yj_tmp;
-                MD_SIMD_FLOAT delz0     = zi0_tmp - zj_tmp;
-                MD_SIMD_FLOAT delx2     = xi2_tmp - xj_tmp;
-                MD_SIMD_FLOAT dely2     = yi2_tmp - yj_tmp;
-                MD_SIMD_FLOAT delz2     = zi2_tmp - zj_tmp;
-                MD_SIMD_FLOAT rsq0      = simd_fma(delx0,
+                MD_SIMD_FLOAT xj_tmp    = simd_real_load_h_duplicate(&cj_x[CL_X_OFFSET]);
+                MD_SIMD_FLOAT yj_tmp    = simd_real_load_h_duplicate(&cj_x[CL_Y_OFFSET]);
+                MD_SIMD_FLOAT zj_tmp    = simd_real_load_h_duplicate(&cj_x[CL_Z_OFFSET]);
+                MD_SIMD_FLOAT delx0     = simd_real_sub(xi0_tmp, xj_tmp);
+                MD_SIMD_FLOAT dely0     = simd_real_sub(yi0_tmp, yj_tmp);
+                MD_SIMD_FLOAT delz0     = simd_real_sub(zi0_tmp, zj_tmp);
+                MD_SIMD_FLOAT delx2     = simd_real_sub(xi2_tmp, xj_tmp);
+                MD_SIMD_FLOAT dely2     = simd_real_sub(yi2_tmp, yj_tmp);
+                MD_SIMD_FLOAT delz2     = simd_real_sub(zi2_tmp, zj_tmp);
+                MD_SIMD_FLOAT rsq0      = simd_real_fma(delx0,
                     delx0,
-                    simd_fma(dely0, dely0, delz0 * delz0));
-                MD_SIMD_FLOAT rsq2      = simd_fma(delx2,
+                    simd_real_fma(dely0, dely0, simd_real_mul(delz0, delz0)));
+                MD_SIMD_FLOAT rsq2      = simd_real_fma(delx2,
                     delx2,
-                    simd_fma(dely2, dely2, delz2 * delz2));
+                    simd_real_fma(dely2, dely2, simd_real_mul(delz2, delz2)));
 
 #if CLUSTER_M == CLUSTER_N
                 unsigned int cond0      = (unsigned int)(cj == ci_cj0);
@@ -632,24 +678,28 @@ double computeForceLJ2xnnFullNeigh(
 #endif
 
 #ifndef ONE_ATOM_TYPE
-                MD_SIMD_INT tj_tmp = simd_int_load_h_duplicate(cj_t);
-                MD_SIMD_INT tvec0  = simd_int_add(tbase0, tj_tmp);
-                MD_SIMD_INT tvec2  = simd_int_add(tbase2, tj_tmp);
+                MD_SIMD_INT tj_tmp = simd_i32_load_h_duplicate(cj_t);
+                MD_SIMD_INT tvec0  = simd_i32_add(tbase0, tj_tmp);
+                MD_SIMD_INT tvec2  = simd_i32_add(tbase2, tj_tmp);
 
-                MD_SIMD_FLOAT cutforcesq0 = simd_gather(tvec0,
+                MD_SIMD_FLOAT cutforcesq0 = simd_real_gather(tvec0,
                     atom->cutforcesq,
                     sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT cutforcesq2 = simd_gather(tvec2,
+                MD_SIMD_FLOAT cutforcesq2 = simd_real_gather(tvec2,
                     atom->cutforcesq,
                     sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT sigma6_0    = simd_gather(tvec0,
+                MD_SIMD_FLOAT sigma6_0    = simd_real_gather(tvec0,
                     atom->sigma6,
                     sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT sigma6_2    = simd_gather(tvec2,
+                MD_SIMD_FLOAT sigma6_2    = simd_real_gather(tvec2,
                     atom->sigma6,
                     sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT eps0 = simd_gather(tvec0, atom->epsilon, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT eps2 = simd_gather(tvec2, atom->epsilon, sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT eps0        = simd_real_gather(tvec0,
+                    atom->epsilon,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT eps2        = simd_real_gather(tvec2,
+                    atom->epsilon,
+                    sizeof(MD_FLOAT));
 #else
                 MD_SIMD_FLOAT cutforcesq0 = cutforcesq_vec;
                 MD_SIMD_FLOAT cutforcesq2 = cutforcesq_vec;
@@ -664,19 +714,41 @@ double computeForceLJ2xnnFullNeigh(
                 MD_SIMD_MASK cutoff_mask2 = simd_mask_and(excl_mask2,
                     simd_mask_cond_lt(rsq2, cutforcesq2));
 
-                MD_SIMD_FLOAT sr2_0  = simd_reciprocal(rsq0);
-                MD_SIMD_FLOAT sr2_2  = simd_reciprocal(rsq2);
-                MD_SIMD_FLOAT sr6_0  = sr2_0 * sr2_0 * sr2_0 * sigma6_0;
-                MD_SIMD_FLOAT sr6_2  = sr2_2 * sr2_2 * sr2_2 * sigma6_2;
-                MD_SIMD_FLOAT force0 = c48_vec * sr6_0 * (sr6_0 - c05_vec) * sr2_0 * eps0;
-                MD_SIMD_FLOAT force2 = c48_vec * sr6_2 * (sr6_2 - c05_vec) * sr2_2 * eps2;
+                MD_SIMD_FLOAT sr2_0 = simd_real_reciprocal(rsq0);
+                MD_SIMD_FLOAT sr2_2 = simd_real_reciprocal(rsq2);
 
-                fix0 = simd_masked_add(fix0, simd_mul(delx0, force0), cutoff_mask0);
-                fiy0 = simd_masked_add(fiy0, simd_mul(dely0, force0), cutoff_mask0);
-                fiz0 = simd_masked_add(fiz0, simd_mul(delz0, force0), cutoff_mask0);
-                fix2 = simd_masked_add(fix2, simd_mul(delx2, force2), cutoff_mask2);
-                fiy2 = simd_masked_add(fiy2, simd_mul(dely2, force2), cutoff_mask2);
-                fiz2 = simd_masked_add(fiz2, simd_mul(delz2, force2), cutoff_mask2);
+                MD_SIMD_FLOAT sr6_0 = simd_real_mul(sr2_0,
+                    simd_real_mul(sr2_0, simd_real_mul(sr2_0, sigma6_0)));
+                MD_SIMD_FLOAT sr6_2 = simd_real_mul(sr2_2,
+                    simd_real_mul(sr2_2, simd_real_mul(sr2_2, sigma6_2)));
+
+                MD_SIMD_FLOAT force0 = simd_real_mul(c48_vec,
+                    simd_real_mul(sr6_0,
+                        simd_real_mul(simd_real_sub(sr6_0, c05_vec),
+                            simd_real_mul(sr2_0, eps0))));
+                MD_SIMD_FLOAT force2 = simd_real_mul(c48_vec,
+                    simd_real_mul(sr6_2,
+                        simd_real_mul(simd_real_sub(sr6_2, c05_vec),
+                            simd_real_mul(sr2_2, eps2))));
+
+                fix0 = simd_real_masked_add(fix0,
+                    simd_real_mul(delx0, force0),
+                    cutoff_mask0);
+                fiy0 = simd_real_masked_add(fiy0,
+                    simd_real_mul(dely0, force0),
+                    cutoff_mask0);
+                fiz0 = simd_real_masked_add(fiz0,
+                    simd_real_mul(delz0, force0),
+                    cutoff_mask0);
+                fix2 = simd_real_masked_add(fix2,
+                    simd_real_mul(delx2, force2),
+                    cutoff_mask2);
+                fiy2 = simd_real_masked_add(fiy2,
+                    simd_real_mul(dely2, force2),
+                    cutoff_mask2);
+                fiz2 = simd_real_masked_add(fiz2,
+                    simd_real_mul(delz2, force2),
+                    cutoff_mask2);
             }
 
             for (int k = numneighs_masked; k < numneighs; k++) {
@@ -689,41 +761,45 @@ double computeForceLJ2xnnFullNeigh(
                 int* cj_t       = &atom->cl_t[cj_sca_base];
 #endif
 
-                MD_SIMD_FLOAT xj_tmp = simd_load_h_duplicate(&cj_x[CL_X_OFFSET]);
-                MD_SIMD_FLOAT yj_tmp = simd_load_h_duplicate(&cj_x[CL_Y_OFFSET]);
-                MD_SIMD_FLOAT zj_tmp = simd_load_h_duplicate(&cj_x[CL_Z_OFFSET]);
-                MD_SIMD_FLOAT delx0  = xi0_tmp - xj_tmp;
-                MD_SIMD_FLOAT dely0  = yi0_tmp - yj_tmp;
-                MD_SIMD_FLOAT delz0  = zi0_tmp - zj_tmp;
-                MD_SIMD_FLOAT delx2  = xi2_tmp - xj_tmp;
-                MD_SIMD_FLOAT dely2  = yi2_tmp - yj_tmp;
-                MD_SIMD_FLOAT delz2  = zi2_tmp - zj_tmp;
-                MD_SIMD_FLOAT rsq0   = simd_fma(delx0,
+                MD_SIMD_FLOAT xj_tmp = simd_real_load_h_duplicate(&cj_x[CL_X_OFFSET]);
+                MD_SIMD_FLOAT yj_tmp = simd_real_load_h_duplicate(&cj_x[CL_Y_OFFSET]);
+                MD_SIMD_FLOAT zj_tmp = simd_real_load_h_duplicate(&cj_x[CL_Z_OFFSET]);
+                MD_SIMD_FLOAT delx0  = simd_real_sub(xi0_tmp, xj_tmp);
+                MD_SIMD_FLOAT dely0  = simd_real_sub(yi0_tmp, yj_tmp);
+                MD_SIMD_FLOAT delz0  = simd_real_sub(zi0_tmp, zj_tmp);
+                MD_SIMD_FLOAT delx2  = simd_real_sub(xi2_tmp, xj_tmp);
+                MD_SIMD_FLOAT dely2  = simd_real_sub(yi2_tmp, yj_tmp);
+                MD_SIMD_FLOAT delz2  = simd_real_sub(zi2_tmp, zj_tmp);
+                MD_SIMD_FLOAT rsq0   = simd_real_fma(delx0,
                     delx0,
-                    simd_fma(dely0, dely0, delz0 * delz0));
-                MD_SIMD_FLOAT rsq2   = simd_fma(delx2,
+                    simd_real_fma(dely0, dely0, simd_real_mul(delz0, delz0)));
+                MD_SIMD_FLOAT rsq2   = simd_real_fma(delx2,
                     delx2,
-                    simd_fma(dely2, dely2, delz2 * delz2));
+                    simd_real_fma(dely2, dely2, simd_real_mul(delz2, delz2)));
 
 #ifndef ONE_ATOM_TYPE
-                MD_SIMD_INT tj_tmp   = simd_int_load_h_duplicate(cj_t);
-                MD_SIMD_INT tvec0    = simd_int_add(tbase0, tj_tmp);
-                MD_SIMD_INT tvec2    = simd_int_add(tbase2, tj_tmp);
+                MD_SIMD_INT tj_tmp   = simd_i32_load_h_duplicate(cj_t);
+                MD_SIMD_INT tvec0    = simd_i32_add(tbase0, tj_tmp);
+                MD_SIMD_INT tvec2    = simd_i32_add(tbase2, tj_tmp);
 
-                MD_SIMD_FLOAT cutforcesq0 = simd_gather(tvec0,
+                MD_SIMD_FLOAT cutforcesq0 = simd_real_gather(tvec0,
                     atom->cutforcesq,
                     sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT cutforcesq2 = simd_gather(tvec2,
+                MD_SIMD_FLOAT cutforcesq2 = simd_real_gather(tvec2,
                     atom->cutforcesq,
                     sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT sigma6_0    = simd_gather(tvec0,
+                MD_SIMD_FLOAT sigma6_0    = simd_real_gather(tvec0,
                     atom->sigma6,
                     sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT sigma6_2    = simd_gather(tvec2,
+                MD_SIMD_FLOAT sigma6_2    = simd_real_gather(tvec2,
                     atom->sigma6,
                     sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT eps0 = simd_gather(tvec0, atom->epsilon, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT eps2 = simd_gather(tvec2, atom->epsilon, sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT eps0        = simd_real_gather(tvec0,
+                    atom->epsilon,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT eps2        = simd_real_gather(tvec2,
+                    atom->epsilon,
+                    sizeof(MD_FLOAT));
 #else
                 MD_SIMD_FLOAT cutforcesq0 = cutforcesq_vec;
                 MD_SIMD_FLOAT cutforcesq2 = cutforcesq_vec;
@@ -736,24 +812,46 @@ double computeForceLJ2xnnFullNeigh(
                 MD_SIMD_MASK cutoff_mask0 = simd_mask_cond_lt(rsq0, cutforcesq0);
                 MD_SIMD_MASK cutoff_mask2 = simd_mask_cond_lt(rsq2, cutforcesq2);
 
-                MD_SIMD_FLOAT sr2_0  = simd_reciprocal(rsq0);
-                MD_SIMD_FLOAT sr2_2  = simd_reciprocal(rsq2);
-                MD_SIMD_FLOAT sr6_0  = sr2_0 * sr2_0 * sr2_0 * sigma6_0;
-                MD_SIMD_FLOAT sr6_2  = sr2_2 * sr2_2 * sr2_2 * sigma6_2;
-                MD_SIMD_FLOAT force0 = c48_vec * sr6_0 * (sr6_0 - c05_vec) * sr2_0 * eps0;
-                MD_SIMD_FLOAT force2 = c48_vec * sr6_2 * (sr6_2 - c05_vec) * sr2_2 * eps2;
+                MD_SIMD_FLOAT sr2_0 = simd_real_reciprocal(rsq0);
+                MD_SIMD_FLOAT sr2_2 = simd_real_reciprocal(rsq2);
 
-                fix0 = simd_masked_add(fix0, simd_mul(delx0, force0), cutoff_mask0);
-                fiy0 = simd_masked_add(fiy0, simd_mul(dely0, force0), cutoff_mask0);
-                fiz0 = simd_masked_add(fiz0, simd_mul(delz0, force0), cutoff_mask0);
-                fix2 = simd_masked_add(fix2, simd_mul(delx2, force2), cutoff_mask2);
-                fiy2 = simd_masked_add(fiy2, simd_mul(dely2, force2), cutoff_mask2);
-                fiz2 = simd_masked_add(fiz2, simd_mul(delz2, force2), cutoff_mask2);
+                MD_SIMD_FLOAT sr6_0 = simd_real_mul(sr2_0,
+                    simd_real_mul(sr2_0, simd_real_mul(sr2_0, sigma6_0)));
+                MD_SIMD_FLOAT sr6_2 = simd_real_mul(sr2_2,
+                    simd_real_mul(sr2_2, simd_real_mul(sr2_2, sigma6_2)));
+
+                MD_SIMD_FLOAT force0 = simd_real_mul(c48_vec,
+                    simd_real_mul(sr6_0,
+                        simd_real_mul(simd_real_sub(sr6_0, c05_vec),
+                            simd_real_mul(sr2_0, eps0))));
+                MD_SIMD_FLOAT force2 = simd_real_mul(c48_vec,
+                    simd_real_mul(sr6_2,
+                        simd_real_mul(simd_real_sub(sr6_2, c05_vec),
+                            simd_real_mul(sr2_2, eps2))));
+
+                fix0 = simd_real_masked_add(fix0,
+                    simd_real_mul(delx0, force0),
+                    cutoff_mask0);
+                fiy0 = simd_real_masked_add(fiy0,
+                    simd_real_mul(dely0, force0),
+                    cutoff_mask0);
+                fiz0 = simd_real_masked_add(fiz0,
+                    simd_real_mul(delz0, force0),
+                    cutoff_mask0);
+                fix2 = simd_real_masked_add(fix2,
+                    simd_real_mul(delx2, force2),
+                    cutoff_mask2);
+                fiy2 = simd_real_masked_add(fiy2,
+                    simd_real_mul(dely2, force2),
+                    cutoff_mask2);
+                fiz2 = simd_real_masked_add(fiz2,
+                    simd_real_mul(delz2, force2),
+                    cutoff_mask2);
             }
 
-            simd_h_dual_incr_reduced_sum(&ci_f[CL_X_OFFSET], fix0, fix2);
-            simd_h_dual_incr_reduced_sum(&ci_f[CL_Y_OFFSET], fiy0, fiy2);
-            simd_h_dual_incr_reduced_sum(&ci_f[CL_Z_OFFSET], fiz0, fiz2);
+            simd_real_h_dual_incr_reduced_sum(&ci_f[CL_X_OFFSET], fix0, fix2);
+            simd_real_h_dual_incr_reduced_sum(&ci_f[CL_Y_OFFSET], fiy0, fiy2);
+            simd_real_h_dual_incr_reduced_sum(&ci_f[CL_Z_OFFSET], fiz0, fiz2);
 
             addStat(stats->calculated_forces, 1);
             addStat(stats->num_neighs, numneighs);
@@ -779,13 +877,13 @@ double computeForceLJ4xnHalfNeigh(
     MD_FLOAT cutforcesq          = param->cutforce * param->cutforce;
     MD_FLOAT sigma6              = param->sigma6;
     MD_FLOAT epsilon             = param->epsilon;
-    MD_SIMD_FLOAT c48_vec        = simd_broadcast(48.0);
-    MD_SIMD_FLOAT c05_vec        = simd_broadcast(0.5);
+    MD_SIMD_FLOAT c48_vec        = simd_real_broadcast(48.0);
+    MD_SIMD_FLOAT c05_vec        = simd_real_broadcast(0.5);
 
 #ifdef ONE_ATOM_TYPE
-    MD_SIMD_FLOAT cutforcesq_vec = simd_broadcast(cutforcesq);
-    MD_SIMD_FLOAT sigma6_vec     = simd_broadcast(sigma6);
-    MD_SIMD_FLOAT eps_vec        = simd_broadcast(epsilon);
+    MD_SIMD_FLOAT cutforcesq_vec = simd_real_broadcast(cutforcesq);
+    MD_SIMD_FLOAT sigma6_vec     = simd_real_broadcast(sigma6);
+    MD_SIMD_FLOAT eps_vec        = simd_real_broadcast(epsilon);
 #endif
 
     for (int ci = 0; ci < atom->Nclusters_local; ci++) {
@@ -817,38 +915,38 @@ double computeForceLJ4xnHalfNeigh(
             int numneighs        = neighbor->numneigh[ci];
             int numneighs_masked = neighbor->numneigh_masked[ci];
 
-            MD_SIMD_FLOAT xi0_tmp = simd_broadcast(ci_x[CL_X_OFFSET + 0]);
-            MD_SIMD_FLOAT xi1_tmp = simd_broadcast(ci_x[CL_X_OFFSET + 1]);
-            MD_SIMD_FLOAT xi2_tmp = simd_broadcast(ci_x[CL_X_OFFSET + 2]);
-            MD_SIMD_FLOAT xi3_tmp = simd_broadcast(ci_x[CL_X_OFFSET + 3]);
-            MD_SIMD_FLOAT yi0_tmp = simd_broadcast(ci_x[CL_Y_OFFSET + 0]);
-            MD_SIMD_FLOAT yi1_tmp = simd_broadcast(ci_x[CL_Y_OFFSET + 1]);
-            MD_SIMD_FLOAT yi2_tmp = simd_broadcast(ci_x[CL_Y_OFFSET + 2]);
-            MD_SIMD_FLOAT yi3_tmp = simd_broadcast(ci_x[CL_Y_OFFSET + 3]);
-            MD_SIMD_FLOAT zi0_tmp = simd_broadcast(ci_x[CL_Z_OFFSET + 0]);
-            MD_SIMD_FLOAT zi1_tmp = simd_broadcast(ci_x[CL_Z_OFFSET + 1]);
-            MD_SIMD_FLOAT zi2_tmp = simd_broadcast(ci_x[CL_Z_OFFSET + 2]);
-            MD_SIMD_FLOAT zi3_tmp = simd_broadcast(ci_x[CL_Z_OFFSET + 3]);
-            MD_SIMD_FLOAT fix0    = simd_zero();
-            MD_SIMD_FLOAT fiy0    = simd_zero();
-            MD_SIMD_FLOAT fiz0    = simd_zero();
-            MD_SIMD_FLOAT fix1    = simd_zero();
-            MD_SIMD_FLOAT fiy1    = simd_zero();
-            MD_SIMD_FLOAT fiz1    = simd_zero();
-            MD_SIMD_FLOAT fix2    = simd_zero();
-            MD_SIMD_FLOAT fiy2    = simd_zero();
-            MD_SIMD_FLOAT fiz2    = simd_zero();
-            MD_SIMD_FLOAT fix3    = simd_zero();
-            MD_SIMD_FLOAT fiy3    = simd_zero();
-            MD_SIMD_FLOAT fiz3    = simd_zero();
+            MD_SIMD_FLOAT xi0_tmp = simd_real_broadcast(ci_x[CL_X_OFFSET + 0]);
+            MD_SIMD_FLOAT xi1_tmp = simd_real_broadcast(ci_x[CL_X_OFFSET + 1]);
+            MD_SIMD_FLOAT xi2_tmp = simd_real_broadcast(ci_x[CL_X_OFFSET + 2]);
+            MD_SIMD_FLOAT xi3_tmp = simd_real_broadcast(ci_x[CL_X_OFFSET + 3]);
+            MD_SIMD_FLOAT yi0_tmp = simd_real_broadcast(ci_x[CL_Y_OFFSET + 0]);
+            MD_SIMD_FLOAT yi1_tmp = simd_real_broadcast(ci_x[CL_Y_OFFSET + 1]);
+            MD_SIMD_FLOAT yi2_tmp = simd_real_broadcast(ci_x[CL_Y_OFFSET + 2]);
+            MD_SIMD_FLOAT yi3_tmp = simd_real_broadcast(ci_x[CL_Y_OFFSET + 3]);
+            MD_SIMD_FLOAT zi0_tmp = simd_real_broadcast(ci_x[CL_Z_OFFSET + 0]);
+            MD_SIMD_FLOAT zi1_tmp = simd_real_broadcast(ci_x[CL_Z_OFFSET + 1]);
+            MD_SIMD_FLOAT zi2_tmp = simd_real_broadcast(ci_x[CL_Z_OFFSET + 2]);
+            MD_SIMD_FLOAT zi3_tmp = simd_real_broadcast(ci_x[CL_Z_OFFSET + 3]);
+            MD_SIMD_FLOAT fix0    = simd_real_zero();
+            MD_SIMD_FLOAT fiy0    = simd_real_zero();
+            MD_SIMD_FLOAT fiz0    = simd_real_zero();
+            MD_SIMD_FLOAT fix1    = simd_real_zero();
+            MD_SIMD_FLOAT fiy1    = simd_real_zero();
+            MD_SIMD_FLOAT fiz1    = simd_real_zero();
+            MD_SIMD_FLOAT fix2    = simd_real_zero();
+            MD_SIMD_FLOAT fiy2    = simd_real_zero();
+            MD_SIMD_FLOAT fiz2    = simd_real_zero();
+            MD_SIMD_FLOAT fix3    = simd_real_zero();
+            MD_SIMD_FLOAT fiy3    = simd_real_zero();
+            MD_SIMD_FLOAT fiz3    = simd_real_zero();
 
 #ifndef ONE_ATOM_TYPE
             int ci_sca_base       = CI_SCALAR_BASE_INDEX(ci);
             int* ci_t             = &atom->cl_t[ci_sca_base];
-            MD_SIMD_INT tbase0    = simd_int_broadcast(ci_t[0] * atom->ntypes);
-            MD_SIMD_INT tbase1    = simd_int_broadcast(ci_t[1] * atom->ntypes);
-            MD_SIMD_INT tbase2    = simd_int_broadcast(ci_t[2] * atom->ntypes);
-            MD_SIMD_INT tbase3    = simd_int_broadcast(ci_t[3] * atom->ntypes);
+            MD_SIMD_INT tbase0    = simd_i32_broadcast(ci_t[0] * atom->ntypes);
+            MD_SIMD_INT tbase1    = simd_i32_broadcast(ci_t[1] * atom->ntypes);
+            MD_SIMD_INT tbase2    = simd_i32_broadcast(ci_t[2] * atom->ntypes);
+            MD_SIMD_INT tbase3    = simd_i32_broadcast(ci_t[3] * atom->ntypes);
 #endif
 
             for (int k = 0; k < numneighs_masked; k++) {
@@ -862,21 +960,21 @@ double computeForceLJ4xnHalfNeigh(
                 int* cj_t       = &atom->cl_t[cj_sca_base];
 #endif
 
-                MD_SIMD_FLOAT xj_tmp    = simd_load(&cj_x[CL_X_OFFSET]);
-                MD_SIMD_FLOAT yj_tmp    = simd_load(&cj_x[CL_Y_OFFSET]);
-                MD_SIMD_FLOAT zj_tmp    = simd_load(&cj_x[CL_Z_OFFSET]);
-                MD_SIMD_FLOAT delx0     = xi0_tmp - xj_tmp;
-                MD_SIMD_FLOAT dely0     = yi0_tmp - yj_tmp;
-                MD_SIMD_FLOAT delz0     = zi0_tmp - zj_tmp;
-                MD_SIMD_FLOAT delx1     = xi1_tmp - xj_tmp;
-                MD_SIMD_FLOAT dely1     = yi1_tmp - yj_tmp;
-                MD_SIMD_FLOAT delz1     = zi1_tmp - zj_tmp;
-                MD_SIMD_FLOAT delx2     = xi2_tmp - xj_tmp;
-                MD_SIMD_FLOAT dely2     = yi2_tmp - yj_tmp;
-                MD_SIMD_FLOAT delz2     = zi2_tmp - zj_tmp;
-                MD_SIMD_FLOAT delx3     = xi3_tmp - xj_tmp;
-                MD_SIMD_FLOAT dely3     = yi3_tmp - yj_tmp;
-                MD_SIMD_FLOAT delz3     = zi3_tmp - zj_tmp;
+                MD_SIMD_FLOAT xj_tmp    = simd_real_load(&cj_x[CL_X_OFFSET]);
+                MD_SIMD_FLOAT yj_tmp    = simd_real_load(&cj_x[CL_Y_OFFSET]);
+                MD_SIMD_FLOAT zj_tmp    = simd_real_load(&cj_x[CL_Z_OFFSET]);
+                MD_SIMD_FLOAT delx0     = simd_real_sub(xi0_tmp, xj_tmp);
+                MD_SIMD_FLOAT dely0     = simd_real_sub(yi0_tmp, yj_tmp);
+                MD_SIMD_FLOAT delz0     = simd_real_sub(zi0_tmp, zj_tmp);
+                MD_SIMD_FLOAT delx1     = simd_real_sub(xi1_tmp, xj_tmp);
+                MD_SIMD_FLOAT dely1     = simd_real_sub(yi1_tmp, yj_tmp);
+                MD_SIMD_FLOAT delz1     = simd_real_sub(zi1_tmp, zj_tmp);
+                MD_SIMD_FLOAT delx2     = simd_real_sub(xi2_tmp, xj_tmp);
+                MD_SIMD_FLOAT dely2     = simd_real_sub(yi2_tmp, yj_tmp);
+                MD_SIMD_FLOAT delz2     = simd_real_sub(zi2_tmp, zj_tmp);
+                MD_SIMD_FLOAT delx3     = simd_real_sub(xi3_tmp, xj_tmp);
+                MD_SIMD_FLOAT dely3     = simd_real_sub(yi3_tmp, yj_tmp);
+                MD_SIMD_FLOAT delz3     = simd_real_sub(zi3_tmp, zj_tmp);
 
 #if CLUSTER_M == CLUSTER_N
                 unsigned int cond0      = (unsigned int)(cj == ci_cj0);
@@ -906,56 +1004,64 @@ double computeForceLJ4xnHalfNeigh(
                     atom->masks_4xn_hn[cond0 * 8 + cond1 * 4 + 3]);
 #endif
 
-                MD_SIMD_FLOAT rsq0 = simd_fma(delx0,
+                MD_SIMD_FLOAT rsq0 = simd_real_fma(delx0,
                     delx0,
-                    simd_fma(dely0, dely0, delz0 * delz0));
-                MD_SIMD_FLOAT rsq1 = simd_fma(delx1,
+                    simd_real_fma(dely0, dely0, simd_real_mul(delz0, delz0)));
+                MD_SIMD_FLOAT rsq1 = simd_real_fma(delx1,
                     delx1,
-                    simd_fma(dely1, dely1, delz1 * delz1));
-                MD_SIMD_FLOAT rsq2 = simd_fma(delx2,
+                    simd_real_fma(dely1, dely1, simd_real_mul(delz1, delz1)));
+                MD_SIMD_FLOAT rsq2 = simd_real_fma(delx2,
                     delx2,
-                    simd_fma(dely2, dely2, delz2 * delz2));
-                MD_SIMD_FLOAT rsq3 = simd_fma(delx3,
+                    simd_real_fma(dely2, dely2, simd_real_mul(delz2, delz2)));
+                MD_SIMD_FLOAT rsq3 = simd_real_fma(delx3,
                     delx3,
-                    simd_fma(dely3, dely3, delz3 * delz3));
+                    simd_real_fma(dely3, dely3, simd_real_mul(delz3, delz3)));
 
 #ifndef ONE_ATOM_TYPE
-                MD_SIMD_INT tj_tmp = simd_int_load(cj_t);
-                MD_SIMD_INT tvec0  = simd_int_add(tbase0, tj_tmp);
-                MD_SIMD_INT tvec1  = simd_int_add(tbase1, tj_tmp);
-                MD_SIMD_INT tvec2  = simd_int_add(tbase2, tj_tmp);
-                MD_SIMD_INT tvec3  = simd_int_add(tbase3, tj_tmp);
+                MD_SIMD_INT tj_tmp = simd_i32_load(cj_t);
+                MD_SIMD_INT tvec0  = simd_i32_add(tbase0, tj_tmp);
+                MD_SIMD_INT tvec1  = simd_i32_add(tbase1, tj_tmp);
+                MD_SIMD_INT tvec2  = simd_i32_add(tbase2, tj_tmp);
+                MD_SIMD_INT tvec3  = simd_i32_add(tbase3, tj_tmp);
 
-                MD_SIMD_FLOAT cutforcesq0 = simd_gather(tvec0,
+                MD_SIMD_FLOAT cutforcesq0 = simd_real_gather(tvec0,
                     atom->cutforcesq,
                     sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT cutforcesq1 = simd_gather(tvec1,
+                MD_SIMD_FLOAT cutforcesq1 = simd_real_gather(tvec1,
                     atom->cutforcesq,
                     sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT cutforcesq2 = simd_gather(tvec2,
+                MD_SIMD_FLOAT cutforcesq2 = simd_real_gather(tvec2,
                     atom->cutforcesq,
                     sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT cutforcesq3 = simd_gather(tvec3,
+                MD_SIMD_FLOAT cutforcesq3 = simd_real_gather(tvec3,
                     atom->cutforcesq,
-                    sizeof(MD_FLOAT));
-
-                MD_SIMD_FLOAT sigma6_0 = simd_gather(tvec0,
-                    atom->sigma6,
-                    sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT sigma6_1 = simd_gather(tvec1,
-                    atom->sigma6,
-                    sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT sigma6_2 = simd_gather(tvec2,
-                    atom->sigma6,
-                    sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT sigma6_3 = simd_gather(tvec3,
-                    atom->sigma6,
                     sizeof(MD_FLOAT));
 
-                MD_SIMD_FLOAT eps0 = simd_gather(tvec0, atom->epsilon, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT eps1 = simd_gather(tvec1, atom->epsilon, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT eps2 = simd_gather(tvec2, atom->epsilon, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT eps3 = simd_gather(tvec3, atom->epsilon, sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT sigma6_0 = simd_real_gather(tvec0,
+                    atom->sigma6,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT sigma6_1 = simd_real_gather(tvec1,
+                    atom->sigma6,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT sigma6_2 = simd_real_gather(tvec2,
+                    atom->sigma6,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT sigma6_3 = simd_real_gather(tvec3,
+                    atom->sigma6,
+                    sizeof(MD_FLOAT));
+
+                MD_SIMD_FLOAT eps0 = simd_real_gather(tvec0,
+                    atom->epsilon,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT eps1 = simd_real_gather(tvec1,
+                    atom->epsilon,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT eps2 = simd_real_gather(tvec2,
+                    atom->epsilon,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT eps3 = simd_real_gather(tvec3,
+                    atom->epsilon,
+                    sizeof(MD_FLOAT));
 #else
                 MD_SIMD_FLOAT cutforcesq0 = cutforcesq_vec;
                 MD_SIMD_FLOAT cutforcesq1 = cutforcesq_vec;
@@ -982,54 +1088,89 @@ double computeForceLJ4xnHalfNeigh(
                 MD_SIMD_MASK cutoff_mask3 = simd_mask_and(excl_mask3,
                     simd_mask_cond_lt(rsq3, cutforcesq3));
 
-                MD_SIMD_FLOAT sr2_0 = simd_reciprocal(rsq0);
-                MD_SIMD_FLOAT sr2_1 = simd_reciprocal(rsq1);
-                MD_SIMD_FLOAT sr2_2 = simd_reciprocal(rsq2);
-                MD_SIMD_FLOAT sr2_3 = simd_reciprocal(rsq3);
+                MD_SIMD_FLOAT sr2_0 = simd_real_reciprocal(rsq0);
+                MD_SIMD_FLOAT sr2_1 = simd_real_reciprocal(rsq1);
+                MD_SIMD_FLOAT sr2_2 = simd_real_reciprocal(rsq2);
+                MD_SIMD_FLOAT sr2_3 = simd_real_reciprocal(rsq3);
 
-                MD_SIMD_FLOAT sr6_0 = sr2_0 * sr2_0 * sr2_0 * sigma6_0;
-                MD_SIMD_FLOAT sr6_1 = sr2_1 * sr2_1 * sr2_1 * sigma6_1;
-                MD_SIMD_FLOAT sr6_2 = sr2_2 * sr2_2 * sr2_2 * sigma6_2;
-                MD_SIMD_FLOAT sr6_3 = sr2_3 * sr2_3 * sr2_3 * sigma6_3;
+                MD_SIMD_FLOAT sr6_0 = simd_real_mul(sr2_0,
+                    simd_real_mul(sr2_0, simd_real_mul(sr2_0, sigma6_0)));
+                MD_SIMD_FLOAT sr6_1 = simd_real_mul(sr2_1,
+                    simd_real_mul(sr2_1, simd_real_mul(sr2_1, sigma6_1)));
+                MD_SIMD_FLOAT sr6_2 = simd_real_mul(sr2_2,
+                    simd_real_mul(sr2_2, simd_real_mul(sr2_2, sigma6_2)));
+                MD_SIMD_FLOAT sr6_3 = simd_real_mul(sr2_3,
+                    simd_real_mul(sr2_3, simd_real_mul(sr2_3, sigma6_3)));
 
-                MD_SIMD_FLOAT force0 = c48_vec * sr6_0 * (sr6_0 - c05_vec) * sr2_0 * eps0;
-                MD_SIMD_FLOAT force1 = c48_vec * sr6_1 * (sr6_1 - c05_vec) * sr2_1 * eps1;
-                MD_SIMD_FLOAT force2 = c48_vec * sr6_2 * (sr6_2 - c05_vec) * sr2_2 * eps2;
-                MD_SIMD_FLOAT force3 = c48_vec * sr6_3 * (sr6_3 - c05_vec) * sr2_3 * eps3;
+                MD_SIMD_FLOAT force0 = simd_real_mul(c48_vec,
+                    simd_real_mul(sr6_0,
+                        simd_real_mul(simd_real_sub(sr6_0, c05_vec),
+                            simd_real_mul(sr2_0, eps0))));
+                MD_SIMD_FLOAT force1 = simd_real_mul(c48_vec,
+                    simd_real_mul(sr6_1,
+                        simd_real_mul(simd_real_sub(sr6_1, c05_vec),
+                            simd_real_mul(sr2_1, eps1))));
+                MD_SIMD_FLOAT force2 = simd_real_mul(c48_vec,
+                    simd_real_mul(sr6_2,
+                        simd_real_mul(simd_real_sub(sr6_2, c05_vec),
+                            simd_real_mul(sr2_2, eps2))));
+                MD_SIMD_FLOAT force3 = simd_real_mul(c48_vec,
+                    simd_real_mul(sr6_3,
+                        simd_real_mul(simd_real_sub(sr6_3, c05_vec),
+                            simd_real_mul(sr2_3, eps3))));
 
-                MD_SIMD_FLOAT tx0 = select_by_mask(delx0 * force0, cutoff_mask0);
-                MD_SIMD_FLOAT ty0 = select_by_mask(dely0 * force0, cutoff_mask0);
-                MD_SIMD_FLOAT tz0 = select_by_mask(delz0 * force0, cutoff_mask0);
-                MD_SIMD_FLOAT tx1 = select_by_mask(delx1 * force1, cutoff_mask1);
-                MD_SIMD_FLOAT ty1 = select_by_mask(dely1 * force1, cutoff_mask1);
-                MD_SIMD_FLOAT tz1 = select_by_mask(delz1 * force1, cutoff_mask1);
-                MD_SIMD_FLOAT tx2 = select_by_mask(delx2 * force2, cutoff_mask2);
-                MD_SIMD_FLOAT ty2 = select_by_mask(dely2 * force2, cutoff_mask2);
-                MD_SIMD_FLOAT tz2 = select_by_mask(delz2 * force2, cutoff_mask2);
-                MD_SIMD_FLOAT tx3 = select_by_mask(delx3 * force3, cutoff_mask3);
-                MD_SIMD_FLOAT ty3 = select_by_mask(dely3 * force3, cutoff_mask3);
-                MD_SIMD_FLOAT tz3 = select_by_mask(delz3 * force3, cutoff_mask3);
+                MD_SIMD_FLOAT tx0 = simd_real_select_by_mask(simd_real_mul(delx0, force0),
+                    cutoff_mask0);
+                MD_SIMD_FLOAT ty0 = simd_real_select_by_mask(simd_real_mul(dely0, force0),
+                    cutoff_mask0);
+                MD_SIMD_FLOAT tz0 = simd_real_select_by_mask(simd_real_mul(delz0, force0),
+                    cutoff_mask0);
+                MD_SIMD_FLOAT tx1 = simd_real_select_by_mask(simd_real_mul(delx1, force1),
+                    cutoff_mask1);
+                MD_SIMD_FLOAT ty1 = simd_real_select_by_mask(simd_real_mul(dely1, force1),
+                    cutoff_mask1);
+                MD_SIMD_FLOAT tz1 = simd_real_select_by_mask(simd_real_mul(delz1, force1),
+                    cutoff_mask1);
+                MD_SIMD_FLOAT tx2 = simd_real_select_by_mask(simd_real_mul(delx2, force2),
+                    cutoff_mask2);
+                MD_SIMD_FLOAT ty2 = simd_real_select_by_mask(simd_real_mul(dely2, force2),
+                    cutoff_mask2);
+                MD_SIMD_FLOAT tz2 = simd_real_select_by_mask(simd_real_mul(delz2, force2),
+                    cutoff_mask2);
+                MD_SIMD_FLOAT tx3 = simd_real_select_by_mask(simd_real_mul(delx3, force3),
+                    cutoff_mask3);
+                MD_SIMD_FLOAT ty3 = simd_real_select_by_mask(simd_real_mul(dely3, force3),
+                    cutoff_mask3);
+                MD_SIMD_FLOAT tz3 = simd_real_select_by_mask(simd_real_mul(delz3, force3),
+                    cutoff_mask3);
 
-                fix0 = simd_add(fix0, tx0);
-                fiy0 = simd_add(fiy0, ty0);
-                fiz0 = simd_add(fiz0, tz0);
-                fix1 = simd_add(fix1, tx1);
-                fiy1 = simd_add(fiy1, ty1);
-                fiz1 = simd_add(fiz1, tz1);
-                fix2 = simd_add(fix2, tx2);
-                fiy2 = simd_add(fiy2, ty2);
-                fiz2 = simd_add(fiz2, tz2);
-                fix3 = simd_add(fix3, tx3);
-                fiy3 = simd_add(fiy3, ty3);
-                fiz3 = simd_add(fiz3, tz3);
+                fix0 = simd_real_add(fix0, tx0);
+                fiy0 = simd_real_add(fiy0, ty0);
+                fiz0 = simd_real_add(fiz0, tz0);
+                fix1 = simd_real_add(fix1, tx1);
+                fiy1 = simd_real_add(fiy1, ty1);
+                fiz1 = simd_real_add(fiz1, tz1);
+                fix2 = simd_real_add(fix2, tx2);
+                fiy2 = simd_real_add(fiy2, ty2);
+                fiz2 = simd_real_add(fiz2, tz2);
+                fix3 = simd_real_add(fix3, tx3);
+                fiy3 = simd_real_add(fiy3, ty3);
+                fiz3 = simd_real_add(fiz3, tz3);
 
                 if (cj < CJ1_FROM_CI(atom->Nlocal)) {
-                    simd_store(&cj_f[CL_X_OFFSET],
-                        simd_load(&cj_f[CL_X_OFFSET]) - (tx0 + tx1 + tx2 + tx3));
-                    simd_store(&cj_f[CL_Y_OFFSET],
-                        simd_load(&cj_f[CL_Y_OFFSET]) - (ty0 + ty1 + ty2 + ty3));
-                    simd_store(&cj_f[CL_Z_OFFSET],
-                        simd_load(&cj_f[CL_Z_OFFSET]) - (tz0 + tz1 + tz2 + tz3));
+                    MD_SIMD_FLOAT tx_sum = simd_real_add(tx0,
+                        simd_real_add(tx1, simd_real_add(tx2, tx3)));
+                    MD_SIMD_FLOAT ty_sum = simd_real_add(ty0,
+                        simd_real_add(ty1, simd_real_add(ty2, ty3)));
+                    MD_SIMD_FLOAT tz_sum = simd_real_add(tz0,
+                        simd_real_add(tz1, simd_real_add(tz2, tz3)));
+
+                    simd_real_store(&cj_f[CL_X_OFFSET],
+                        simd_real_sub(simd_real_load(&cj_f[CL_X_OFFSET]), tx_sum));
+                    simd_real_store(&cj_f[CL_Y_OFFSET],
+                        simd_real_sub(simd_real_load(&cj_f[CL_Y_OFFSET]), ty_sum));
+                    simd_real_store(&cj_f[CL_Z_OFFSET],
+                        simd_real_sub(simd_real_load(&cj_f[CL_Z_OFFSET]), tz_sum));
                 }
             }
 
@@ -1044,72 +1185,80 @@ double computeForceLJ4xnHalfNeigh(
                 int* cj_t       = &atom->cl_t[cj_sca_base];
 #endif
 
-                MD_SIMD_FLOAT xj_tmp = simd_load(&cj_x[CL_X_OFFSET]);
-                MD_SIMD_FLOAT yj_tmp = simd_load(&cj_x[CL_Y_OFFSET]);
-                MD_SIMD_FLOAT zj_tmp = simd_load(&cj_x[CL_Z_OFFSET]);
-                MD_SIMD_FLOAT delx0  = xi0_tmp - xj_tmp;
-                MD_SIMD_FLOAT dely0  = yi0_tmp - yj_tmp;
-                MD_SIMD_FLOAT delz0  = zi0_tmp - zj_tmp;
-                MD_SIMD_FLOAT delx1  = xi1_tmp - xj_tmp;
-                MD_SIMD_FLOAT dely1  = yi1_tmp - yj_tmp;
-                MD_SIMD_FLOAT delz1  = zi1_tmp - zj_tmp;
-                MD_SIMD_FLOAT delx2  = xi2_tmp - xj_tmp;
-                MD_SIMD_FLOAT dely2  = yi2_tmp - yj_tmp;
-                MD_SIMD_FLOAT delz2  = zi2_tmp - zj_tmp;
-                MD_SIMD_FLOAT delx3  = xi3_tmp - xj_tmp;
-                MD_SIMD_FLOAT dely3  = yi3_tmp - yj_tmp;
-                MD_SIMD_FLOAT delz3  = zi3_tmp - zj_tmp;
+                MD_SIMD_FLOAT xj_tmp = simd_real_load(&cj_x[CL_X_OFFSET]);
+                MD_SIMD_FLOAT yj_tmp = simd_real_load(&cj_x[CL_Y_OFFSET]);
+                MD_SIMD_FLOAT zj_tmp = simd_real_load(&cj_x[CL_Z_OFFSET]);
+                MD_SIMD_FLOAT delx0  = simd_real_sub(xi0_tmp, xj_tmp);
+                MD_SIMD_FLOAT dely0  = simd_real_sub(yi0_tmp, yj_tmp);
+                MD_SIMD_FLOAT delz0  = simd_real_sub(zi0_tmp, zj_tmp);
+                MD_SIMD_FLOAT delx1  = simd_real_sub(xi1_tmp, xj_tmp);
+                MD_SIMD_FLOAT dely1  = simd_real_sub(yi1_tmp, yj_tmp);
+                MD_SIMD_FLOAT delz1  = simd_real_sub(zi1_tmp, zj_tmp);
+                MD_SIMD_FLOAT delx2  = simd_real_sub(xi2_tmp, xj_tmp);
+                MD_SIMD_FLOAT dely2  = simd_real_sub(yi2_tmp, yj_tmp);
+                MD_SIMD_FLOAT delz2  = simd_real_sub(zi2_tmp, zj_tmp);
+                MD_SIMD_FLOAT delx3  = simd_real_sub(xi3_tmp, xj_tmp);
+                MD_SIMD_FLOAT dely3  = simd_real_sub(yi3_tmp, yj_tmp);
+                MD_SIMD_FLOAT delz3  = simd_real_sub(zi3_tmp, zj_tmp);
 
-                MD_SIMD_FLOAT rsq0 = simd_fma(delx0,
+                MD_SIMD_FLOAT rsq0 = simd_real_fma(delx0,
                     delx0,
-                    simd_fma(dely0, dely0, delz0 * delz0));
-                MD_SIMD_FLOAT rsq1 = simd_fma(delx1,
+                    simd_real_fma(dely0, dely0, simd_real_mul(delz0, delz0)));
+                MD_SIMD_FLOAT rsq1 = simd_real_fma(delx1,
                     delx1,
-                    simd_fma(dely1, dely1, delz1 * delz1));
-                MD_SIMD_FLOAT rsq2 = simd_fma(delx2,
+                    simd_real_fma(dely1, dely1, simd_real_mul(delz1, delz1)));
+                MD_SIMD_FLOAT rsq2 = simd_real_fma(delx2,
                     delx2,
-                    simd_fma(dely2, dely2, delz2 * delz2));
-                MD_SIMD_FLOAT rsq3 = simd_fma(delx3,
+                    simd_real_fma(dely2, dely2, simd_real_mul(delz2, delz2)));
+                MD_SIMD_FLOAT rsq3 = simd_real_fma(delx3,
                     delx3,
-                    simd_fma(dely3, dely3, delz3 * delz3));
+                    simd_real_fma(dely3, dely3, simd_real_mul(delz3, delz3)));
 
 #ifndef ONE_ATOM_TYPE
-                MD_SIMD_INT tj_tmp = simd_int_load(cj_t);
-                MD_SIMD_INT tvec0  = simd_int_add(tbase0, tj_tmp);
-                MD_SIMD_INT tvec1  = simd_int_add(tbase1, tj_tmp);
-                MD_SIMD_INT tvec2  = simd_int_add(tbase2, tj_tmp);
-                MD_SIMD_INT tvec3  = simd_int_add(tbase3, tj_tmp);
+                MD_SIMD_INT tj_tmp = simd_i32_load(cj_t);
+                MD_SIMD_INT tvec0  = simd_i32_add(tbase0, tj_tmp);
+                MD_SIMD_INT tvec1  = simd_i32_add(tbase1, tj_tmp);
+                MD_SIMD_INT tvec2  = simd_i32_add(tbase2, tj_tmp);
+                MD_SIMD_INT tvec3  = simd_i32_add(tbase3, tj_tmp);
 
-                MD_SIMD_FLOAT cutforcesq0 = simd_gather(tvec0,
+                MD_SIMD_FLOAT cutforcesq0 = simd_real_gather(tvec0,
                     atom->cutforcesq,
                     sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT cutforcesq1 = simd_gather(tvec1,
+                MD_SIMD_FLOAT cutforcesq1 = simd_real_gather(tvec1,
                     atom->cutforcesq,
                     sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT cutforcesq2 = simd_gather(tvec2,
+                MD_SIMD_FLOAT cutforcesq2 = simd_real_gather(tvec2,
                     atom->cutforcesq,
                     sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT cutforcesq3 = simd_gather(tvec3,
+                MD_SIMD_FLOAT cutforcesq3 = simd_real_gather(tvec3,
                     atom->cutforcesq,
-                    sizeof(MD_FLOAT));
-
-                MD_SIMD_FLOAT sigma6_0 = simd_gather(tvec0,
-                    atom->sigma6,
-                    sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT sigma6_1 = simd_gather(tvec1,
-                    atom->sigma6,
-                    sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT sigma6_2 = simd_gather(tvec2,
-                    atom->sigma6,
-                    sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT sigma6_3 = simd_gather(tvec3,
-                    atom->sigma6,
                     sizeof(MD_FLOAT));
 
-                MD_SIMD_FLOAT eps0 = simd_gather(tvec0, atom->epsilon, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT eps1 = simd_gather(tvec1, atom->epsilon, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT eps2 = simd_gather(tvec2, atom->epsilon, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT eps3 = simd_gather(tvec3, atom->epsilon, sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT sigma6_0 = simd_real_gather(tvec0,
+                    atom->sigma6,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT sigma6_1 = simd_real_gather(tvec1,
+                    atom->sigma6,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT sigma6_2 = simd_real_gather(tvec2,
+                    atom->sigma6,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT sigma6_3 = simd_real_gather(tvec3,
+                    atom->sigma6,
+                    sizeof(MD_FLOAT));
+
+                MD_SIMD_FLOAT eps0 = simd_real_gather(tvec0,
+                    atom->epsilon,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT eps1 = simd_real_gather(tvec1,
+                    atom->epsilon,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT eps2 = simd_real_gather(tvec2,
+                    atom->epsilon,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT eps3 = simd_real_gather(tvec3,
+                    atom->epsilon,
+                    sizeof(MD_FLOAT));
 #else
                 MD_SIMD_FLOAT cutforcesq0 = cutforcesq_vec;
                 MD_SIMD_FLOAT cutforcesq1 = cutforcesq_vec;
@@ -1132,60 +1281,95 @@ double computeForceLJ4xnHalfNeigh(
                 MD_SIMD_MASK cutoff_mask2 = simd_mask_cond_lt(rsq2, cutforcesq2);
                 MD_SIMD_MASK cutoff_mask3 = simd_mask_cond_lt(rsq3, cutforcesq3);
 
-                MD_SIMD_FLOAT sr2_0 = simd_reciprocal(rsq0);
-                MD_SIMD_FLOAT sr2_1 = simd_reciprocal(rsq1);
-                MD_SIMD_FLOAT sr2_2 = simd_reciprocal(rsq2);
-                MD_SIMD_FLOAT sr2_3 = simd_reciprocal(rsq3);
+                MD_SIMD_FLOAT sr2_0 = simd_real_reciprocal(rsq0);
+                MD_SIMD_FLOAT sr2_1 = simd_real_reciprocal(rsq1);
+                MD_SIMD_FLOAT sr2_2 = simd_real_reciprocal(rsq2);
+                MD_SIMD_FLOAT sr2_3 = simd_real_reciprocal(rsq3);
 
-                MD_SIMD_FLOAT sr6_0 = sr2_0 * sr2_0 * sr2_0 * sigma6_0;
-                MD_SIMD_FLOAT sr6_1 = sr2_1 * sr2_1 * sr2_1 * sigma6_1;
-                MD_SIMD_FLOAT sr6_2 = sr2_2 * sr2_2 * sr2_2 * sigma6_2;
-                MD_SIMD_FLOAT sr6_3 = sr2_3 * sr2_3 * sr2_3 * sigma6_3;
+                MD_SIMD_FLOAT sr6_0 = simd_real_mul(sr2_0,
+                    simd_real_mul(sr2_0, simd_real_mul(sr2_0, sigma6_0)));
+                MD_SIMD_FLOAT sr6_1 = simd_real_mul(sr2_1,
+                    simd_real_mul(sr2_1, simd_real_mul(sr2_1, sigma6_1)));
+                MD_SIMD_FLOAT sr6_2 = simd_real_mul(sr2_2,
+                    simd_real_mul(sr2_2, simd_real_mul(sr2_2, sigma6_2)));
+                MD_SIMD_FLOAT sr6_3 = simd_real_mul(sr2_3,
+                    simd_real_mul(sr2_3, simd_real_mul(sr2_3, sigma6_3)));
 
-                MD_SIMD_FLOAT force0 = c48_vec * sr6_0 * (sr6_0 - c05_vec) * sr2_0 * eps0;
-                MD_SIMD_FLOAT force1 = c48_vec * sr6_1 * (sr6_1 - c05_vec) * sr2_1 * eps1;
-                MD_SIMD_FLOAT force2 = c48_vec * sr6_2 * (sr6_2 - c05_vec) * sr2_2 * eps2;
-                MD_SIMD_FLOAT force3 = c48_vec * sr6_3 * (sr6_3 - c05_vec) * sr2_3 * eps3;
+                MD_SIMD_FLOAT force0 = simd_real_mul(c48_vec,
+                    simd_real_mul(sr6_0,
+                        simd_real_mul(simd_real_sub(sr6_0, c05_vec),
+                            simd_real_mul(sr2_0, eps0))));
+                MD_SIMD_FLOAT force1 = simd_real_mul(c48_vec,
+                    simd_real_mul(sr6_1,
+                        simd_real_mul(simd_real_sub(sr6_1, c05_vec),
+                            simd_real_mul(sr2_1, eps1))));
+                MD_SIMD_FLOAT force2 = simd_real_mul(c48_vec,
+                    simd_real_mul(sr6_2,
+                        simd_real_mul(simd_real_sub(sr6_2, c05_vec),
+                            simd_real_mul(sr2_2, eps2))));
+                MD_SIMD_FLOAT force3 = simd_real_mul(c48_vec,
+                    simd_real_mul(sr6_3,
+                        simd_real_mul(simd_real_sub(sr6_3, c05_vec),
+                            simd_real_mul(sr2_3, eps3))));
 
-                MD_SIMD_FLOAT tx0 = select_by_mask(delx0 * force0, cutoff_mask0);
-                MD_SIMD_FLOAT ty0 = select_by_mask(dely0 * force0, cutoff_mask0);
-                MD_SIMD_FLOAT tz0 = select_by_mask(delz0 * force0, cutoff_mask0);
-                MD_SIMD_FLOAT tx1 = select_by_mask(delx1 * force1, cutoff_mask1);
-                MD_SIMD_FLOAT ty1 = select_by_mask(dely1 * force1, cutoff_mask1);
-                MD_SIMD_FLOAT tz1 = select_by_mask(delz1 * force1, cutoff_mask1);
-                MD_SIMD_FLOAT tx2 = select_by_mask(delx2 * force2, cutoff_mask2);
-                MD_SIMD_FLOAT ty2 = select_by_mask(dely2 * force2, cutoff_mask2);
-                MD_SIMD_FLOAT tz2 = select_by_mask(delz2 * force2, cutoff_mask2);
-                MD_SIMD_FLOAT tx3 = select_by_mask(delx3 * force3, cutoff_mask3);
-                MD_SIMD_FLOAT ty3 = select_by_mask(dely3 * force3, cutoff_mask3);
-                MD_SIMD_FLOAT tz3 = select_by_mask(delz3 * force3, cutoff_mask3);
+                MD_SIMD_FLOAT tx0 = simd_real_select_by_mask(simd_real_mul(delx0, force0),
+                    cutoff_mask0);
+                MD_SIMD_FLOAT ty0 = simd_real_select_by_mask(simd_real_mul(dely0, force0),
+                    cutoff_mask0);
+                MD_SIMD_FLOAT tz0 = simd_real_select_by_mask(simd_real_mul(delz0, force0),
+                    cutoff_mask0);
+                MD_SIMD_FLOAT tx1 = simd_real_select_by_mask(simd_real_mul(delx1, force1),
+                    cutoff_mask1);
+                MD_SIMD_FLOAT ty1 = simd_real_select_by_mask(simd_real_mul(dely1, force1),
+                    cutoff_mask1);
+                MD_SIMD_FLOAT tz1 = simd_real_select_by_mask(simd_real_mul(delz1, force1),
+                    cutoff_mask1);
+                MD_SIMD_FLOAT tx2 = simd_real_select_by_mask(simd_real_mul(delx2, force2),
+                    cutoff_mask2);
+                MD_SIMD_FLOAT ty2 = simd_real_select_by_mask(simd_real_mul(dely2, force2),
+                    cutoff_mask2);
+                MD_SIMD_FLOAT tz2 = simd_real_select_by_mask(simd_real_mul(delz2, force2),
+                    cutoff_mask2);
+                MD_SIMD_FLOAT tx3 = simd_real_select_by_mask(simd_real_mul(delx3, force3),
+                    cutoff_mask3);
+                MD_SIMD_FLOAT ty3 = simd_real_select_by_mask(simd_real_mul(dely3, force3),
+                    cutoff_mask3);
+                MD_SIMD_FLOAT tz3 = simd_real_select_by_mask(simd_real_mul(delz3, force3),
+                    cutoff_mask3);
 
-                fix0 = simd_add(fix0, tx0);
-                fiy0 = simd_add(fiy0, ty0);
-                fiz0 = simd_add(fiz0, tz0);
-                fix1 = simd_add(fix1, tx1);
-                fiy1 = simd_add(fiy1, ty1);
-                fiz1 = simd_add(fiz1, tz1);
-                fix2 = simd_add(fix2, tx2);
-                fiy2 = simd_add(fiy2, ty2);
-                fiz2 = simd_add(fiz2, tz2);
-                fix3 = simd_add(fix3, tx3);
-                fiy3 = simd_add(fiy3, ty3);
-                fiz3 = simd_add(fiz3, tz3);
+                fix0 = simd_real_add(fix0, tx0);
+                fiy0 = simd_real_add(fiy0, ty0);
+                fiz0 = simd_real_add(fiz0, tz0);
+                fix1 = simd_real_add(fix1, tx1);
+                fiy1 = simd_real_add(fiy1, ty1);
+                fiz1 = simd_real_add(fiz1, tz1);
+                fix2 = simd_real_add(fix2, tx2);
+                fiy2 = simd_real_add(fiy2, ty2);
+                fiz2 = simd_real_add(fiz2, tz2);
+                fix3 = simd_real_add(fix3, tx3);
+                fiy3 = simd_real_add(fiy3, ty3);
+                fiz3 = simd_real_add(fiz3, tz3);
 
                 if (cj < CJ1_FROM_CI(atom->Nlocal)) {
-                    simd_store(&cj_f[CL_X_OFFSET],
-                        simd_load(&cj_f[CL_X_OFFSET]) - (tx0 + tx1 + tx2 + tx3));
-                    simd_store(&cj_f[CL_Y_OFFSET],
-                        simd_load(&cj_f[CL_Y_OFFSET]) - (ty0 + ty1 + ty2 + ty3));
-                    simd_store(&cj_f[CL_Z_OFFSET],
-                        simd_load(&cj_f[CL_Z_OFFSET]) - (tz0 + tz1 + tz2 + tz3));
+                    MD_SIMD_FLOAT tx_sum = simd_real_add(tx0,
+                        simd_real_add(tx1, simd_real_add(tx2, tx3)));
+                    MD_SIMD_FLOAT ty_sum = simd_real_add(ty0,
+                        simd_real_add(ty1, simd_real_add(ty2, ty3)));
+                    MD_SIMD_FLOAT tz_sum = simd_real_add(tz0,
+                        simd_real_add(tz1, simd_real_add(tz2, tz3)));
+
+                    simd_real_store(&cj_f[CL_X_OFFSET],
+                        simd_real_sub(simd_real_load(&cj_f[CL_X_OFFSET]), tx_sum));
+                    simd_real_store(&cj_f[CL_Y_OFFSET],
+                        simd_real_sub(simd_real_load(&cj_f[CL_Y_OFFSET]), ty_sum));
+                    simd_real_store(&cj_f[CL_Z_OFFSET],
+                        simd_real_sub(simd_real_load(&cj_f[CL_Z_OFFSET]), tz_sum));
                 }
             }
 
-            simd_incr_reduced_sum(&ci_f[CL_X_OFFSET], fix0, fix1, fix2, fix3);
-            simd_incr_reduced_sum(&ci_f[CL_Y_OFFSET], fiy0, fiy1, fiy2, fiy3);
-            simd_incr_reduced_sum(&ci_f[CL_Z_OFFSET], fiz0, fiz1, fiz2, fiz3);
+            simd_real_incr_reduced_sum(&ci_f[CL_X_OFFSET], fix0, fix1, fix2, fix3);
+            simd_real_incr_reduced_sum(&ci_f[CL_Y_OFFSET], fiy0, fiy1, fiy2, fiy3);
+            simd_real_incr_reduced_sum(&ci_f[CL_Z_OFFSET], fiz0, fiz1, fiz2, fiz3);
 
             addStat(stats->calculated_forces, 1);
             addStat(stats->num_neighs, numneighs);
@@ -1210,13 +1394,13 @@ double computeForceLJ4xnFullNeigh(
     MD_FLOAT cutforcesq          = param->cutforce * param->cutforce;
     MD_FLOAT sigma6              = param->sigma6;
     MD_FLOAT epsilon             = param->epsilon;
-    MD_SIMD_FLOAT c48_vec        = simd_broadcast(48.0);
-    MD_SIMD_FLOAT c05_vec        = simd_broadcast(0.5);
+    MD_SIMD_FLOAT c48_vec        = simd_real_broadcast(48.0);
+    MD_SIMD_FLOAT c05_vec        = simd_real_broadcast(0.5);
 
 #ifdef ONE_ATOM_TYPE
-    MD_SIMD_FLOAT cutforcesq_vec = simd_broadcast(cutforcesq);
-    MD_SIMD_FLOAT sigma6_vec     = simd_broadcast(sigma6);
-    MD_SIMD_FLOAT eps_vec        = simd_broadcast(epsilon);
+    MD_SIMD_FLOAT cutforcesq_vec = simd_real_broadcast(cutforcesq);
+    MD_SIMD_FLOAT sigma6_vec     = simd_real_broadcast(sigma6);
+    MD_SIMD_FLOAT eps_vec        = simd_real_broadcast(epsilon);
 #endif
 
     for (int ci = 0; ci < atom->Nclusters_local; ci++) {
@@ -1248,38 +1432,38 @@ double computeForceLJ4xnFullNeigh(
             int numneighs        = neighbor->numneigh[ci];
             int numneighs_masked = neighbor->numneigh_masked[ci];
 
-            MD_SIMD_FLOAT xi0_tmp = simd_broadcast(ci_x[CL_X_OFFSET + 0]);
-            MD_SIMD_FLOAT xi1_tmp = simd_broadcast(ci_x[CL_X_OFFSET + 1]);
-            MD_SIMD_FLOAT xi2_tmp = simd_broadcast(ci_x[CL_X_OFFSET + 2]);
-            MD_SIMD_FLOAT xi3_tmp = simd_broadcast(ci_x[CL_X_OFFSET + 3]);
-            MD_SIMD_FLOAT yi0_tmp = simd_broadcast(ci_x[CL_Y_OFFSET + 0]);
-            MD_SIMD_FLOAT yi1_tmp = simd_broadcast(ci_x[CL_Y_OFFSET + 1]);
-            MD_SIMD_FLOAT yi2_tmp = simd_broadcast(ci_x[CL_Y_OFFSET + 2]);
-            MD_SIMD_FLOAT yi3_tmp = simd_broadcast(ci_x[CL_Y_OFFSET + 3]);
-            MD_SIMD_FLOAT zi0_tmp = simd_broadcast(ci_x[CL_Z_OFFSET + 0]);
-            MD_SIMD_FLOAT zi1_tmp = simd_broadcast(ci_x[CL_Z_OFFSET + 1]);
-            MD_SIMD_FLOAT zi2_tmp = simd_broadcast(ci_x[CL_Z_OFFSET + 2]);
-            MD_SIMD_FLOAT zi3_tmp = simd_broadcast(ci_x[CL_Z_OFFSET + 3]);
-            MD_SIMD_FLOAT fix0    = simd_zero();
-            MD_SIMD_FLOAT fiy0    = simd_zero();
-            MD_SIMD_FLOAT fiz0    = simd_zero();
-            MD_SIMD_FLOAT fix1    = simd_zero();
-            MD_SIMD_FLOAT fiy1    = simd_zero();
-            MD_SIMD_FLOAT fiz1    = simd_zero();
-            MD_SIMD_FLOAT fix2    = simd_zero();
-            MD_SIMD_FLOAT fiy2    = simd_zero();
-            MD_SIMD_FLOAT fiz2    = simd_zero();
-            MD_SIMD_FLOAT fix3    = simd_zero();
-            MD_SIMD_FLOAT fiy3    = simd_zero();
-            MD_SIMD_FLOAT fiz3    = simd_zero();
+            MD_SIMD_FLOAT xi0_tmp = simd_real_broadcast(ci_x[CL_X_OFFSET + 0]);
+            MD_SIMD_FLOAT xi1_tmp = simd_real_broadcast(ci_x[CL_X_OFFSET + 1]);
+            MD_SIMD_FLOAT xi2_tmp = simd_real_broadcast(ci_x[CL_X_OFFSET + 2]);
+            MD_SIMD_FLOAT xi3_tmp = simd_real_broadcast(ci_x[CL_X_OFFSET + 3]);
+            MD_SIMD_FLOAT yi0_tmp = simd_real_broadcast(ci_x[CL_Y_OFFSET + 0]);
+            MD_SIMD_FLOAT yi1_tmp = simd_real_broadcast(ci_x[CL_Y_OFFSET + 1]);
+            MD_SIMD_FLOAT yi2_tmp = simd_real_broadcast(ci_x[CL_Y_OFFSET + 2]);
+            MD_SIMD_FLOAT yi3_tmp = simd_real_broadcast(ci_x[CL_Y_OFFSET + 3]);
+            MD_SIMD_FLOAT zi0_tmp = simd_real_broadcast(ci_x[CL_Z_OFFSET + 0]);
+            MD_SIMD_FLOAT zi1_tmp = simd_real_broadcast(ci_x[CL_Z_OFFSET + 1]);
+            MD_SIMD_FLOAT zi2_tmp = simd_real_broadcast(ci_x[CL_Z_OFFSET + 2]);
+            MD_SIMD_FLOAT zi3_tmp = simd_real_broadcast(ci_x[CL_Z_OFFSET + 3]);
+            MD_SIMD_FLOAT fix0    = simd_real_zero();
+            MD_SIMD_FLOAT fiy0    = simd_real_zero();
+            MD_SIMD_FLOAT fiz0    = simd_real_zero();
+            MD_SIMD_FLOAT fix1    = simd_real_zero();
+            MD_SIMD_FLOAT fiy1    = simd_real_zero();
+            MD_SIMD_FLOAT fiz1    = simd_real_zero();
+            MD_SIMD_FLOAT fix2    = simd_real_zero();
+            MD_SIMD_FLOAT fiy2    = simd_real_zero();
+            MD_SIMD_FLOAT fiz2    = simd_real_zero();
+            MD_SIMD_FLOAT fix3    = simd_real_zero();
+            MD_SIMD_FLOAT fiy3    = simd_real_zero();
+            MD_SIMD_FLOAT fiz3    = simd_real_zero();
 
 #ifndef ONE_ATOM_TYPE
             int ci_sca_base       = CI_SCALAR_BASE_INDEX(ci);
             int* ci_t             = &atom->cl_t[ci_sca_base];
-            MD_SIMD_INT tbase0    = simd_int_broadcast(ci_t[0] * atom->ntypes);
-            MD_SIMD_INT tbase1    = simd_int_broadcast(ci_t[1] * atom->ntypes);
-            MD_SIMD_INT tbase2    = simd_int_broadcast(ci_t[2] * atom->ntypes);
-            MD_SIMD_INT tbase3    = simd_int_broadcast(ci_t[3] * atom->ntypes);
+            MD_SIMD_INT tbase0    = simd_i32_broadcast(ci_t[0] * atom->ntypes);
+            MD_SIMD_INT tbase1    = simd_i32_broadcast(ci_t[1] * atom->ntypes);
+            MD_SIMD_INT tbase2    = simd_i32_broadcast(ci_t[2] * atom->ntypes);
+            MD_SIMD_INT tbase3    = simd_i32_broadcast(ci_t[3] * atom->ntypes);
 #endif
 
             for (int k = 0; k < numneighs_masked; k++) {
@@ -1292,21 +1476,21 @@ double computeForceLJ4xnFullNeigh(
                 int* cj_t       = &atom->cl_t[cj_sca_base];
 #endif
 
-                MD_SIMD_FLOAT xj_tmp    = simd_load(&cj_x[CL_X_OFFSET]);
-                MD_SIMD_FLOAT yj_tmp    = simd_load(&cj_x[CL_Y_OFFSET]);
-                MD_SIMD_FLOAT zj_tmp    = simd_load(&cj_x[CL_Z_OFFSET]);
-                MD_SIMD_FLOAT delx0     = xi0_tmp - xj_tmp;
-                MD_SIMD_FLOAT dely0     = yi0_tmp - yj_tmp;
-                MD_SIMD_FLOAT delz0     = zi0_tmp - zj_tmp;
-                MD_SIMD_FLOAT delx1     = xi1_tmp - xj_tmp;
-                MD_SIMD_FLOAT dely1     = yi1_tmp - yj_tmp;
-                MD_SIMD_FLOAT delz1     = zi1_tmp - zj_tmp;
-                MD_SIMD_FLOAT delx2     = xi2_tmp - xj_tmp;
-                MD_SIMD_FLOAT dely2     = yi2_tmp - yj_tmp;
-                MD_SIMD_FLOAT delz2     = zi2_tmp - zj_tmp;
-                MD_SIMD_FLOAT delx3     = xi3_tmp - xj_tmp;
-                MD_SIMD_FLOAT dely3     = yi3_tmp - yj_tmp;
-                MD_SIMD_FLOAT delz3     = zi3_tmp - zj_tmp;
+                MD_SIMD_FLOAT xj_tmp    = simd_real_load(&cj_x[CL_X_OFFSET]);
+                MD_SIMD_FLOAT yj_tmp    = simd_real_load(&cj_x[CL_Y_OFFSET]);
+                MD_SIMD_FLOAT zj_tmp    = simd_real_load(&cj_x[CL_Z_OFFSET]);
+                MD_SIMD_FLOAT delx0     = simd_real_sub(xi0_tmp, xj_tmp);
+                MD_SIMD_FLOAT dely0     = simd_real_sub(yi0_tmp, yj_tmp);
+                MD_SIMD_FLOAT delz0     = simd_real_sub(zi0_tmp, zj_tmp);
+                MD_SIMD_FLOAT delx1     = simd_real_sub(xi1_tmp, xj_tmp);
+                MD_SIMD_FLOAT dely1     = simd_real_sub(yi1_tmp, yj_tmp);
+                MD_SIMD_FLOAT delz1     = simd_real_sub(zi1_tmp, zj_tmp);
+                MD_SIMD_FLOAT delx2     = simd_real_sub(xi2_tmp, xj_tmp);
+                MD_SIMD_FLOAT dely2     = simd_real_sub(yi2_tmp, yj_tmp);
+                MD_SIMD_FLOAT delz2     = simd_real_sub(zi2_tmp, zj_tmp);
+                MD_SIMD_FLOAT delx3     = simd_real_sub(xi3_tmp, xj_tmp);
+                MD_SIMD_FLOAT dely3     = simd_real_sub(yi3_tmp, yj_tmp);
+                MD_SIMD_FLOAT delz3     = simd_real_sub(zi3_tmp, zj_tmp);
 
 #if CLUSTER_M == CLUSTER_N
                 unsigned int cond0      = (unsigned int)(cj == ci_cj0);
@@ -1336,56 +1520,64 @@ double computeForceLJ4xnFullNeigh(
                     atom->masks_4xn_fn[cond0 * 8 + cond1 * 4 + 3]);
 #endif
 
-                MD_SIMD_FLOAT rsq0 = simd_fma(delx0,
+                MD_SIMD_FLOAT rsq0 = simd_real_fma(delx0,
                     delx0,
-                    simd_fma(dely0, dely0, delz0 * delz0));
-                MD_SIMD_FLOAT rsq1 = simd_fma(delx1,
+                    simd_real_fma(dely0, dely0, simd_real_mul(delz0, delz0)));
+                MD_SIMD_FLOAT rsq1 = simd_real_fma(delx1,
                     delx1,
-                    simd_fma(dely1, dely1, delz1 * delz1));
-                MD_SIMD_FLOAT rsq2 = simd_fma(delx2,
+                    simd_real_fma(dely1, dely1, simd_real_mul(delz1, delz1)));
+                MD_SIMD_FLOAT rsq2 = simd_real_fma(delx2,
                     delx2,
-                    simd_fma(dely2, dely2, delz2 * delz2));
-                MD_SIMD_FLOAT rsq3 = simd_fma(delx3,
+                    simd_real_fma(dely2, dely2, simd_real_mul(delz2, delz2)));
+                MD_SIMD_FLOAT rsq3 = simd_real_fma(delx3,
                     delx3,
-                    simd_fma(dely3, dely3, delz3 * delz3));
+                    simd_real_fma(dely3, dely3, simd_real_mul(delz3, delz3)));
 
 #ifndef ONE_ATOM_TYPE
-                MD_SIMD_INT tj_tmp = simd_int_load(cj_t);
-                MD_SIMD_INT tvec0  = simd_int_add(tbase0, tj_tmp);
-                MD_SIMD_INT tvec1  = simd_int_add(tbase1, tj_tmp);
-                MD_SIMD_INT tvec2  = simd_int_add(tbase2, tj_tmp);
-                MD_SIMD_INT tvec3  = simd_int_add(tbase3, tj_tmp);
+                MD_SIMD_INT tj_tmp = simd_i32_load(cj_t);
+                MD_SIMD_INT tvec0  = simd_i32_add(tbase0, tj_tmp);
+                MD_SIMD_INT tvec1  = simd_i32_add(tbase1, tj_tmp);
+                MD_SIMD_INT tvec2  = simd_i32_add(tbase2, tj_tmp);
+                MD_SIMD_INT tvec3  = simd_i32_add(tbase3, tj_tmp);
 
-                MD_SIMD_FLOAT cutforcesq0 = simd_gather(tvec0,
+                MD_SIMD_FLOAT cutforcesq0 = simd_real_gather(tvec0,
                     atom->cutforcesq,
                     sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT cutforcesq1 = simd_gather(tvec1,
+                MD_SIMD_FLOAT cutforcesq1 = simd_real_gather(tvec1,
                     atom->cutforcesq,
                     sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT cutforcesq2 = simd_gather(tvec2,
+                MD_SIMD_FLOAT cutforcesq2 = simd_real_gather(tvec2,
                     atom->cutforcesq,
                     sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT cutforcesq3 = simd_gather(tvec3,
+                MD_SIMD_FLOAT cutforcesq3 = simd_real_gather(tvec3,
                     atom->cutforcesq,
-                    sizeof(MD_FLOAT));
-
-                MD_SIMD_FLOAT sigma6_0 = simd_gather(tvec0,
-                    atom->sigma6,
-                    sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT sigma6_1 = simd_gather(tvec1,
-                    atom->sigma6,
-                    sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT sigma6_2 = simd_gather(tvec2,
-                    atom->sigma6,
-                    sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT sigma6_3 = simd_gather(tvec3,
-                    atom->sigma6,
                     sizeof(MD_FLOAT));
 
-                MD_SIMD_FLOAT eps0 = simd_gather(tvec0, atom->epsilon, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT eps1 = simd_gather(tvec1, atom->epsilon, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT eps2 = simd_gather(tvec2, atom->epsilon, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT eps3 = simd_gather(tvec3, atom->epsilon, sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT sigma6_0 = simd_real_gather(tvec0,
+                    atom->sigma6,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT sigma6_1 = simd_real_gather(tvec1,
+                    atom->sigma6,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT sigma6_2 = simd_real_gather(tvec2,
+                    atom->sigma6,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT sigma6_3 = simd_real_gather(tvec3,
+                    atom->sigma6,
+                    sizeof(MD_FLOAT));
+
+                MD_SIMD_FLOAT eps0 = simd_real_gather(tvec0,
+                    atom->epsilon,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT eps1 = simd_real_gather(tvec1,
+                    atom->epsilon,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT eps2 = simd_real_gather(tvec2,
+                    atom->epsilon,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT eps3 = simd_real_gather(tvec3,
+                    atom->epsilon,
+                    sizeof(MD_FLOAT));
 #else
                 MD_SIMD_FLOAT cutforcesq0 = cutforcesq_vec;
                 MD_SIMD_FLOAT cutforcesq1 = cutforcesq_vec;
@@ -1412,33 +1604,73 @@ double computeForceLJ4xnFullNeigh(
                 MD_SIMD_MASK cutoff_mask3 = simd_mask_and(excl_mask3,
                     simd_mask_cond_lt(rsq3, cutforcesq3));
 
-                MD_SIMD_FLOAT sr2_0 = simd_reciprocal(rsq0);
-                MD_SIMD_FLOAT sr2_1 = simd_reciprocal(rsq1);
-                MD_SIMD_FLOAT sr2_2 = simd_reciprocal(rsq2);
-                MD_SIMD_FLOAT sr2_3 = simd_reciprocal(rsq3);
+                MD_SIMD_FLOAT sr2_0 = simd_real_reciprocal(rsq0);
+                MD_SIMD_FLOAT sr2_1 = simd_real_reciprocal(rsq1);
+                MD_SIMD_FLOAT sr2_2 = simd_real_reciprocal(rsq2);
+                MD_SIMD_FLOAT sr2_3 = simd_real_reciprocal(rsq3);
 
-                MD_SIMD_FLOAT sr6_0 = sr2_0 * sr2_0 * sr2_0 * sigma6_0;
-                MD_SIMD_FLOAT sr6_1 = sr2_1 * sr2_1 * sr2_1 * sigma6_1;
-                MD_SIMD_FLOAT sr6_2 = sr2_2 * sr2_2 * sr2_2 * sigma6_2;
-                MD_SIMD_FLOAT sr6_3 = sr2_3 * sr2_3 * sr2_3 * sigma6_3;
+                MD_SIMD_FLOAT sr6_0 = simd_real_mul(sr2_0,
+                    simd_real_mul(sr2_0, simd_real_mul(sr2_0, sigma6_0)));
+                MD_SIMD_FLOAT sr6_1 = simd_real_mul(sr2_1,
+                    simd_real_mul(sr2_1, simd_real_mul(sr2_1, sigma6_1)));
+                MD_SIMD_FLOAT sr6_2 = simd_real_mul(sr2_2,
+                    simd_real_mul(sr2_2, simd_real_mul(sr2_2, sigma6_2)));
+                MD_SIMD_FLOAT sr6_3 = simd_real_mul(sr2_3,
+                    simd_real_mul(sr2_3, simd_real_mul(sr2_3, sigma6_3)));
 
-                MD_SIMD_FLOAT force0 = c48_vec * sr6_0 * (sr6_0 - c05_vec) * sr2_0 * eps0;
-                MD_SIMD_FLOAT force1 = c48_vec * sr6_1 * (sr6_1 - c05_vec) * sr2_1 * eps1;
-                MD_SIMD_FLOAT force2 = c48_vec * sr6_2 * (sr6_2 - c05_vec) * sr2_2 * eps2;
-                MD_SIMD_FLOAT force3 = c48_vec * sr6_3 * (sr6_3 - c05_vec) * sr2_3 * eps3;
+                MD_SIMD_FLOAT force0 = simd_real_mul(c48_vec,
+                    simd_real_mul(sr6_0,
+                        simd_real_mul(simd_real_sub(sr6_0, c05_vec),
+                            simd_real_mul(sr2_0, eps0))));
+                MD_SIMD_FLOAT force1 = simd_real_mul(c48_vec,
+                    simd_real_mul(sr6_1,
+                        simd_real_mul(simd_real_sub(sr6_1, c05_vec),
+                            simd_real_mul(sr2_1, eps1))));
+                MD_SIMD_FLOAT force2 = simd_real_mul(c48_vec,
+                    simd_real_mul(sr6_2,
+                        simd_real_mul(simd_real_sub(sr6_2, c05_vec),
+                            simd_real_mul(sr2_2, eps2))));
+                MD_SIMD_FLOAT force3 = simd_real_mul(c48_vec,
+                    simd_real_mul(sr6_3,
+                        simd_real_mul(simd_real_sub(sr6_3, c05_vec),
+                            simd_real_mul(sr2_3, eps3))));
 
-                fix0 = simd_masked_add(fix0, delx0 * force0, cutoff_mask0);
-                fiy0 = simd_masked_add(fiy0, dely0 * force0, cutoff_mask0);
-                fiz0 = simd_masked_add(fiz0, delz0 * force0, cutoff_mask0);
-                fix1 = simd_masked_add(fix1, delx1 * force1, cutoff_mask1);
-                fiy1 = simd_masked_add(fiy1, dely1 * force1, cutoff_mask1);
-                fiz1 = simd_masked_add(fiz1, delz1 * force1, cutoff_mask1);
-                fix2 = simd_masked_add(fix2, delx2 * force2, cutoff_mask2);
-                fiy2 = simd_masked_add(fiy2, dely2 * force2, cutoff_mask2);
-                fiz2 = simd_masked_add(fiz2, delz2 * force2, cutoff_mask2);
-                fix3 = simd_masked_add(fix3, delx3 * force3, cutoff_mask3);
-                fiy3 = simd_masked_add(fiy3, dely3 * force3, cutoff_mask3);
-                fiz3 = simd_masked_add(fiz3, delz3 * force3, cutoff_mask3);
+                fix0 = simd_real_masked_add(fix0,
+                    simd_real_mul(delx0, force0),
+                    cutoff_mask0);
+                fiy0 = simd_real_masked_add(fiy0,
+                    simd_real_mul(dely0, force0),
+                    cutoff_mask0);
+                fiz0 = simd_real_masked_add(fiz0,
+                    simd_real_mul(delz0, force0),
+                    cutoff_mask0);
+                fix1 = simd_real_masked_add(fix1,
+                    simd_real_mul(delx1, force1),
+                    cutoff_mask1);
+                fiy1 = simd_real_masked_add(fiy1,
+                    simd_real_mul(dely1, force1),
+                    cutoff_mask1);
+                fiz1 = simd_real_masked_add(fiz1,
+                    simd_real_mul(delz1, force1),
+                    cutoff_mask1);
+                fix2 = simd_real_masked_add(fix2,
+                    simd_real_mul(delx2, force2),
+                    cutoff_mask2);
+                fiy2 = simd_real_masked_add(fiy2,
+                    simd_real_mul(dely2, force2),
+                    cutoff_mask2);
+                fiz2 = simd_real_masked_add(fiz2,
+                    simd_real_mul(delz2, force2),
+                    cutoff_mask2);
+                fix3 = simd_real_masked_add(fix3,
+                    simd_real_mul(delx3, force3),
+                    cutoff_mask3);
+                fiy3 = simd_real_masked_add(fiy3,
+                    simd_real_mul(dely3, force3),
+                    cutoff_mask3);
+                fiz3 = simd_real_masked_add(fiz3,
+                    simd_real_mul(delz3, force3),
+                    cutoff_mask3);
             }
 
             for (int k = numneighs_masked; k < numneighs; k++) {
@@ -1451,72 +1683,80 @@ double computeForceLJ4xnFullNeigh(
                 int* cj_t       = &atom->cl_t[cj_sca_base];
 #endif
 
-                MD_SIMD_FLOAT xj_tmp = simd_load(&cj_x[CL_X_OFFSET]);
-                MD_SIMD_FLOAT yj_tmp = simd_load(&cj_x[CL_Y_OFFSET]);
-                MD_SIMD_FLOAT zj_tmp = simd_load(&cj_x[CL_Z_OFFSET]);
-                MD_SIMD_FLOAT delx0  = xi0_tmp - xj_tmp;
-                MD_SIMD_FLOAT dely0  = yi0_tmp - yj_tmp;
-                MD_SIMD_FLOAT delz0  = zi0_tmp - zj_tmp;
-                MD_SIMD_FLOAT delx1  = xi1_tmp - xj_tmp;
-                MD_SIMD_FLOAT dely1  = yi1_tmp - yj_tmp;
-                MD_SIMD_FLOAT delz1  = zi1_tmp - zj_tmp;
-                MD_SIMD_FLOAT delx2  = xi2_tmp - xj_tmp;
-                MD_SIMD_FLOAT dely2  = yi2_tmp - yj_tmp;
-                MD_SIMD_FLOAT delz2  = zi2_tmp - zj_tmp;
-                MD_SIMD_FLOAT delx3  = xi3_tmp - xj_tmp;
-                MD_SIMD_FLOAT dely3  = yi3_tmp - yj_tmp;
-                MD_SIMD_FLOAT delz3  = zi3_tmp - zj_tmp;
+                MD_SIMD_FLOAT xj_tmp = simd_real_load(&cj_x[CL_X_OFFSET]);
+                MD_SIMD_FLOAT yj_tmp = simd_real_load(&cj_x[CL_Y_OFFSET]);
+                MD_SIMD_FLOAT zj_tmp = simd_real_load(&cj_x[CL_Z_OFFSET]);
+                MD_SIMD_FLOAT delx0  = simd_real_sub(xi0_tmp, xj_tmp);
+                MD_SIMD_FLOAT dely0  = simd_real_sub(yi0_tmp, yj_tmp);
+                MD_SIMD_FLOAT delz0  = simd_real_sub(zi0_tmp, zj_tmp);
+                MD_SIMD_FLOAT delx1  = simd_real_sub(xi1_tmp, xj_tmp);
+                MD_SIMD_FLOAT dely1  = simd_real_sub(yi1_tmp, yj_tmp);
+                MD_SIMD_FLOAT delz1  = simd_real_sub(zi1_tmp, zj_tmp);
+                MD_SIMD_FLOAT delx2  = simd_real_sub(xi2_tmp, xj_tmp);
+                MD_SIMD_FLOAT dely2  = simd_real_sub(yi2_tmp, yj_tmp);
+                MD_SIMD_FLOAT delz2  = simd_real_sub(zi2_tmp, zj_tmp);
+                MD_SIMD_FLOAT delx3  = simd_real_sub(xi3_tmp, xj_tmp);
+                MD_SIMD_FLOAT dely3  = simd_real_sub(yi3_tmp, yj_tmp);
+                MD_SIMD_FLOAT delz3  = simd_real_sub(zi3_tmp, zj_tmp);
 
-                MD_SIMD_FLOAT rsq0 = simd_fma(delx0,
+                MD_SIMD_FLOAT rsq0 = simd_real_fma(delx0,
                     delx0,
-                    simd_fma(dely0, dely0, delz0 * delz0));
-                MD_SIMD_FLOAT rsq1 = simd_fma(delx1,
+                    simd_real_fma(dely0, dely0, simd_real_mul(delz0, delz0)));
+                MD_SIMD_FLOAT rsq1 = simd_real_fma(delx1,
                     delx1,
-                    simd_fma(dely1, dely1, delz1 * delz1));
-                MD_SIMD_FLOAT rsq2 = simd_fma(delx2,
+                    simd_real_fma(dely1, dely1, simd_real_mul(delz1, delz1)));
+                MD_SIMD_FLOAT rsq2 = simd_real_fma(delx2,
                     delx2,
-                    simd_fma(dely2, dely2, delz2 * delz2));
-                MD_SIMD_FLOAT rsq3 = simd_fma(delx3,
+                    simd_real_fma(dely2, dely2, simd_real_mul(delz2, delz2)));
+                MD_SIMD_FLOAT rsq3 = simd_real_fma(delx3,
                     delx3,
-                    simd_fma(dely3, dely3, delz3 * delz3));
+                    simd_real_fma(dely3, dely3, simd_real_mul(delz3, delz3)));
 
 #ifndef ONE_ATOM_TYPE
-                MD_SIMD_INT tj_tmp = simd_int_load(cj_t);
-                MD_SIMD_INT tvec0  = simd_int_add(tbase0, tj_tmp);
-                MD_SIMD_INT tvec1  = simd_int_add(tbase1, tj_tmp);
-                MD_SIMD_INT tvec2  = simd_int_add(tbase2, tj_tmp);
-                MD_SIMD_INT tvec3  = simd_int_add(tbase3, tj_tmp);
+                MD_SIMD_INT tj_tmp = simd_i32_load(cj_t);
+                MD_SIMD_INT tvec0  = simd_i32_add(tbase0, tj_tmp);
+                MD_SIMD_INT tvec1  = simd_i32_add(tbase1, tj_tmp);
+                MD_SIMD_INT tvec2  = simd_i32_add(tbase2, tj_tmp);
+                MD_SIMD_INT tvec3  = simd_i32_add(tbase3, tj_tmp);
 
-                MD_SIMD_FLOAT cutforcesq0 = simd_gather(tvec0,
+                MD_SIMD_FLOAT cutforcesq0 = simd_real_gather(tvec0,
                     atom->cutforcesq,
                     sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT cutforcesq1 = simd_gather(tvec1,
+                MD_SIMD_FLOAT cutforcesq1 = simd_real_gather(tvec1,
                     atom->cutforcesq,
                     sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT cutforcesq2 = simd_gather(tvec2,
+                MD_SIMD_FLOAT cutforcesq2 = simd_real_gather(tvec2,
                     atom->cutforcesq,
                     sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT cutforcesq3 = simd_gather(tvec3,
+                MD_SIMD_FLOAT cutforcesq3 = simd_real_gather(tvec3,
                     atom->cutforcesq,
-                    sizeof(MD_FLOAT));
-
-                MD_SIMD_FLOAT sigma6_0 = simd_gather(tvec0,
-                    atom->sigma6,
-                    sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT sigma6_1 = simd_gather(tvec1,
-                    atom->sigma6,
-                    sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT sigma6_2 = simd_gather(tvec2,
-                    atom->sigma6,
-                    sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT sigma6_3 = simd_gather(tvec3,
-                    atom->sigma6,
                     sizeof(MD_FLOAT));
 
-                MD_SIMD_FLOAT eps0 = simd_gather(tvec0, atom->epsilon, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT eps1 = simd_gather(tvec1, atom->epsilon, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT eps2 = simd_gather(tvec2, atom->epsilon, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT eps3 = simd_gather(tvec3, atom->epsilon, sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT sigma6_0 = simd_real_gather(tvec0,
+                    atom->sigma6,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT sigma6_1 = simd_real_gather(tvec1,
+                    atom->sigma6,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT sigma6_2 = simd_real_gather(tvec2,
+                    atom->sigma6,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT sigma6_3 = simd_real_gather(tvec3,
+                    atom->sigma6,
+                    sizeof(MD_FLOAT));
+
+                MD_SIMD_FLOAT eps0 = simd_real_gather(tvec0,
+                    atom->epsilon,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT eps1 = simd_real_gather(tvec1,
+                    atom->epsilon,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT eps2 = simd_real_gather(tvec2,
+                    atom->epsilon,
+                    sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT eps3 = simd_real_gather(tvec3,
+                    atom->epsilon,
+                    sizeof(MD_FLOAT));
 #else
                 MD_SIMD_FLOAT cutforcesq0 = cutforcesq_vec;
                 MD_SIMD_FLOAT cutforcesq1 = cutforcesq_vec;
@@ -1539,38 +1779,78 @@ double computeForceLJ4xnFullNeigh(
                 MD_SIMD_MASK cutoff_mask2 = simd_mask_cond_lt(rsq2, cutforcesq2);
                 MD_SIMD_MASK cutoff_mask3 = simd_mask_cond_lt(rsq3, cutforcesq3);
 
-                MD_SIMD_FLOAT sr2_0 = simd_reciprocal(rsq0);
-                MD_SIMD_FLOAT sr2_1 = simd_reciprocal(rsq1);
-                MD_SIMD_FLOAT sr2_2 = simd_reciprocal(rsq2);
-                MD_SIMD_FLOAT sr2_3 = simd_reciprocal(rsq3);
+                MD_SIMD_FLOAT sr2_0 = simd_real_reciprocal(rsq0);
+                MD_SIMD_FLOAT sr2_1 = simd_real_reciprocal(rsq1);
+                MD_SIMD_FLOAT sr2_2 = simd_real_reciprocal(rsq2);
+                MD_SIMD_FLOAT sr2_3 = simd_real_reciprocal(rsq3);
 
-                MD_SIMD_FLOAT sr6_0 = sr2_0 * sr2_0 * sr2_0 * sigma6_0;
-                MD_SIMD_FLOAT sr6_1 = sr2_1 * sr2_1 * sr2_1 * sigma6_1;
-                MD_SIMD_FLOAT sr6_2 = sr2_2 * sr2_2 * sr2_2 * sigma6_2;
-                MD_SIMD_FLOAT sr6_3 = sr2_3 * sr2_3 * sr2_3 * sigma6_3;
+                MD_SIMD_FLOAT sr6_0 = simd_real_mul(sr2_0,
+                    simd_real_mul(sr2_0, simd_real_mul(sr2_0, sigma6_0)));
+                MD_SIMD_FLOAT sr6_1 = simd_real_mul(sr2_1,
+                    simd_real_mul(sr2_1, simd_real_mul(sr2_1, sigma6_1)));
+                MD_SIMD_FLOAT sr6_2 = simd_real_mul(sr2_2,
+                    simd_real_mul(sr2_2, simd_real_mul(sr2_2, sigma6_2)));
+                MD_SIMD_FLOAT sr6_3 = simd_real_mul(sr2_3,
+                    simd_real_mul(sr2_3, simd_real_mul(sr2_3, sigma6_3)));
 
-                MD_SIMD_FLOAT force0 = c48_vec * sr6_0 * (sr6_0 - c05_vec) * sr2_0 * eps0;
-                MD_SIMD_FLOAT force1 = c48_vec * sr6_1 * (sr6_1 - c05_vec) * sr2_1 * eps1;
-                MD_SIMD_FLOAT force2 = c48_vec * sr6_2 * (sr6_2 - c05_vec) * sr2_2 * eps2;
-                MD_SIMD_FLOAT force3 = c48_vec * sr6_3 * (sr6_3 - c05_vec) * sr2_3 * eps3;
+                MD_SIMD_FLOAT force0 = simd_real_mul(c48_vec,
+                    simd_real_mul(sr6_0,
+                        simd_real_mul(simd_real_sub(sr6_0, c05_vec),
+                            simd_real_mul(sr2_0, eps0))));
+                MD_SIMD_FLOAT force1 = simd_real_mul(c48_vec,
+                    simd_real_mul(sr6_1,
+                        simd_real_mul(simd_real_sub(sr6_1, c05_vec),
+                            simd_real_mul(sr2_1, eps1))));
+                MD_SIMD_FLOAT force2 = simd_real_mul(c48_vec,
+                    simd_real_mul(sr6_2,
+                        simd_real_mul(simd_real_sub(sr6_2, c05_vec),
+                            simd_real_mul(sr2_2, eps2))));
+                MD_SIMD_FLOAT force3 = simd_real_mul(c48_vec,
+                    simd_real_mul(sr6_3,
+                        simd_real_mul(simd_real_sub(sr6_3, c05_vec),
+                            simd_real_mul(sr2_3, eps3))));
 
-                fix0 = simd_masked_add(fix0, delx0 * force0, cutoff_mask0);
-                fiy0 = simd_masked_add(fiy0, dely0 * force0, cutoff_mask0);
-                fiz0 = simd_masked_add(fiz0, delz0 * force0, cutoff_mask0);
-                fix1 = simd_masked_add(fix1, delx1 * force1, cutoff_mask1);
-                fiy1 = simd_masked_add(fiy1, dely1 * force1, cutoff_mask1);
-                fiz1 = simd_masked_add(fiz1, delz1 * force1, cutoff_mask1);
-                fix2 = simd_masked_add(fix2, delx2 * force2, cutoff_mask2);
-                fiy2 = simd_masked_add(fiy2, dely2 * force2, cutoff_mask2);
-                fiz2 = simd_masked_add(fiz2, delz2 * force2, cutoff_mask2);
-                fix3 = simd_masked_add(fix3, delx3 * force3, cutoff_mask3);
-                fiy3 = simd_masked_add(fiy3, dely3 * force3, cutoff_mask3);
-                fiz3 = simd_masked_add(fiz3, delz3 * force3, cutoff_mask3);
+                fix0 = simd_real_masked_add(fix0,
+                    simd_real_mul(delx0, force0),
+                    cutoff_mask0);
+                fiy0 = simd_real_masked_add(fiy0,
+                    simd_real_mul(dely0, force0),
+                    cutoff_mask0);
+                fiz0 = simd_real_masked_add(fiz0,
+                    simd_real_mul(delz0, force0),
+                    cutoff_mask0);
+                fix1 = simd_real_masked_add(fix1,
+                    simd_real_mul(delx1, force1),
+                    cutoff_mask1);
+                fiy1 = simd_real_masked_add(fiy1,
+                    simd_real_mul(dely1, force1),
+                    cutoff_mask1);
+                fiz1 = simd_real_masked_add(fiz1,
+                    simd_real_mul(delz1, force1),
+                    cutoff_mask1);
+                fix2 = simd_real_masked_add(fix2,
+                    simd_real_mul(delx2, force2),
+                    cutoff_mask2);
+                fiy2 = simd_real_masked_add(fiy2,
+                    simd_real_mul(dely2, force2),
+                    cutoff_mask2);
+                fiz2 = simd_real_masked_add(fiz2,
+                    simd_real_mul(delz2, force2),
+                    cutoff_mask2);
+                fix3 = simd_real_masked_add(fix3,
+                    simd_real_mul(delx3, force3),
+                    cutoff_mask3);
+                fiy3 = simd_real_masked_add(fiy3,
+                    simd_real_mul(dely3, force3),
+                    cutoff_mask3);
+                fiz3 = simd_real_masked_add(fiz3,
+                    simd_real_mul(delz3, force3),
+                    cutoff_mask3);
             }
 
-            simd_incr_reduced_sum(&ci_f[CL_X_OFFSET], fix0, fix1, fix2, fix3);
-            simd_incr_reduced_sum(&ci_f[CL_Y_OFFSET], fiy0, fiy1, fiy2, fiy3);
-            simd_incr_reduced_sum(&ci_f[CL_Z_OFFSET], fiz0, fiz1, fiz2, fiz3);
+            simd_real_incr_reduced_sum(&ci_f[CL_X_OFFSET], fix0, fix1, fix2, fix3);
+            simd_real_incr_reduced_sum(&ci_f[CL_Y_OFFSET], fiy0, fiy1, fiy2, fiy3);
+            simd_real_incr_reduced_sum(&ci_f[CL_Z_OFFSET], fiz0, fiz1, fiz2, fiz3);
 
             addStat(stats->calculated_forces, 1);
             addStat(stats->num_neighs, numneighs);

--- a/src/clusterpair/force_lj.c
+++ b/src/clusterpair/force_lj.c
@@ -509,9 +509,6 @@ double computeForceLJ2xnnFullNeigh(
     MD_FLOAT cutforcesq          = param->cutforce * param->cutforce;
     MD_FLOAT sigma6              = param->sigma6;
     MD_FLOAT epsilon             = param->epsilon;
-    MD_SIMD_FLOAT cutforcesq_vec = simd_broadcast(cutforcesq);
-    MD_SIMD_FLOAT sigma6_vec     = simd_broadcast(sigma6);
-    MD_SIMD_FLOAT eps_vec        = simd_broadcast(epsilon);
     MD_SIMD_FLOAT c48_vec        = simd_broadcast(48.0);
     MD_SIMD_FLOAT c05_vec        = simd_broadcast(0.5);
 

--- a/src/clusterpair/main-stub.c
+++ b/src/clusterpair/main-stub.c
@@ -258,11 +258,11 @@ int main(int argc, const char* argv[])
     }
 
     for (int ci = 0; ci < niclusters; ++ci) {
-        int ci_sca_base = CI_SCALAR_BASE_INDEX(ci);
-        int ci_vec_base = CI_VECTOR_BASE_INDEX(ci);
-        MD_FLOAT* ci_x  = &atom->cl_x[ci_vec_base];
-        MD_FLOAT* ci_v  = &atom->cl_v[ci_vec_base];
-        int* ci_type    = &atom->cl_type[ci_sca_base];
+        int ci_sca_base   = CI_SCALAR_BASE_INDEX(ci);
+        int ci_vec_base   = CI_VECTOR_BASE_INDEX(ci);
+        MD_FLOAT* ci_x    = &atom->cl_x[ci_vec_base];
+        MD_FLOAT* ci_v    = &atom->cl_v[ci_vec_base];
+        int* ci_t         = &atom->cl_t[ci_sca_base];
 
         for (int cii = 0; cii < iclusters_natoms; ++cii) {
             ci_x[CL_X_OFFSET + cii] = (MD_FLOAT)(ci * iclusters_natoms + cii) * 0.00001;
@@ -271,7 +271,7 @@ int main(int argc, const char* argv[])
             ci_v[CL_X_OFFSET + cii] = 0.0;
             ci_v[CL_Y_OFFSET + cii] = 0.0;
             ci_v[CL_Z_OFFSET + cii] = 0.0;
-            ci_type[cii]            = rand() % atom->ntypes;
+            ci_t[cii]               = rand() % atom->ntypes;
             atom->Nlocal++;
         }
 

--- a/src/clusterpair/main-stub.c
+++ b/src/clusterpair/main-stub.c
@@ -258,11 +258,11 @@ int main(int argc, const char* argv[])
     }
 
     for (int ci = 0; ci < niclusters; ++ci) {
-        int ci_sca_base   = CI_SCALAR_BASE_INDEX(ci);
-        int ci_vec_base   = CI_VECTOR_BASE_INDEX(ci);
-        MD_FLOAT* ci_x    = &atom->cl_x[ci_vec_base];
-        MD_FLOAT* ci_v    = &atom->cl_v[ci_vec_base];
-        int* ci_t         = &atom->cl_t[ci_sca_base];
+        int ci_sca_base = CI_SCALAR_BASE_INDEX(ci);
+        int ci_vec_base = CI_VECTOR_BASE_INDEX(ci);
+        MD_FLOAT* ci_x  = &atom->cl_x[ci_vec_base];
+        MD_FLOAT* ci_v  = &atom->cl_v[ci_vec_base];
+        int* ci_t       = &atom->cl_t[ci_sca_base];
 
         for (int cii = 0; cii < iclusters_natoms; ++cii) {
             ci_x[CL_X_OFFSET + cii] = (MD_FLOAT)(ci * iclusters_natoms + cii) * 0.00001;
@@ -329,15 +329,27 @@ int main(int argc, const char* argv[])
         } else {
             if (param.half_neigh) {
                 if (VECTOR_WIDTH > CLUSTER_M * 2) {
-                    T_accum += computeForceLJ2xnnHalfNeigh(&param, atom, &neighbor, &stats);
+                    T_accum += computeForceLJ2xnnHalfNeigh(&param,
+                        atom,
+                        &neighbor,
+                        &stats);
                 } else {
-                    T_accum += computeForceLJ4xnHalfNeigh(&param, atom, &neighbor, &stats);
+                    T_accum += computeForceLJ4xnHalfNeigh(&param,
+                        atom,
+                        &neighbor,
+                        &stats);
                 }
             } else {
                 if (VECTOR_WIDTH > CLUSTER_M * 2) {
-                    T_accum += computeForceLJ2xnnFullNeigh(&param, atom, &neighbor, &stats);
+                    T_accum += computeForceLJ2xnnFullNeigh(&param,
+                        atom,
+                        &neighbor,
+                        &stats);
                 } else {
-                    T_accum += computeForceLJ4xnFullNeigh(&param, atom, &neighbor, &stats);
+                    T_accum += computeForceLJ4xnFullNeigh(&param,
+                        atom,
+                        &neighbor,
+                        &stats);
                 }
             }
         }

--- a/src/clusterpair/main.c
+++ b/src/clusterpair/main.c
@@ -272,7 +272,6 @@ int main(int argc, char** argv)
 #endif
 
         timer[FORCE] += computeForce(&param, &atom, &neighbor, &stats);
-
         finalIntegrate(&param, &atom);
 
         if (!((n + 1) % param.nstat) && (n + 1) < param.ntimes) {

--- a/src/clusterpair/main.c
+++ b/src/clusterpair/main.c
@@ -30,10 +30,9 @@
 #include <vtk.h>
 #include <xtc.h>
 
-extern void copyDataToCUDADevice(Atom*);
+extern void copyDataToCUDADevice(Atom*, Neighbor*);
 extern void copyDataFromCUDADevice(Atom*);
 extern void cudaDeviceFree(void);
-extern int isReneighboured;
 
 #define HLINE "------------------------------------------------------------------\n"
 
@@ -229,7 +228,7 @@ int main(int argc, char** argv)
 #endif
 
 #ifdef CUDA_TARGET
-    copyDataToCUDADevice(&atom);
+    copyDataToCUDADevice(&atom, &neighbor);
 #endif
 
     timer[FORCE] = computeForce(&param, &atom, &neighbor, &stats);
@@ -262,8 +261,7 @@ int main(int argc, char** argv)
             timer[NEIGH] += reneighbour(&param, &atom, &neighbor);
 
 #ifdef CUDA_TARGET
-            copyDataToCUDADevice(&atom);
-            isReneighboured = 1;
+            copyDataToCUDADevice(&atom, &neighbor);
 #endif
         }
 

--- a/src/clusterpair/neighbor.c
+++ b/src/clusterpair/neighbor.c
@@ -274,13 +274,13 @@ void buildNeighborCPU(Atom* atom, Neighbor* neighbor)
             unsigned int* neighptr_imask = &(
                 neighbor->neighbors_imask[ci * neighbor->maxneighs]);
             int n = 0, nmasked = 0;
-            int ibin          = atom->icluster_bin[ci];
-            int ci_vec_base   = CI_VECTOR_BASE_INDEX(ci);
-            MD_FLOAT* ci_x    = &atom->cl_x[ci_vec_base];
+            int ibin        = atom->icluster_bin[ci];
+            int ci_vec_base = CI_VECTOR_BASE_INDEX(ci);
+            MD_FLOAT* ci_x  = &atom->cl_x[ci_vec_base];
 
 #ifndef ONE_ATOM_TYPE
-            int ci_sca_base   = CI_SCALAR_BASE_INDEX(ci);
-            int* ci_t         = &atom->cl_t[ci_sca_base];
+            int ci_sca_base = CI_SCALAR_BASE_INDEX(ci);
+            int* ci_t       = &atom->cl_t[ci_sca_base];
 #endif
 
             MD_FLOAT ibb_xmin = atom->iclusters[ci].bbminx;
@@ -291,39 +291,39 @@ void buildNeighborCPU(Atom* atom, Neighbor* neighbor)
             MD_FLOAT ibb_zmax = atom->iclusters[ci].bbmaxz;
 
 #if defined(CLUSTERPAIR_KERNEL_2XNN)
-            MD_SIMD_FLOAT xi0_tmp        = simd_load_h_dual(&ci_x[CL_X_OFFSET + 0]);
-            MD_SIMD_FLOAT xi2_tmp        = simd_load_h_dual(&ci_x[CL_X_OFFSET + 2]);
-            MD_SIMD_FLOAT yi0_tmp        = simd_load_h_dual(&ci_x[CL_Y_OFFSET + 0]);
-            MD_SIMD_FLOAT yi2_tmp        = simd_load_h_dual(&ci_x[CL_Y_OFFSET + 2]);
-            MD_SIMD_FLOAT zi0_tmp        = simd_load_h_dual(&ci_x[CL_Z_OFFSET + 0]);
-            MD_SIMD_FLOAT zi2_tmp        = simd_load_h_dual(&ci_x[CL_Z_OFFSET + 2]);
+            MD_SIMD_FLOAT xi0_tmp = simd_load_h_dual(&ci_x[CL_X_OFFSET + 0]);
+            MD_SIMD_FLOAT xi2_tmp = simd_load_h_dual(&ci_x[CL_X_OFFSET + 2]);
+            MD_SIMD_FLOAT yi0_tmp = simd_load_h_dual(&ci_x[CL_Y_OFFSET + 0]);
+            MD_SIMD_FLOAT yi2_tmp = simd_load_h_dual(&ci_x[CL_Y_OFFSET + 2]);
+            MD_SIMD_FLOAT zi0_tmp = simd_load_h_dual(&ci_x[CL_Z_OFFSET + 0]);
+            MD_SIMD_FLOAT zi2_tmp = simd_load_h_dual(&ci_x[CL_Z_OFFSET + 2]);
 
 #ifndef ONE_ATOM_TYPE
-            MD_SIMD_INT tbase0           = simd_int_load_h_dual_scaled(&ci_t[0], atom->ntypes);
-            MD_SIMD_INT tbase2           = simd_int_load_h_dual_scaled(&ci_t[2], atom->ntypes);
+            MD_SIMD_INT tbase0 = simd_int_load_h_dual_scaled(&ci_t[0], atom->ntypes);
+            MD_SIMD_INT tbase2 = simd_int_load_h_dual_scaled(&ci_t[2], atom->ntypes);
 #else
             MD_SIMD_FLOAT cutneighsq_vec = simd_broadcast(cutneighsq);
 #endif
 
 #elif defined(CLUSTERPAIR_KERNEL_4XN)
-            MD_SIMD_FLOAT xi0_tmp        = simd_broadcast(ci_x[CL_X_OFFSET + 0]);
-            MD_SIMD_FLOAT xi1_tmp        = simd_broadcast(ci_x[CL_X_OFFSET + 1]);
-            MD_SIMD_FLOAT xi2_tmp        = simd_broadcast(ci_x[CL_X_OFFSET + 2]);
-            MD_SIMD_FLOAT xi3_tmp        = simd_broadcast(ci_x[CL_X_OFFSET + 3]);
-            MD_SIMD_FLOAT yi0_tmp        = simd_broadcast(ci_x[CL_Y_OFFSET + 0]);
-            MD_SIMD_FLOAT yi1_tmp        = simd_broadcast(ci_x[CL_Y_OFFSET + 1]);
-            MD_SIMD_FLOAT yi2_tmp        = simd_broadcast(ci_x[CL_Y_OFFSET + 2]);
-            MD_SIMD_FLOAT yi3_tmp        = simd_broadcast(ci_x[CL_Y_OFFSET + 3]);
-            MD_SIMD_FLOAT zi0_tmp        = simd_broadcast(ci_x[CL_Z_OFFSET + 0]);
-            MD_SIMD_FLOAT zi1_tmp        = simd_broadcast(ci_x[CL_Z_OFFSET + 1]);
-            MD_SIMD_FLOAT zi2_tmp        = simd_broadcast(ci_x[CL_Z_OFFSET + 2]);
-            MD_SIMD_FLOAT zi3_tmp        = simd_broadcast(ci_x[CL_Z_OFFSET + 3]);
+            MD_SIMD_FLOAT xi0_tmp = simd_broadcast(ci_x[CL_X_OFFSET + 0]);
+            MD_SIMD_FLOAT xi1_tmp = simd_broadcast(ci_x[CL_X_OFFSET + 1]);
+            MD_SIMD_FLOAT xi2_tmp = simd_broadcast(ci_x[CL_X_OFFSET + 2]);
+            MD_SIMD_FLOAT xi3_tmp = simd_broadcast(ci_x[CL_X_OFFSET + 3]);
+            MD_SIMD_FLOAT yi0_tmp = simd_broadcast(ci_x[CL_Y_OFFSET + 0]);
+            MD_SIMD_FLOAT yi1_tmp = simd_broadcast(ci_x[CL_Y_OFFSET + 1]);
+            MD_SIMD_FLOAT yi2_tmp = simd_broadcast(ci_x[CL_Y_OFFSET + 2]);
+            MD_SIMD_FLOAT yi3_tmp = simd_broadcast(ci_x[CL_Y_OFFSET + 3]);
+            MD_SIMD_FLOAT zi0_tmp = simd_broadcast(ci_x[CL_Z_OFFSET + 0]);
+            MD_SIMD_FLOAT zi1_tmp = simd_broadcast(ci_x[CL_Z_OFFSET + 1]);
+            MD_SIMD_FLOAT zi2_tmp = simd_broadcast(ci_x[CL_Z_OFFSET + 2]);
+            MD_SIMD_FLOAT zi3_tmp = simd_broadcast(ci_x[CL_Z_OFFSET + 3]);
 
 #ifndef ONE_ATOM_TYPE
-            MD_SIMD_INT tbase0           = simd_int_broadcast(ci_t[0] * atom->ntypes);
-            MD_SIMD_INT tbase1           = simd_int_broadcast(ci_t[1] * atom->ntypes);
-            MD_SIMD_INT tbase2           = simd_int_broadcast(ci_t[2] * atom->ntypes);
-            MD_SIMD_INT tbase3           = simd_int_broadcast(ci_t[3] * atom->ntypes);
+            MD_SIMD_INT tbase0    = simd_int_broadcast(ci_t[0] * atom->ntypes);
+            MD_SIMD_INT tbase1    = simd_int_broadcast(ci_t[1] * atom->ntypes);
+            MD_SIMD_INT tbase2    = simd_int_broadcast(ci_t[2] * atom->ntypes);
+            MD_SIMD_INT tbase3    = simd_int_broadcast(ci_t[3] * atom->ntypes);
 #else
             MD_SIMD_FLOAT cutneighsq_vec = simd_broadcast(cutneighsq);
 #endif
@@ -393,44 +393,54 @@ void buildNeighborCPU(Atom* atom, Neighbor* neighbor)
 
 #ifndef ONE_ATOM_TYPE
                                     int cj_sca_base = CJ_SCALAR_BASE_INDEX(cj);
-                                    int *cj_t       = &atom->cl_t[cj_sca_base];
+                                    int* cj_t       = &atom->cl_t[cj_sca_base];
 #endif
 
 #if defined(CLUSTERPAIR_KERNEL_2XNN)
 
-                                    MD_SIMD_FLOAT xj_tmp = simd_load_h_duplicate(&cj_x[CL_X_OFFSET]);
-                                    MD_SIMD_FLOAT yj_tmp = simd_load_h_duplicate(&cj_x[CL_Y_OFFSET]);
-                                    MD_SIMD_FLOAT zj_tmp = simd_load_h_duplicate(&cj_x[CL_Z_OFFSET]);
+                                    MD_SIMD_FLOAT xj_tmp = simd_load_h_duplicate(
+                                        &cj_x[CL_X_OFFSET]);
+                                    MD_SIMD_FLOAT yj_tmp = simd_load_h_duplicate(
+                                        &cj_x[CL_Y_OFFSET]);
+                                    MD_SIMD_FLOAT zj_tmp = simd_load_h_duplicate(
+                                        &cj_x[CL_Z_OFFSET]);
 
 #ifndef ONE_ATOM_TYPE
                                     MD_SIMD_INT tj_tmp = simd_int_load_h_duplicate(cj_t);
                                     MD_SIMD_INT tvec0  = simd_int_add(tbase0, tj_tmp);
                                     MD_SIMD_INT tvec2  = simd_int_add(tbase2, tj_tmp);
 
-                                    MD_SIMD_FLOAT cutneighsq0 = simd_gather(tvec0, atom->cutneighsq, sizeof(MD_FLOAT));
-                                    MD_SIMD_FLOAT cutneighsq2 = simd_gather(tvec2, atom->cutneighsq, sizeof(MD_FLOAT));
+                                    MD_SIMD_FLOAT cutneighsq0 = simd_gather(tvec0,
+                                        atom->cutneighsq,
+                                        sizeof(MD_FLOAT));
+                                    MD_SIMD_FLOAT cutneighsq2 = simd_gather(tvec2,
+                                        atom->cutneighsq,
+                                        sizeof(MD_FLOAT));
 #else
                                     MD_SIMD_FLOAT cutneighsq0 = cutneighsq_vec;
                                     MD_SIMD_FLOAT cutneighsq2 = cutneighsq_vec;
 #endif
 
-                                    MD_SIMD_FLOAT delx0  = xi0_tmp - xj_tmp;
-                                    MD_SIMD_FLOAT dely0  = yi0_tmp - yj_tmp;
-                                    MD_SIMD_FLOAT delz0  = zi0_tmp - zj_tmp;
-                                    MD_SIMD_FLOAT delx2  = xi2_tmp - xj_tmp;
-                                    MD_SIMD_FLOAT dely2  = yi2_tmp - yj_tmp;
-                                    MD_SIMD_FLOAT delz2  = zi2_tmp - zj_tmp;
-                                    MD_SIMD_FLOAT rsq0   = simd_fma(delx0,
+                                    MD_SIMD_FLOAT delx0 = xi0_tmp - xj_tmp;
+                                    MD_SIMD_FLOAT dely0 = yi0_tmp - yj_tmp;
+                                    MD_SIMD_FLOAT delz0 = zi0_tmp - zj_tmp;
+                                    MD_SIMD_FLOAT delx2 = xi2_tmp - xj_tmp;
+                                    MD_SIMD_FLOAT dely2 = yi2_tmp - yj_tmp;
+                                    MD_SIMD_FLOAT delz2 = zi2_tmp - zj_tmp;
+                                    MD_SIMD_FLOAT rsq0  = simd_fma(delx0,
                                         delx0,
                                         simd_fma(dely0, dely0, delz0 * delz0));
-                                    MD_SIMD_FLOAT rsq2   = simd_fma(delx2,
+                                    MD_SIMD_FLOAT rsq2  = simd_fma(delx2,
                                         delx2,
                                         simd_fma(dely2, dely2, delz2 * delz2));
 
-                                    MD_SIMD_MASK cutoff_mask0 = simd_mask_cond_lt(rsq0, cutneighsq0);
-                                    MD_SIMD_MASK cutoff_mask2 = simd_mask_cond_lt(rsq2, cutneighsq2);
+                                    MD_SIMD_MASK cutoff_mask0 = simd_mask_cond_lt(rsq0,
+                                        cutneighsq0);
+                                    MD_SIMD_MASK cutoff_mask2 = simd_mask_cond_lt(rsq2,
+                                        cutneighsq2);
 
-                                    if(simd_test_any(cutoff_mask0) || simd_test_any(cutoff_mask2)) {
+                                    if (simd_test_any(cutoff_mask0) ||
+                                        simd_test_any(cutoff_mask2)) {
                                         is_neighbor = 1;
                                     }
 
@@ -440,16 +450,24 @@ void buildNeighborCPU(Atom* atom, Neighbor* neighbor)
                                     MD_SIMD_FLOAT yj_tmp = simd_load(&cj_x[CL_Y_OFFSET]);
                                     MD_SIMD_FLOAT zj_tmp = simd_load(&cj_x[CL_Z_OFFSET]);
 #ifndef ONE_ATOM_TYPE
-                                    MD_SIMD_INT tj_tmp = simd_int_load(cj_t);
-                                    MD_SIMD_INT tvec0  = simd_int_add(tbase0, tj_tmp);
-                                    MD_SIMD_INT tvec1  = simd_int_add(tbase1, tj_tmp);
-                                    MD_SIMD_INT tvec2  = simd_int_add(tbase2, tj_tmp);
-                                    MD_SIMD_INT tvec3  = simd_int_add(tbase3, tj_tmp);
+                                    MD_SIMD_INT tj_tmp   = simd_int_load(cj_t);
+                                    MD_SIMD_INT tvec0    = simd_int_add(tbase0, tj_tmp);
+                                    MD_SIMD_INT tvec1    = simd_int_add(tbase1, tj_tmp);
+                                    MD_SIMD_INT tvec2    = simd_int_add(tbase2, tj_tmp);
+                                    MD_SIMD_INT tvec3    = simd_int_add(tbase3, tj_tmp);
 
-                                    MD_SIMD_FLOAT cutneighsq0 = simd_gather(tvec0, atom->cutneighsq, sizeof(MD_FLOAT));
-                                    MD_SIMD_FLOAT cutneighsq1 = simd_gather(tvec1, atom->cutneighsq, sizeof(MD_FLOAT));
-                                    MD_SIMD_FLOAT cutneighsq2 = simd_gather(tvec2, atom->cutneighsq, sizeof(MD_FLOAT));
-                                    MD_SIMD_FLOAT cutneighsq3 = simd_gather(tvec3, atom->cutneighsq, sizeof(MD_FLOAT));
+                                    MD_SIMD_FLOAT cutneighsq0 = simd_gather(tvec0,
+                                        atom->cutneighsq,
+                                        sizeof(MD_FLOAT));
+                                    MD_SIMD_FLOAT cutneighsq1 = simd_gather(tvec1,
+                                        atom->cutneighsq,
+                                        sizeof(MD_FLOAT));
+                                    MD_SIMD_FLOAT cutneighsq2 = simd_gather(tvec2,
+                                        atom->cutneighsq,
+                                        sizeof(MD_FLOAT));
+                                    MD_SIMD_FLOAT cutneighsq3 = simd_gather(tvec3,
+                                        atom->cutneighsq,
+                                        sizeof(MD_FLOAT));
 #else
                                     MD_SIMD_FLOAT cutneighsq0 = cutneighsq_vec;
                                     MD_SIMD_FLOAT cutneighsq1 = cutneighsq_vec;
@@ -457,18 +475,18 @@ void buildNeighborCPU(Atom* atom, Neighbor* neighbor)
                                     MD_SIMD_FLOAT cutneighsq3 = cutneighsq_vec;
 #endif
 
-                                    MD_SIMD_FLOAT delx0  = xi0_tmp - xj_tmp;
-                                    MD_SIMD_FLOAT dely0  = yi0_tmp - yj_tmp;
-                                    MD_SIMD_FLOAT delz0  = zi0_tmp - zj_tmp;
-                                    MD_SIMD_FLOAT delx1  = xi1_tmp - xj_tmp;
-                                    MD_SIMD_FLOAT dely1  = yi1_tmp - yj_tmp;
-                                    MD_SIMD_FLOAT delz1  = zi1_tmp - zj_tmp;
-                                    MD_SIMD_FLOAT delx2  = xi2_tmp - xj_tmp;
-                                    MD_SIMD_FLOAT dely2  = yi2_tmp - yj_tmp;
-                                    MD_SIMD_FLOAT delz2  = zi2_tmp - zj_tmp;
-                                    MD_SIMD_FLOAT delx3  = xi3_tmp - xj_tmp;
-                                    MD_SIMD_FLOAT dely3  = yi3_tmp - yj_tmp;
-                                    MD_SIMD_FLOAT delz3  = zi3_tmp - zj_tmp;
+                                    MD_SIMD_FLOAT delx0 = xi0_tmp - xj_tmp;
+                                    MD_SIMD_FLOAT dely0 = yi0_tmp - yj_tmp;
+                                    MD_SIMD_FLOAT delz0 = zi0_tmp - zj_tmp;
+                                    MD_SIMD_FLOAT delx1 = xi1_tmp - xj_tmp;
+                                    MD_SIMD_FLOAT dely1 = yi1_tmp - yj_tmp;
+                                    MD_SIMD_FLOAT delz1 = zi1_tmp - zj_tmp;
+                                    MD_SIMD_FLOAT delx2 = xi2_tmp - xj_tmp;
+                                    MD_SIMD_FLOAT dely2 = yi2_tmp - yj_tmp;
+                                    MD_SIMD_FLOAT delz2 = zi2_tmp - zj_tmp;
+                                    MD_SIMD_FLOAT delx3 = xi3_tmp - xj_tmp;
+                                    MD_SIMD_FLOAT dely3 = yi3_tmp - yj_tmp;
+                                    MD_SIMD_FLOAT delz3 = zi3_tmp - zj_tmp;
 
                                     MD_SIMD_FLOAT rsq0 = simd_fma(delx0,
                                         delx0,
@@ -483,13 +501,19 @@ void buildNeighborCPU(Atom* atom, Neighbor* neighbor)
                                         delx3,
                                         simd_fma(dely3, dely3, delz3 * delz3));
 
-                                    MD_SIMD_MASK cutoff_mask0 = simd_mask_cond_lt(rsq0, cutneighsq0);
-                                    MD_SIMD_MASK cutoff_mask1 = simd_mask_cond_lt(rsq1, cutneighsq1);
-                                    MD_SIMD_MASK cutoff_mask2 = simd_mask_cond_lt(rsq2, cutneighsq2);
-                                    MD_SIMD_MASK cutoff_mask3 = simd_mask_cond_lt(rsq3, cutneighsq3);
+                                    MD_SIMD_MASK cutoff_mask0 = simd_mask_cond_lt(rsq0,
+                                        cutneighsq0);
+                                    MD_SIMD_MASK cutoff_mask1 = simd_mask_cond_lt(rsq1,
+                                        cutneighsq1);
+                                    MD_SIMD_MASK cutoff_mask2 = simd_mask_cond_lt(rsq2,
+                                        cutneighsq2);
+                                    MD_SIMD_MASK cutoff_mask3 = simd_mask_cond_lt(rsq3,
+                                        cutneighsq3);
 
-                                    if (simd_test_any(cutoff_mask0) || simd_test_any(cutoff_mask1) ||
-                                        simd_test_any(cutoff_mask2) || simd_test_any(cutoff_mask3)) {
+                                    if (simd_test_any(cutoff_mask0) ||
+                                        simd_test_any(cutoff_mask1) ||
+                                        simd_test_any(cutoff_mask2) ||
+                                        simd_test_any(cutoff_mask3)) {
                                         is_neighbor = 1;
                                     }
 
@@ -498,21 +522,21 @@ void buildNeighborCPU(Atom* atom, Neighbor* neighbor)
                                     is_neighbor = 0;
                                     for (int cii = 0; cii < CLUSTER_M; cii++) {
                                         for (int cjj = 0; cjj < CLUSTER_N; cjj++) {
-                                            MD_FLOAT delx =
-                                                ci_x[CL_X_OFFSET + cii] - cj_x[CL_X_OFFSET + cjj];
-                                            MD_FLOAT dely =
-                                                ci_x[CL_Y_OFFSET + cii] - cj_x[CL_Y_OFFSET + cjj];
-                                            MD_FLOAT delz =
-                                                ci_x[CL_Z_OFFSET + cii] - cj_x[CL_Z_OFFSET + cjj];
+                                            MD_FLOAT delx = ci_x[CL_X_OFFSET + cii] -
+                                                            cj_x[CL_X_OFFSET + cjj];
+                                            MD_FLOAT dely = ci_x[CL_Y_OFFSET + cii] -
+                                                            cj_x[CL_Y_OFFSET + cjj];
+                                            MD_FLOAT delz = ci_x[CL_Z_OFFSET + cii] -
+                                                            cj_x[CL_Z_OFFSET + cjj];
 
-                                            if (delx * delx + dely * dely + delz * delz < cutneighsq) {
+                                            if (delx * delx + dely * dely + delz * delz <
+                                                cutneighsq) {
                                                 is_neighbor = 1;
                                             }
                                         }
                                     }
 
 #endif
-
                                 }
 
                                 if (is_neighbor) {
@@ -654,26 +678,26 @@ void pruneNeighbor(Parameter* param, Atom* atom, Neighbor* neighbor)
 
 #if defined(CLUSTERPAIR_KERNEL_2XNN)
         MD_SIMD_FLOAT cutneighsq_vec = simd_broadcast(cutsq);
-        MD_SIMD_FLOAT xi0_tmp = simd_load_h_dual(&ci_x[CL_X_OFFSET + 0]);
-        MD_SIMD_FLOAT xi2_tmp = simd_load_h_dual(&ci_x[CL_X_OFFSET + 2]);
-        MD_SIMD_FLOAT yi0_tmp = simd_load_h_dual(&ci_x[CL_Y_OFFSET + 0]);
-        MD_SIMD_FLOAT yi2_tmp = simd_load_h_dual(&ci_x[CL_Y_OFFSET + 2]);
-        MD_SIMD_FLOAT zi0_tmp = simd_load_h_dual(&ci_x[CL_Z_OFFSET + 0]);
-        MD_SIMD_FLOAT zi2_tmp = simd_load_h_dual(&ci_x[CL_Z_OFFSET + 2]);
+        MD_SIMD_FLOAT xi0_tmp        = simd_load_h_dual(&ci_x[CL_X_OFFSET + 0]);
+        MD_SIMD_FLOAT xi2_tmp        = simd_load_h_dual(&ci_x[CL_X_OFFSET + 2]);
+        MD_SIMD_FLOAT yi0_tmp        = simd_load_h_dual(&ci_x[CL_Y_OFFSET + 0]);
+        MD_SIMD_FLOAT yi2_tmp        = simd_load_h_dual(&ci_x[CL_Y_OFFSET + 2]);
+        MD_SIMD_FLOAT zi0_tmp        = simd_load_h_dual(&ci_x[CL_Z_OFFSET + 0]);
+        MD_SIMD_FLOAT zi2_tmp        = simd_load_h_dual(&ci_x[CL_Z_OFFSET + 2]);
 #elif defined(CLUSTERPAIR_KERNEL_4XN)
         MD_SIMD_FLOAT cutneighsq_vec = simd_broadcast(cutsq);
-        MD_SIMD_FLOAT xi0_tmp = simd_broadcast(ci_x[CL_X_OFFSET + 0]);
-        MD_SIMD_FLOAT xi1_tmp = simd_broadcast(ci_x[CL_X_OFFSET + 1]);
-        MD_SIMD_FLOAT xi2_tmp = simd_broadcast(ci_x[CL_X_OFFSET + 2]);
-        MD_SIMD_FLOAT xi3_tmp = simd_broadcast(ci_x[CL_X_OFFSET + 3]);
-        MD_SIMD_FLOAT yi0_tmp = simd_broadcast(ci_x[CL_Y_OFFSET + 0]);
-        MD_SIMD_FLOAT yi1_tmp = simd_broadcast(ci_x[CL_Y_OFFSET + 1]);
-        MD_SIMD_FLOAT yi2_tmp = simd_broadcast(ci_x[CL_Y_OFFSET + 2]);
-        MD_SIMD_FLOAT yi3_tmp = simd_broadcast(ci_x[CL_Y_OFFSET + 3]);
-        MD_SIMD_FLOAT zi0_tmp = simd_broadcast(ci_x[CL_Z_OFFSET + 0]);
-        MD_SIMD_FLOAT zi1_tmp = simd_broadcast(ci_x[CL_Z_OFFSET + 1]);
-        MD_SIMD_FLOAT zi2_tmp = simd_broadcast(ci_x[CL_Z_OFFSET + 2]);
-        MD_SIMD_FLOAT zi3_tmp = simd_broadcast(ci_x[CL_Z_OFFSET + 3]);
+        MD_SIMD_FLOAT xi0_tmp        = simd_broadcast(ci_x[CL_X_OFFSET + 0]);
+        MD_SIMD_FLOAT xi1_tmp        = simd_broadcast(ci_x[CL_X_OFFSET + 1]);
+        MD_SIMD_FLOAT xi2_tmp        = simd_broadcast(ci_x[CL_X_OFFSET + 2]);
+        MD_SIMD_FLOAT xi3_tmp        = simd_broadcast(ci_x[CL_X_OFFSET + 3]);
+        MD_SIMD_FLOAT yi0_tmp        = simd_broadcast(ci_x[CL_Y_OFFSET + 0]);
+        MD_SIMD_FLOAT yi1_tmp        = simd_broadcast(ci_x[CL_Y_OFFSET + 1]);
+        MD_SIMD_FLOAT yi2_tmp        = simd_broadcast(ci_x[CL_Y_OFFSET + 2]);
+        MD_SIMD_FLOAT yi3_tmp        = simd_broadcast(ci_x[CL_Y_OFFSET + 3]);
+        MD_SIMD_FLOAT zi0_tmp        = simd_broadcast(ci_x[CL_Z_OFFSET + 0]);
+        MD_SIMD_FLOAT zi1_tmp        = simd_broadcast(ci_x[CL_Z_OFFSET + 1]);
+        MD_SIMD_FLOAT zi2_tmp        = simd_broadcast(ci_x[CL_Z_OFFSET + 2]);
+        MD_SIMD_FLOAT zi3_tmp        = simd_broadcast(ci_x[CL_Z_OFFSET + 3]);
 #endif
 
         // Remove dummy clusters if necessary
@@ -695,23 +719,23 @@ void pruneNeighbor(Parameter* param, Atom* atom, Neighbor* neighbor)
             MD_SIMD_FLOAT yj_tmp = simd_load_h_duplicate(&cj_x[CL_Y_OFFSET]);
             MD_SIMD_FLOAT zj_tmp = simd_load_h_duplicate(&cj_x[CL_Z_OFFSET]);
 
-            MD_SIMD_FLOAT delx0  = xi0_tmp - xj_tmp;
-            MD_SIMD_FLOAT dely0  = yi0_tmp - yj_tmp;
-            MD_SIMD_FLOAT delz0  = zi0_tmp - zj_tmp;
-            MD_SIMD_FLOAT delx2  = xi2_tmp - xj_tmp;
-            MD_SIMD_FLOAT dely2  = yi2_tmp - yj_tmp;
-            MD_SIMD_FLOAT delz2  = zi2_tmp - zj_tmp;
-            MD_SIMD_FLOAT rsq0   = simd_fma(delx0,
+            MD_SIMD_FLOAT delx0 = xi0_tmp - xj_tmp;
+            MD_SIMD_FLOAT dely0 = yi0_tmp - yj_tmp;
+            MD_SIMD_FLOAT delz0 = zi0_tmp - zj_tmp;
+            MD_SIMD_FLOAT delx2 = xi2_tmp - xj_tmp;
+            MD_SIMD_FLOAT dely2 = yi2_tmp - yj_tmp;
+            MD_SIMD_FLOAT delz2 = zi2_tmp - zj_tmp;
+            MD_SIMD_FLOAT rsq0  = simd_fma(delx0,
                 delx0,
                 simd_fma(dely0, dely0, delz0 * delz0));
-            MD_SIMD_FLOAT rsq2   = simd_fma(delx2,
+            MD_SIMD_FLOAT rsq2  = simd_fma(delx2,
                 delx2,
                 simd_fma(dely2, dely2, delz2 * delz2));
 
             MD_SIMD_MASK cutoff_mask0 = simd_mask_cond_lt(rsq0, cutneighsq_vec);
             MD_SIMD_MASK cutoff_mask2 = simd_mask_cond_lt(rsq2, cutneighsq_vec);
 
-            if(simd_test_any(cutoff_mask0) || simd_test_any(cutoff_mask2)) {
+            if (simd_test_any(cutoff_mask0) || simd_test_any(cutoff_mask2)) {
                 atom_dist_in_range = 1;
             }
 
@@ -721,18 +745,18 @@ void pruneNeighbor(Parameter* param, Atom* atom, Neighbor* neighbor)
             MD_SIMD_FLOAT yj_tmp = simd_load(&cj_x[CL_Y_OFFSET]);
             MD_SIMD_FLOAT zj_tmp = simd_load(&cj_x[CL_Z_OFFSET]);
 
-            MD_SIMD_FLOAT delx0  = xi0_tmp - xj_tmp;
-            MD_SIMD_FLOAT dely0  = yi0_tmp - yj_tmp;
-            MD_SIMD_FLOAT delz0  = zi0_tmp - zj_tmp;
-            MD_SIMD_FLOAT delx1  = xi1_tmp - xj_tmp;
-            MD_SIMD_FLOAT dely1  = yi1_tmp - yj_tmp;
-            MD_SIMD_FLOAT delz1  = zi1_tmp - zj_tmp;
-            MD_SIMD_FLOAT delx2  = xi2_tmp - xj_tmp;
-            MD_SIMD_FLOAT dely2  = yi2_tmp - yj_tmp;
-            MD_SIMD_FLOAT delz2  = zi2_tmp - zj_tmp;
-            MD_SIMD_FLOAT delx3  = xi3_tmp - xj_tmp;
-            MD_SIMD_FLOAT dely3  = yi3_tmp - yj_tmp;
-            MD_SIMD_FLOAT delz3  = zi3_tmp - zj_tmp;
+            MD_SIMD_FLOAT delx0 = xi0_tmp - xj_tmp;
+            MD_SIMD_FLOAT dely0 = yi0_tmp - yj_tmp;
+            MD_SIMD_FLOAT delz0 = zi0_tmp - zj_tmp;
+            MD_SIMD_FLOAT delx1 = xi1_tmp - xj_tmp;
+            MD_SIMD_FLOAT dely1 = yi1_tmp - yj_tmp;
+            MD_SIMD_FLOAT delz1 = zi1_tmp - zj_tmp;
+            MD_SIMD_FLOAT delx2 = xi2_tmp - xj_tmp;
+            MD_SIMD_FLOAT dely2 = yi2_tmp - yj_tmp;
+            MD_SIMD_FLOAT delz2 = zi2_tmp - zj_tmp;
+            MD_SIMD_FLOAT delx3 = xi3_tmp - xj_tmp;
+            MD_SIMD_FLOAT dely3 = yi3_tmp - yj_tmp;
+            MD_SIMD_FLOAT delz3 = zi3_tmp - zj_tmp;
 
             MD_SIMD_FLOAT rsq0 = simd_fma(delx0,
                 delx0,
@@ -1001,7 +1025,7 @@ void buildClusters(Atom* atom)
                     ci_x[CL_X_OFFSET + cii] = INFINITY;
                     ci_x[CL_Y_OFFSET + cii] = INFINITY;
                     ci_x[CL_Z_OFFSET + cii] = INFINITY;
-                    ci_t[cii] = 0;
+                    ci_t[cii]               = 0;
                 }
 
                 ac++;

--- a/src/clusterpair/neighbor.c
+++ b/src/clusterpair/neighbor.c
@@ -299,9 +299,8 @@ void buildNeighborCPU(Atom* atom, Neighbor* neighbor)
             MD_SIMD_FLOAT zi2_tmp        = simd_load_h_dual(&ci_x[CL_Z_OFFSET + 2]);
 
 #ifndef ONE_ATOM_TYPE
-            MD_SIMD_INT ntypes_vec       = simd_int_broadcast(atom->ntypes);
-            MD_SIMD_INT tbase0           = simd_int_load_h_dual(&ci_t[0]) * ntypes_vec;
-            MD_SIMD_INT tbase2           = simd_int_load_h_dual(&ci_t[2]) * ntypes_vec;
+            MD_SIMD_INT tbase0           = simd_int_load_h_dual_scaled(&ci_t[0], atom->ntypes);
+            MD_SIMD_INT tbase2           = simd_int_load_h_dual_scaled(&ci_t[2], atom->ntypes);
 #else
             MD_SIMD_FLOAT cutneighsq_vec = simd_broadcast(cutneighsq);
 #endif
@@ -321,11 +320,10 @@ void buildNeighborCPU(Atom* atom, Neighbor* neighbor)
             MD_SIMD_FLOAT zi3_tmp        = simd_broadcast(ci_x[CL_Z_OFFSET + 3]);
 
 #ifndef ONE_ATOM_TYPE
-            MD_SIMD_INT ntypes_vec       = simd_int_broadcast(atom->ntypes);
-            MD_SIMD_INT tbase0           = simd_int_broadcast(ci_t[0]) * ntypes_vec;
-            MD_SIMD_INT tbase1           = simd_int_broadcast(ci_t[1]) * ntypes_vec;
-            MD_SIMD_INT tbase2           = simd_int_broadcast(ci_t[2]) * ntypes_vec;
-            MD_SIMD_INT tbase3           = simd_int_broadcast(ci_t[3]) * ntypes_vec;
+            MD_SIMD_INT tbase0           = simd_int_broadcast(ci_t[0] * atom->ntypes);
+            MD_SIMD_INT tbase1           = simd_int_broadcast(ci_t[1] * atom->ntypes);
+            MD_SIMD_INT tbase2           = simd_int_broadcast(ci_t[2] * atom->ntypes);
+            MD_SIMD_INT tbase3           = simd_int_broadcast(ci_t[3] * atom->ntypes);
 #else
             MD_SIMD_FLOAT cutneighsq_vec = simd_broadcast(cutneighsq);
 #endif
@@ -406,8 +404,8 @@ void buildNeighborCPU(Atom* atom, Neighbor* neighbor)
 
 #ifndef ONE_ATOM_TYPE
                                     MD_SIMD_INT tj_tmp = simd_int_load_h_duplicate(cj_t);
-                                    MD_SIMD_INT tvec0 = tbase0 + tj_tmp;
-                                    MD_SIMD_INT tvec2 = tbase2 + tj_tmp;
+                                    MD_SIMD_INT tvec0  = simd_int_add(tbase0, tj_tmp);
+                                    MD_SIMD_INT tvec2  = simd_int_add(tbase2, tj_tmp);
 
                                     MD_SIMD_FLOAT cutneighsq0 = simd_gather(tvec0, atom->cutneighsq, sizeof(MD_FLOAT));
                                     MD_SIMD_FLOAT cutneighsq2 = simd_gather(tvec2, atom->cutneighsq, sizeof(MD_FLOAT));
@@ -443,10 +441,10 @@ void buildNeighborCPU(Atom* atom, Neighbor* neighbor)
                                     MD_SIMD_FLOAT zj_tmp = simd_load(&cj_x[CL_Z_OFFSET]);
 #ifndef ONE_ATOM_TYPE
                                     MD_SIMD_INT tj_tmp = simd_int_load(cj_t);
-                                    MD_SIMD_INT tvec0  = tbase0 + tj_tmp;
-                                    MD_SIMD_INT tvec1  = tbase1 + tj_tmp;
-                                    MD_SIMD_INT tvec2  = tbase2 + tj_tmp;
-                                    MD_SIMD_INT tvec3  = tbase3 + tj_tmp;
+                                    MD_SIMD_INT tvec0  = simd_int_add(tbase0, tj_tmp);
+                                    MD_SIMD_INT tvec1  = simd_int_add(tbase1, tj_tmp);
+                                    MD_SIMD_INT tvec2  = simd_int_add(tbase2, tj_tmp);
+                                    MD_SIMD_INT tvec3  = simd_int_add(tbase3, tj_tmp);
 
                                     MD_SIMD_FLOAT cutneighsq0 = simd_gather(tvec0, atom->cutneighsq, sizeof(MD_FLOAT));
                                     MD_SIMD_FLOAT cutneighsq1 = simd_gather(tvec1, atom->cutneighsq, sizeof(MD_FLOAT));

--- a/src/clusterpair/neighbor.c
+++ b/src/clusterpair/neighbor.c
@@ -421,18 +421,22 @@ void buildNeighborCPU(Atom* atom, Neighbor* neighbor)
                                     MD_SIMD_FLOAT cutneighsq2 = cutneighsq_vec;
 #endif
 
-                                    MD_SIMD_FLOAT delx0 = xi0_tmp - xj_tmp;
-                                    MD_SIMD_FLOAT dely0 = yi0_tmp - yj_tmp;
-                                    MD_SIMD_FLOAT delz0 = zi0_tmp - zj_tmp;
-                                    MD_SIMD_FLOAT delx2 = xi2_tmp - xj_tmp;
-                                    MD_SIMD_FLOAT dely2 = yi2_tmp - yj_tmp;
-                                    MD_SIMD_FLOAT delz2 = zi2_tmp - zj_tmp;
+                                    MD_SIMD_FLOAT delx0 = simd_real_sub(xi0_tmp, xj_tmp);
+                                    MD_SIMD_FLOAT dely0 = simd_real_sub(yi0_tmp, yj_tmp);
+                                    MD_SIMD_FLOAT delz0 = simd_real_sub(zi0_tmp, zj_tmp);
+                                    MD_SIMD_FLOAT delx2 = simd_real_sub(xi2_tmp, xj_tmp);
+                                    MD_SIMD_FLOAT dely2 = simd_real_sub(yi2_tmp, yj_tmp);
+                                    MD_SIMD_FLOAT delz2 = simd_real_sub(zi2_tmp, zj_tmp);
                                     MD_SIMD_FLOAT rsq0  = simd_real_fma(delx0,
                                         delx0,
-                                        simd_real_fma(dely0, dely0, delz0 * delz0));
+                                        simd_real_fma(dely0,
+                                            dely0,
+                                            simd_real_mul(delz0, delz0)));
                                     MD_SIMD_FLOAT rsq2  = simd_real_fma(delx2,
                                         delx2,
-                                        simd_real_fma(dely2, dely2, delz2 * delz2));
+                                        simd_real_fma(dely2,
+                                            dely2,
+                                            simd_real_mul(delz2, delz2)));
 
                                     MD_SIMD_MASK cutoff_mask0 = simd_mask_cond_lt(rsq0,
                                         cutneighsq0);
@@ -478,31 +482,39 @@ void buildNeighborCPU(Atom* atom, Neighbor* neighbor)
                                     MD_SIMD_FLOAT cutneighsq3 = cutneighsq_vec;
 #endif
 
-                                    MD_SIMD_FLOAT delx0 = xi0_tmp - xj_tmp;
-                                    MD_SIMD_FLOAT dely0 = yi0_tmp - yj_tmp;
-                                    MD_SIMD_FLOAT delz0 = zi0_tmp - zj_tmp;
-                                    MD_SIMD_FLOAT delx1 = xi1_tmp - xj_tmp;
-                                    MD_SIMD_FLOAT dely1 = yi1_tmp - yj_tmp;
-                                    MD_SIMD_FLOAT delz1 = zi1_tmp - zj_tmp;
-                                    MD_SIMD_FLOAT delx2 = xi2_tmp - xj_tmp;
-                                    MD_SIMD_FLOAT dely2 = yi2_tmp - yj_tmp;
-                                    MD_SIMD_FLOAT delz2 = zi2_tmp - zj_tmp;
-                                    MD_SIMD_FLOAT delx3 = xi3_tmp - xj_tmp;
-                                    MD_SIMD_FLOAT dely3 = yi3_tmp - yj_tmp;
-                                    MD_SIMD_FLOAT delz3 = zi3_tmp - zj_tmp;
+                                    MD_SIMD_FLOAT delx0 = simd_real_sub(xi0_tmp, xj_tmp);
+                                    MD_SIMD_FLOAT dely0 = simd_real_sub(yi0_tmp, yj_tmp);
+                                    MD_SIMD_FLOAT delz0 = simd_real_sub(zi0_tmp, zj_tmp);
+                                    MD_SIMD_FLOAT delx1 = simd_real_sub(xi1_tmp, xj_tmp);
+                                    MD_SIMD_FLOAT dely1 = simd_real_sub(yi1_tmp, yj_tmp);
+                                    MD_SIMD_FLOAT delz1 = simd_real_sub(zi1_tmp, zj_tmp);
+                                    MD_SIMD_FLOAT delx2 = simd_real_sub(xi2_tmp, xj_tmp);
+                                    MD_SIMD_FLOAT dely2 = simd_real_sub(yi2_tmp, yj_tmp);
+                                    MD_SIMD_FLOAT delz2 = simd_real_sub(zi2_tmp, zj_tmp);
+                                    MD_SIMD_FLOAT delx3 = simd_real_sub(xi3_tmp, xj_tmp);
+                                    MD_SIMD_FLOAT dely3 = simd_real_sub(yi3_tmp, yj_tmp);
+                                    MD_SIMD_FLOAT delz3 = simd_real_sub(zi3_tmp, zj_tmp);
 
                                     MD_SIMD_FLOAT rsq0 = simd_real_fma(delx0,
                                         delx0,
-                                        simd_real_fma(dely0, dely0, delz0 * delz0));
+                                        simd_real_fma(dely0,
+                                            dely0,
+                                            simd_real_mul(delz0, delz0)));
                                     MD_SIMD_FLOAT rsq1 = simd_real_fma(delx1,
                                         delx1,
-                                        simd_real_fma(dely1, dely1, delz1 * delz1));
+                                        simd_real_fma(dely1,
+                                            dely1,
+                                            simd_real_mul(delz1, delz1)));
                                     MD_SIMD_FLOAT rsq2 = simd_real_fma(delx2,
                                         delx2,
-                                        simd_real_fma(dely2, dely2, delz2 * delz2));
+                                        simd_real_fma(dely2,
+                                            dely2,
+                                            simd_real_mul(delz2, delz2)));
                                     MD_SIMD_FLOAT rsq3 = simd_real_fma(delx3,
                                         delx3,
-                                        simd_real_fma(dely3, dely3, delz3 * delz3));
+                                        simd_real_fma(dely3,
+                                            dely3,
+                                            simd_real_mul(delz3, delz3)));
 
                                     MD_SIMD_MASK cutoff_mask0 = simd_mask_cond_lt(rsq0,
                                         cutneighsq0);

--- a/src/clusterpair/neighbor.c
+++ b/src/clusterpair/neighbor.c
@@ -275,10 +275,13 @@ void buildNeighborCPU(Atom* atom, Neighbor* neighbor)
                 neighbor->neighbors_imask[ci * neighbor->maxneighs]);
             int n = 0, nmasked = 0;
             int ibin          = atom->icluster_bin[ci];
-            int ci_sca_base   = CI_SCALAR_BASE_INDEX(ci);
             int ci_vec_base   = CI_VECTOR_BASE_INDEX(ci);
             MD_FLOAT* ci_x    = &atom->cl_x[ci_vec_base];
+
+#ifndef ONE_ATOM_TYPE
+            int ci_sca_base   = CI_SCALAR_BASE_INDEX(ci);
             int* ci_t         = &atom->cl_t[ci_sca_base];
+#endif
 
             MD_FLOAT ibb_xmin = atom->iclusters[ci].bbminx;
             MD_FLOAT ibb_xmax = atom->iclusters[ci].bbmaxx;
@@ -294,6 +297,7 @@ void buildNeighborCPU(Atom* atom, Neighbor* neighbor)
             MD_SIMD_FLOAT yi2_tmp        = simd_load_h_dual(&ci_x[CL_Y_OFFSET + 2]);
             MD_SIMD_FLOAT zi0_tmp        = simd_load_h_dual(&ci_x[CL_Z_OFFSET + 0]);
             MD_SIMD_FLOAT zi2_tmp        = simd_load_h_dual(&ci_x[CL_Z_OFFSET + 2]);
+
 #ifndef ONE_ATOM_TYPE
             MD_SIMD_INT ntypes_vec       = simd_int_broadcast(atom->ntypes);
             MD_SIMD_INT tbase0           = simd_int_load_h_dual(&ci_t[0]) * ntypes_vec;
@@ -315,6 +319,7 @@ void buildNeighborCPU(Atom* atom, Neighbor* neighbor)
             MD_SIMD_FLOAT zi1_tmp        = simd_broadcast(ci_x[CL_Z_OFFSET + 1]);
             MD_SIMD_FLOAT zi2_tmp        = simd_broadcast(ci_x[CL_Z_OFFSET + 2]);
             MD_SIMD_FLOAT zi3_tmp        = simd_broadcast(ci_x[CL_Z_OFFSET + 3]);
+
 #ifndef ONE_ATOM_TYPE
             MD_SIMD_INT ntypes_vec       = simd_int_broadcast(atom->ntypes);
             MD_SIMD_INT tbase0           = simd_int_broadcast(ci_t[0]) * ntypes_vec;
@@ -385,10 +390,13 @@ void buildNeighborCPU(Atom* atom, Neighbor* neighbor)
                                 int is_neighbor = (d_bb_sq < rbb_sq) ? 1 : 0;
 
                                 if (!is_neighbor) {
-                                    int cj_sca_base = CJ_SCALAR_BASE_INDEX(cj);
                                     int cj_vec_base = CJ_VECTOR_BASE_INDEX(cj);
                                     MD_FLOAT* cj_x  = &atom->cl_x[cj_vec_base];
+
+#ifndef ONE_ATOM_TYPE
+                                    int cj_sca_base = CJ_SCALAR_BASE_INDEX(cj);
                                     int *cj_t       = &atom->cl_t[cj_sca_base];
+#endif
 
 #if defined(CLUSTERPAIR_KERNEL_2XNN)
 
@@ -398,7 +406,6 @@ void buildNeighborCPU(Atom* atom, Neighbor* neighbor)
 
 #ifndef ONE_ATOM_TYPE
                                     MD_SIMD_INT tj_tmp = simd_int_load_h_duplicate(cj_t);
-
                                     MD_SIMD_INT tvec0 = tbase0 + tj_tmp;
                                     MD_SIMD_INT tvec2 = tbase2 + tj_tmp;
 
@@ -435,12 +442,11 @@ void buildNeighborCPU(Atom* atom, Neighbor* neighbor)
                                     MD_SIMD_FLOAT yj_tmp = simd_load(&cj_x[CL_Y_OFFSET]);
                                     MD_SIMD_FLOAT zj_tmp = simd_load(&cj_x[CL_Z_OFFSET]);
 #ifndef ONE_ATOM_TYPE
-                                    MD_SIMD_INT tj_tmp   = simd_int_load(cj_t);
-
-                                    MD_SIMD_INT tvec0 = tbase0 + tj_tmp;
-                                    MD_SIMD_INT tvec1 = tbase1 + tj_tmp;
-                                    MD_SIMD_INT tvec2 = tbase2 + tj_tmp;
-                                    MD_SIMD_INT tvec3 = tbase3 + tj_tmp;
+                                    MD_SIMD_INT tj_tmp = simd_int_load(cj_t);
+                                    MD_SIMD_INT tvec0  = tbase0 + tj_tmp;
+                                    MD_SIMD_INT tvec1  = tbase1 + tj_tmp;
+                                    MD_SIMD_INT tvec2  = tbase2 + tj_tmp;
+                                    MD_SIMD_INT tvec3  = tbase3 + tj_tmp;
 
                                     MD_SIMD_FLOAT cutneighsq0 = simd_gather(tvec0, atom->cutneighsq, sizeof(MD_FLOAT));
                                     MD_SIMD_FLOAT cutneighsq1 = simd_gather(tvec1, atom->cutneighsq, sizeof(MD_FLOAT));

--- a/src/clusterpair/neighbor.c
+++ b/src/clusterpair/neighbor.c
@@ -12,6 +12,7 @@
 #include <force.h>
 #include <neighbor.h>
 #include <parameter.h>
+#include <simd.h>
 #include <util.h>
 
 #define SMALL  1.0e-6
@@ -195,27 +196,6 @@ MD_FLOAT getBoundingBoxDistanceSq(Atom* atom, int ci, int cj)
     return d2;
 }
 
-int atomDistanceInRange(Atom* atom, int ci, int cj, MD_FLOAT rsq)
-{
-    int ci_vec_base = CI_VECTOR_BASE_INDEX(ci);
-    int cj_vec_base = CJ_VECTOR_BASE_INDEX(cj);
-    MD_FLOAT* ci_x  = &atom->cl_x[ci_vec_base];
-    MD_FLOAT* cj_x  = &atom->cl_x[cj_vec_base];
-
-    for (int cii = 0; cii < atom->iclusters[ci].natoms; cii++) {
-        for (int cjj = 0; cjj < atom->jclusters[cj].natoms; cjj++) {
-            MD_FLOAT delx = ci_x[CL_X_OFFSET + cii] - cj_x[CL_X_OFFSET + cjj];
-            MD_FLOAT dely = ci_x[CL_Y_OFFSET + cii] - cj_x[CL_Y_OFFSET + cjj];
-            MD_FLOAT delz = ci_x[CL_Z_OFFSET + cii] - cj_x[CL_Z_OFFSET + cjj];
-            if (delx * delx + dely * dely + delz * delz < rsq) {
-                return 1;
-            }
-        }
-    }
-
-    return 0;
-}
-
 /* Returns a diagonal or off-diagonal interaction mask for plain C lists */
 static unsigned int get_imask(int rdiag, int ci, int cj)
 {
@@ -295,12 +275,42 @@ void buildNeighborCPU(Atom* atom, Neighbor* neighbor)
                 neighbor->neighbors_imask[ci * neighbor->maxneighs]);
             int n = 0, nmasked = 0;
             int ibin          = atom->icluster_bin[ci];
+            int ci_vec_base   = CI_VECTOR_BASE_INDEX(ci);
+            MD_FLOAT* ci_x    = &atom->cl_x[ci_vec_base];
             MD_FLOAT ibb_xmin = atom->iclusters[ci].bbminx;
             MD_FLOAT ibb_xmax = atom->iclusters[ci].bbmaxx;
             MD_FLOAT ibb_ymin = atom->iclusters[ci].bbminy;
             MD_FLOAT ibb_ymax = atom->iclusters[ci].bbmaxy;
             MD_FLOAT ibb_zmin = atom->iclusters[ci].bbminz;
             MD_FLOAT ibb_zmax = atom->iclusters[ci].bbmaxz;
+
+#if !defined(USE_REFERENCE_VERSION) && VECTOR_WIDTH > CLUSTER_M * 2
+            // Simd2xNN
+            MD_SIMD_FLOAT rsq_vec = simd_broadcast(cutneighsq);
+            MD_SIMD_FLOAT xi0_tmp = simd_load_h_dual(&ci_x[CL_X_OFFSET + 0]);
+            MD_SIMD_FLOAT xi2_tmp = simd_load_h_dual(&ci_x[CL_X_OFFSET + 2]);
+            MD_SIMD_FLOAT yi0_tmp = simd_load_h_dual(&ci_x[CL_Y_OFFSET + 0]);
+            MD_SIMD_FLOAT yi2_tmp = simd_load_h_dual(&ci_x[CL_Y_OFFSET + 2]);
+            MD_SIMD_FLOAT zi0_tmp = simd_load_h_dual(&ci_x[CL_Z_OFFSET + 0]);
+            MD_SIMD_FLOAT zi2_tmp = simd_load_h_dual(&ci_x[CL_Z_OFFSET + 2]);
+
+#elif !defined(USE_REFERENCE_VERSION) && VECTOR_WIDTH <= CLUSTER_M * 2
+            // Simd4xN
+            MD_SIMD_FLOAT rsq_vec = simd_broadcast(cutneighsq);
+            MD_SIMD_FLOAT xi0_tmp = simd_broadcast(ci_x[CL_X_OFFSET + 0]);
+            MD_SIMD_FLOAT xi1_tmp = simd_broadcast(ci_x[CL_X_OFFSET + 1]);
+            MD_SIMD_FLOAT xi2_tmp = simd_broadcast(ci_x[CL_X_OFFSET + 2]);
+            MD_SIMD_FLOAT xi3_tmp = simd_broadcast(ci_x[CL_X_OFFSET + 3]);
+            MD_SIMD_FLOAT yi0_tmp = simd_broadcast(ci_x[CL_Y_OFFSET + 0]);
+            MD_SIMD_FLOAT yi1_tmp = simd_broadcast(ci_x[CL_Y_OFFSET + 1]);
+            MD_SIMD_FLOAT yi2_tmp = simd_broadcast(ci_x[CL_Y_OFFSET + 2]);
+            MD_SIMD_FLOAT yi3_tmp = simd_broadcast(ci_x[CL_Y_OFFSET + 3]);
+            MD_SIMD_FLOAT zi0_tmp = simd_broadcast(ci_x[CL_Z_OFFSET + 0]);
+            MD_SIMD_FLOAT zi1_tmp = simd_broadcast(ci_x[CL_Z_OFFSET + 1]);
+            MD_SIMD_FLOAT zi2_tmp = simd_broadcast(ci_x[CL_Z_OFFSET + 2]);
+            MD_SIMD_FLOAT zi3_tmp = simd_broadcast(ci_x[CL_Z_OFFSET + 3]);
+
+#endif
 
             for (int k = 0; k < nstencil; k++) {
                 int jbin     = ibin + stencil[k];
@@ -357,8 +367,99 @@ void buildNeighborCPU(Atom* atom, Neighbor* neighbor)
                             d_bb_sq += dm0 * dm0;
 
                             if (d_bb_sq < cutneighsq) {
-                                if (d_bb_sq < rbb_sq ||
-                                    atomDistanceInRange(atom, ci, cj, cutneighsq)) {
+                                int is_neighbor = (d_bb_sq < rbb_sq) ? 1 : 0;
+
+                                if (!is_neighbor) {
+                                    int cj_vec_base = CJ_VECTOR_BASE_INDEX(cj);
+                                    MD_FLOAT* cj_x  = &atom->cl_x[cj_vec_base];
+
+#if !defined(USE_REFERENCE_VERSION) && VECTOR_WIDTH > CLUSTER_M * 2
+                                    MD_SIMD_FLOAT xj_tmp = simd_load_h_duplicate(&cj_x[CL_X_OFFSET]);
+                                    MD_SIMD_FLOAT yj_tmp = simd_load_h_duplicate(&cj_x[CL_Y_OFFSET]);
+                                    MD_SIMD_FLOAT zj_tmp = simd_load_h_duplicate(&cj_x[CL_Z_OFFSET]);
+
+                                    MD_SIMD_FLOAT delx0  = xi0_tmp - xj_tmp;
+                                    MD_SIMD_FLOAT dely0  = yi0_tmp - yj_tmp;
+                                    MD_SIMD_FLOAT delz0  = zi0_tmp - zj_tmp;
+                                    MD_SIMD_FLOAT delx2  = xi2_tmp - xj_tmp;
+                                    MD_SIMD_FLOAT dely2  = yi2_tmp - yj_tmp;
+                                    MD_SIMD_FLOAT delz2  = zi2_tmp - zj_tmp;
+                                    MD_SIMD_FLOAT rsq0   = simd_fma(delx0,
+                                        delx0,
+                                        simd_fma(dely0, dely0, delz0 * delz0));
+                                    MD_SIMD_FLOAT rsq2   = simd_fma(delx2,
+                                        delx2,
+                                        simd_fma(dely2, dely2, delz2 * delz2));
+
+                                    MD_SIMD_MASK cutoff_mask0 = simd_mask_cond_lt(rsq0, rsq_vec);
+                                    MD_SIMD_MASK cutoff_mask2 = simd_mask_cond_lt(rsq2, rsq_vec);
+
+                                    if(simd_test_any(cutoff_mask0) || simd_test_any(cutoff_mask2)) {
+                                        is_neighbor = 1;
+                                    }
+
+#elif !defined(USE_REFERENCE_VERSION) && VECTOR_WIDTH <= CLUSTER_M * 2
+                                    MD_SIMD_FLOAT xj_tmp = simd_load(&cj_x[CL_X_OFFSET]);
+                                    MD_SIMD_FLOAT yj_tmp = simd_load(&cj_x[CL_Y_OFFSET]);
+                                    MD_SIMD_FLOAT zj_tmp = simd_load(&cj_x[CL_Z_OFFSET]);
+
+                                    MD_SIMD_FLOAT delx0  = xi0_tmp - xj_tmp;
+                                    MD_SIMD_FLOAT dely0  = yi0_tmp - yj_tmp;
+                                    MD_SIMD_FLOAT delz0  = zi0_tmp - zj_tmp;
+                                    MD_SIMD_FLOAT delx1  = xi1_tmp - xj_tmp;
+                                    MD_SIMD_FLOAT dely1  = yi1_tmp - yj_tmp;
+                                    MD_SIMD_FLOAT delz1  = zi1_tmp - zj_tmp;
+                                    MD_SIMD_FLOAT delx2  = xi2_tmp - xj_tmp;
+                                    MD_SIMD_FLOAT dely2  = yi2_tmp - yj_tmp;
+                                    MD_SIMD_FLOAT delz2  = zi2_tmp - zj_tmp;
+                                    MD_SIMD_FLOAT delx3  = xi3_tmp - xj_tmp;
+                                    MD_SIMD_FLOAT dely3  = yi3_tmp - yj_tmp;
+                                    MD_SIMD_FLOAT delz3  = zi3_tmp - zj_tmp;
+
+                                    MD_SIMD_FLOAT rsq0 = simd_fma(delx0,
+                                        delx0,
+                                        simd_fma(dely0, dely0, delz0 * delz0));
+                                    MD_SIMD_FLOAT rsq1 = simd_fma(delx1,
+                                        delx1,
+                                        simd_fma(dely1, dely1, delz1 * delz1));
+                                    MD_SIMD_FLOAT rsq2 = simd_fma(delx2,
+                                        delx2,
+                                        simd_fma(dely2, dely2, delz2 * delz2));
+                                    MD_SIMD_FLOAT rsq3 = simd_fma(delx3,
+                                        delx3,
+                                        simd_fma(dely3, dely3, delz3 * delz3));
+
+                                    MD_SIMD_MASK cutoff_mask0 = simd_mask_cond_lt(rsq0, rsq_vec);
+                                    MD_SIMD_MASK cutoff_mask1 = simd_mask_cond_lt(rsq1, rsq_vec);
+                                    MD_SIMD_MASK cutoff_mask2 = simd_mask_cond_lt(rsq2, rsq_vec);
+                                    MD_SIMD_MASK cutoff_mask3 = simd_mask_cond_lt(rsq3, rsq_vec);
+
+                                    if (simd_test_any(cutoff_mask0) || simd_test_any(cutoff_mask1) ||
+                                        simd_test_any(cutoff_mask2) || simd_test_any(cutoff_mask3)) {
+                                        is_neighbor = 1;
+                                    }
+
+#else
+                                    for (int cii = 0; cii < atom->iclusters[ci].natoms; cii++) {
+                                        for (int cjj = 0; cjj < atom->jclusters[cj].natoms; cjj++) {
+                                            MD_FLOAT delx =
+                                                ci_x[CL_X_OFFSET + cii] - cj_x[CL_X_OFFSET + cjj];
+                                            MD_FLOAT dely =
+                                                ci_x[CL_Y_OFFSET + cii] - cj_x[CL_Y_OFFSET + cjj];
+                                            MD_FLOAT delz =
+                                                ci_x[CL_Z_OFFSET + cii] - cj_x[CL_Z_OFFSET + cjj];
+
+                                            if (delx * delx + dely * dely + delz * delz < cutsq) {
+                                                is_neighbor = 1;
+                                                break;
+                                            }
+                                        }
+                                    }
+
+#endif
+                                }
+
+                                if (is_neighbor) {
                                     // We use true (1) for rdiag because we only care if
                                     // there are masks at all, and when this is set to
                                     // false (0) the self-exclusions are not accounted
@@ -492,6 +593,36 @@ void pruneNeighbor(Parameter* param, Atom* atom, Neighbor* neighbor)
         int numneighs              = neighbor->numneigh[ci];
         int numneighs_masked       = neighbor->numneigh_masked[ci];
         int k                      = 0;
+        int ci_vec_base            = CI_VECTOR_BASE_INDEX(ci);
+        MD_FLOAT* ci_x             = &atom->cl_x[ci_vec_base];
+
+#if !defined(USE_REFERENCE_VERSION) && VECTOR_WIDTH > CLUSTER_M * 2
+        // Simd2xNN
+        MD_SIMD_FLOAT rsq_vec = simd_broadcast(cutsq);
+        MD_SIMD_FLOAT xi0_tmp = simd_load_h_dual(&ci_x[CL_X_OFFSET + 0]);
+        MD_SIMD_FLOAT xi2_tmp = simd_load_h_dual(&ci_x[CL_X_OFFSET + 2]);
+        MD_SIMD_FLOAT yi0_tmp = simd_load_h_dual(&ci_x[CL_Y_OFFSET + 0]);
+        MD_SIMD_FLOAT yi2_tmp = simd_load_h_dual(&ci_x[CL_Y_OFFSET + 2]);
+        MD_SIMD_FLOAT zi0_tmp = simd_load_h_dual(&ci_x[CL_Z_OFFSET + 0]);
+        MD_SIMD_FLOAT zi2_tmp = simd_load_h_dual(&ci_x[CL_Z_OFFSET + 2]);
+
+#elif !defined(USE_REFERENCE_VERSION) && VECTOR_WIDTH <= CLUSTER_M * 2
+        // Simd4xN
+        MD_SIMD_FLOAT rsq_vec = simd_broadcast(cutsq);
+        MD_SIMD_FLOAT xi0_tmp = simd_broadcast(ci_x[CL_X_OFFSET + 0]);
+        MD_SIMD_FLOAT xi1_tmp = simd_broadcast(ci_x[CL_X_OFFSET + 1]);
+        MD_SIMD_FLOAT xi2_tmp = simd_broadcast(ci_x[CL_X_OFFSET + 2]);
+        MD_SIMD_FLOAT xi3_tmp = simd_broadcast(ci_x[CL_X_OFFSET + 3]);
+        MD_SIMD_FLOAT yi0_tmp = simd_broadcast(ci_x[CL_Y_OFFSET + 0]);
+        MD_SIMD_FLOAT yi1_tmp = simd_broadcast(ci_x[CL_Y_OFFSET + 1]);
+        MD_SIMD_FLOAT yi2_tmp = simd_broadcast(ci_x[CL_Y_OFFSET + 2]);
+        MD_SIMD_FLOAT yi3_tmp = simd_broadcast(ci_x[CL_Y_OFFSET + 3]);
+        MD_SIMD_FLOAT zi0_tmp = simd_broadcast(ci_x[CL_Z_OFFSET + 0]);
+        MD_SIMD_FLOAT zi1_tmp = simd_broadcast(ci_x[CL_Z_OFFSET + 1]);
+        MD_SIMD_FLOAT zi2_tmp = simd_broadcast(ci_x[CL_Z_OFFSET + 2]);
+        MD_SIMD_FLOAT zi3_tmp = simd_broadcast(ci_x[CL_Z_OFFSET + 3]);
+
+#endif
 
         // Remove dummy clusters if necessary
         if (CLUSTER_N < VECTOR_WIDTH) {
@@ -501,8 +632,93 @@ void pruneNeighbor(Parameter* param, Atom* atom, Neighbor* neighbor)
         }
 
         while (k < numneighs) {
-            int cj = neighs[k];
-            if (atomDistanceInRange(atom, ci, cj, cutsq)) {
+            int cj                 = neighs[k];
+            int cj_vec_base        = CJ_VECTOR_BASE_INDEX(cj);
+            MD_FLOAT* cj_x         = &atom->cl_x[cj_vec_base];
+            int atom_dist_in_range = 0;
+
+#if !defined(USE_REFERENCE_VERSION) && VECTOR_WIDTH > CLUSTER_M * 2
+            MD_SIMD_FLOAT xj_tmp = simd_load_h_duplicate(&cj_x[CL_X_OFFSET]);
+            MD_SIMD_FLOAT yj_tmp = simd_load_h_duplicate(&cj_x[CL_Y_OFFSET]);
+            MD_SIMD_FLOAT zj_tmp = simd_load_h_duplicate(&cj_x[CL_Z_OFFSET]);
+
+            MD_SIMD_FLOAT delx0  = xi0_tmp - xj_tmp;
+            MD_SIMD_FLOAT dely0  = yi0_tmp - yj_tmp;
+            MD_SIMD_FLOAT delz0  = zi0_tmp - zj_tmp;
+            MD_SIMD_FLOAT delx2  = xi2_tmp - xj_tmp;
+            MD_SIMD_FLOAT dely2  = yi2_tmp - yj_tmp;
+            MD_SIMD_FLOAT delz2  = zi2_tmp - zj_tmp;
+            MD_SIMD_FLOAT rsq0   = simd_fma(delx0,
+                delx0,
+                simd_fma(dely0, dely0, delz0 * delz0));
+            MD_SIMD_FLOAT rsq2   = simd_fma(delx2,
+                delx2,
+                simd_fma(dely2, dely2, delz2 * delz2));
+
+            MD_SIMD_MASK cutoff_mask0 = simd_mask_cond_lt(rsq0, rsq_vec);
+            MD_SIMD_MASK cutoff_mask2 = simd_mask_cond_lt(rsq2, rsq_vec);
+
+            if(simd_test_any(cutoff_mask0) || simd_test_any(cutoff_mask2)) {
+                atom_dist_in_range = 1;
+            }
+
+#elif !defined(USE_REFERENCE_VERSION) && VECTOR_WIDTH <= CLUSTER_M * 2
+            MD_SIMD_FLOAT xj_tmp = simd_load(&cj_x[CL_X_OFFSET]);
+            MD_SIMD_FLOAT yj_tmp = simd_load(&cj_x[CL_Y_OFFSET]);
+            MD_SIMD_FLOAT zj_tmp = simd_load(&cj_x[CL_Z_OFFSET]);
+
+            MD_SIMD_FLOAT delx0  = xi0_tmp - xj_tmp;
+            MD_SIMD_FLOAT dely0  = yi0_tmp - yj_tmp;
+            MD_SIMD_FLOAT delz0  = zi0_tmp - zj_tmp;
+            MD_SIMD_FLOAT delx1  = xi1_tmp - xj_tmp;
+            MD_SIMD_FLOAT dely1  = yi1_tmp - yj_tmp;
+            MD_SIMD_FLOAT delz1  = zi1_tmp - zj_tmp;
+            MD_SIMD_FLOAT delx2  = xi2_tmp - xj_tmp;
+            MD_SIMD_FLOAT dely2  = yi2_tmp - yj_tmp;
+            MD_SIMD_FLOAT delz2  = zi2_tmp - zj_tmp;
+            MD_SIMD_FLOAT delx3  = xi3_tmp - xj_tmp;
+            MD_SIMD_FLOAT dely3  = yi3_tmp - yj_tmp;
+            MD_SIMD_FLOAT delz3  = zi3_tmp - zj_tmp;
+
+            MD_SIMD_FLOAT rsq0 = simd_fma(delx0,
+                delx0,
+                simd_fma(dely0, dely0, delz0 * delz0));
+            MD_SIMD_FLOAT rsq1 = simd_fma(delx1,
+                delx1,
+                simd_fma(dely1, dely1, delz1 * delz1));
+            MD_SIMD_FLOAT rsq2 = simd_fma(delx2,
+                delx2,
+                simd_fma(dely2, dely2, delz2 * delz2));
+            MD_SIMD_FLOAT rsq3 = simd_fma(delx3,
+                delx3,
+                simd_fma(dely3, dely3, delz3 * delz3));
+
+            MD_SIMD_MASK cutoff_mask0 = simd_mask_cond_lt(rsq0, rsq_vec);
+            MD_SIMD_MASK cutoff_mask1 = simd_mask_cond_lt(rsq1, rsq_vec);
+            MD_SIMD_MASK cutoff_mask2 = simd_mask_cond_lt(rsq2, rsq_vec);
+            MD_SIMD_MASK cutoff_mask3 = simd_mask_cond_lt(rsq3, rsq_vec);
+
+            if (simd_test_any(cutoff_mask0) || simd_test_any(cutoff_mask1) ||
+                simd_test_any(cutoff_mask2) || simd_test_any(cutoff_mask3)) {
+                atom_dist_in_range = 1;
+            }
+
+#else
+            for (int cii = 0; cii < atom->iclusters[ci].natoms; cii++) {
+                for (int cjj = 0; cjj < atom->jclusters[cj].natoms; cjj++) {
+                    MD_FLOAT delx = ci_x[CL_X_OFFSET + cii] - cj_x[CL_X_OFFSET + cjj];
+                    MD_FLOAT dely = ci_x[CL_Y_OFFSET + cii] - cj_x[CL_Y_OFFSET + cjj];
+                    MD_FLOAT delz = ci_x[CL_Z_OFFSET + cii] - cj_x[CL_Z_OFFSET + cjj];
+                    if (delx * delx + dely * dely + delz * delz < cutsq) {
+                        atom_dist_in_range = 1;
+                        break;
+                    }
+                }
+            }
+
+#endif
+
+            if (atom_dist_in_range) {
                 k++;
             } else {
                 numneighs--;

--- a/src/clusterpair/neighbor.c
+++ b/src/clusterpair/neighbor.c
@@ -291,41 +291,41 @@ void buildNeighborCPU(Atom* atom, Neighbor* neighbor)
             MD_FLOAT ibb_zmax = atom->iclusters[ci].bbmaxz;
 
 #if defined(CLUSTERPAIR_KERNEL_2XNN)
-            MD_SIMD_FLOAT xi0_tmp = simd_load_h_dual(&ci_x[CL_X_OFFSET + 0]);
-            MD_SIMD_FLOAT xi2_tmp = simd_load_h_dual(&ci_x[CL_X_OFFSET + 2]);
-            MD_SIMD_FLOAT yi0_tmp = simd_load_h_dual(&ci_x[CL_Y_OFFSET + 0]);
-            MD_SIMD_FLOAT yi2_tmp = simd_load_h_dual(&ci_x[CL_Y_OFFSET + 2]);
-            MD_SIMD_FLOAT zi0_tmp = simd_load_h_dual(&ci_x[CL_Z_OFFSET + 0]);
-            MD_SIMD_FLOAT zi2_tmp = simd_load_h_dual(&ci_x[CL_Z_OFFSET + 2]);
+            MD_SIMD_FLOAT xi0_tmp = simd_real_load_h_dual(&ci_x[CL_X_OFFSET + 0]);
+            MD_SIMD_FLOAT xi2_tmp = simd_real_load_h_dual(&ci_x[CL_X_OFFSET + 2]);
+            MD_SIMD_FLOAT yi0_tmp = simd_real_load_h_dual(&ci_x[CL_Y_OFFSET + 0]);
+            MD_SIMD_FLOAT yi2_tmp = simd_real_load_h_dual(&ci_x[CL_Y_OFFSET + 2]);
+            MD_SIMD_FLOAT zi0_tmp = simd_real_load_h_dual(&ci_x[CL_Z_OFFSET + 0]);
+            MD_SIMD_FLOAT zi2_tmp = simd_real_load_h_dual(&ci_x[CL_Z_OFFSET + 2]);
 
 #ifndef ONE_ATOM_TYPE
-            MD_SIMD_INT tbase0 = simd_int_load_h_dual_scaled(&ci_t[0], atom->ntypes);
-            MD_SIMD_INT tbase2 = simd_int_load_h_dual_scaled(&ci_t[2], atom->ntypes);
+            MD_SIMD_INT tbase0 = simd_i32_load_h_dual_scaled(&ci_t[0], atom->ntypes);
+            MD_SIMD_INT tbase2 = simd_i32_load_h_dual_scaled(&ci_t[2], atom->ntypes);
 #else
-            MD_SIMD_FLOAT cutneighsq_vec = simd_broadcast(cutneighsq);
+            MD_SIMD_FLOAT cutneighsq_vec = simd_real_broadcast(cutneighsq);
 #endif
 
 #elif defined(CLUSTERPAIR_KERNEL_4XN)
-            MD_SIMD_FLOAT xi0_tmp = simd_broadcast(ci_x[CL_X_OFFSET + 0]);
-            MD_SIMD_FLOAT xi1_tmp = simd_broadcast(ci_x[CL_X_OFFSET + 1]);
-            MD_SIMD_FLOAT xi2_tmp = simd_broadcast(ci_x[CL_X_OFFSET + 2]);
-            MD_SIMD_FLOAT xi3_tmp = simd_broadcast(ci_x[CL_X_OFFSET + 3]);
-            MD_SIMD_FLOAT yi0_tmp = simd_broadcast(ci_x[CL_Y_OFFSET + 0]);
-            MD_SIMD_FLOAT yi1_tmp = simd_broadcast(ci_x[CL_Y_OFFSET + 1]);
-            MD_SIMD_FLOAT yi2_tmp = simd_broadcast(ci_x[CL_Y_OFFSET + 2]);
-            MD_SIMD_FLOAT yi3_tmp = simd_broadcast(ci_x[CL_Y_OFFSET + 3]);
-            MD_SIMD_FLOAT zi0_tmp = simd_broadcast(ci_x[CL_Z_OFFSET + 0]);
-            MD_SIMD_FLOAT zi1_tmp = simd_broadcast(ci_x[CL_Z_OFFSET + 1]);
-            MD_SIMD_FLOAT zi2_tmp = simd_broadcast(ci_x[CL_Z_OFFSET + 2]);
-            MD_SIMD_FLOAT zi3_tmp = simd_broadcast(ci_x[CL_Z_OFFSET + 3]);
+            MD_SIMD_FLOAT xi0_tmp = simd_real_broadcast(ci_x[CL_X_OFFSET + 0]);
+            MD_SIMD_FLOAT xi1_tmp = simd_real_broadcast(ci_x[CL_X_OFFSET + 1]);
+            MD_SIMD_FLOAT xi2_tmp = simd_real_broadcast(ci_x[CL_X_OFFSET + 2]);
+            MD_SIMD_FLOAT xi3_tmp = simd_real_broadcast(ci_x[CL_X_OFFSET + 3]);
+            MD_SIMD_FLOAT yi0_tmp = simd_real_broadcast(ci_x[CL_Y_OFFSET + 0]);
+            MD_SIMD_FLOAT yi1_tmp = simd_real_broadcast(ci_x[CL_Y_OFFSET + 1]);
+            MD_SIMD_FLOAT yi2_tmp = simd_real_broadcast(ci_x[CL_Y_OFFSET + 2]);
+            MD_SIMD_FLOAT yi3_tmp = simd_real_broadcast(ci_x[CL_Y_OFFSET + 3]);
+            MD_SIMD_FLOAT zi0_tmp = simd_real_broadcast(ci_x[CL_Z_OFFSET + 0]);
+            MD_SIMD_FLOAT zi1_tmp = simd_real_broadcast(ci_x[CL_Z_OFFSET + 1]);
+            MD_SIMD_FLOAT zi2_tmp = simd_real_broadcast(ci_x[CL_Z_OFFSET + 2]);
+            MD_SIMD_FLOAT zi3_tmp = simd_real_broadcast(ci_x[CL_Z_OFFSET + 3]);
 
 #ifndef ONE_ATOM_TYPE
-            MD_SIMD_INT tbase0    = simd_int_broadcast(ci_t[0] * atom->ntypes);
-            MD_SIMD_INT tbase1    = simd_int_broadcast(ci_t[1] * atom->ntypes);
-            MD_SIMD_INT tbase2    = simd_int_broadcast(ci_t[2] * atom->ntypes);
-            MD_SIMD_INT tbase3    = simd_int_broadcast(ci_t[3] * atom->ntypes);
+            MD_SIMD_INT tbase0    = simd_i32_broadcast(ci_t[0] * atom->ntypes);
+            MD_SIMD_INT tbase1    = simd_i32_broadcast(ci_t[1] * atom->ntypes);
+            MD_SIMD_INT tbase2    = simd_i32_broadcast(ci_t[2] * atom->ntypes);
+            MD_SIMD_INT tbase3    = simd_i32_broadcast(ci_t[3] * atom->ntypes);
 #else
-            MD_SIMD_FLOAT cutneighsq_vec = simd_broadcast(cutneighsq);
+            MD_SIMD_FLOAT cutneighsq_vec = simd_real_broadcast(cutneighsq);
 #endif
 
 #endif
@@ -398,22 +398,22 @@ void buildNeighborCPU(Atom* atom, Neighbor* neighbor)
 
 #if defined(CLUSTERPAIR_KERNEL_2XNN)
 
-                                    MD_SIMD_FLOAT xj_tmp = simd_load_h_duplicate(
+                                    MD_SIMD_FLOAT xj_tmp = simd_real_load_h_duplicate(
                                         &cj_x[CL_X_OFFSET]);
-                                    MD_SIMD_FLOAT yj_tmp = simd_load_h_duplicate(
+                                    MD_SIMD_FLOAT yj_tmp = simd_real_load_h_duplicate(
                                         &cj_x[CL_Y_OFFSET]);
-                                    MD_SIMD_FLOAT zj_tmp = simd_load_h_duplicate(
+                                    MD_SIMD_FLOAT zj_tmp = simd_real_load_h_duplicate(
                                         &cj_x[CL_Z_OFFSET]);
 
 #ifndef ONE_ATOM_TYPE
-                                    MD_SIMD_INT tj_tmp = simd_int_load_h_duplicate(cj_t);
-                                    MD_SIMD_INT tvec0  = simd_int_add(tbase0, tj_tmp);
-                                    MD_SIMD_INT tvec2  = simd_int_add(tbase2, tj_tmp);
+                                    MD_SIMD_INT tj_tmp = simd_i32_load_h_duplicate(cj_t);
+                                    MD_SIMD_INT tvec0  = simd_i32_add(tbase0, tj_tmp);
+                                    MD_SIMD_INT tvec2  = simd_i32_add(tbase2, tj_tmp);
 
-                                    MD_SIMD_FLOAT cutneighsq0 = simd_gather(tvec0,
+                                    MD_SIMD_FLOAT cutneighsq0 = simd_real_gather(tvec0,
                                         atom->cutneighsq,
                                         sizeof(MD_FLOAT));
-                                    MD_SIMD_FLOAT cutneighsq2 = simd_gather(tvec2,
+                                    MD_SIMD_FLOAT cutneighsq2 = simd_real_gather(tvec2,
                                         atom->cutneighsq,
                                         sizeof(MD_FLOAT));
 #else
@@ -427,12 +427,12 @@ void buildNeighborCPU(Atom* atom, Neighbor* neighbor)
                                     MD_SIMD_FLOAT delx2 = xi2_tmp - xj_tmp;
                                     MD_SIMD_FLOAT dely2 = yi2_tmp - yj_tmp;
                                     MD_SIMD_FLOAT delz2 = zi2_tmp - zj_tmp;
-                                    MD_SIMD_FLOAT rsq0  = simd_fma(delx0,
+                                    MD_SIMD_FLOAT rsq0  = simd_real_fma(delx0,
                                         delx0,
-                                        simd_fma(dely0, dely0, delz0 * delz0));
-                                    MD_SIMD_FLOAT rsq2  = simd_fma(delx2,
+                                        simd_real_fma(dely0, dely0, delz0 * delz0));
+                                    MD_SIMD_FLOAT rsq2  = simd_real_fma(delx2,
                                         delx2,
-                                        simd_fma(dely2, dely2, delz2 * delz2));
+                                        simd_real_fma(dely2, dely2, delz2 * delz2));
 
                                     MD_SIMD_MASK cutoff_mask0 = simd_mask_cond_lt(rsq0,
                                         cutneighsq0);
@@ -446,26 +446,29 @@ void buildNeighborCPU(Atom* atom, Neighbor* neighbor)
 
 #elif defined(CLUSTERPAIR_KERNEL_4XN)
 
-                                    MD_SIMD_FLOAT xj_tmp = simd_load(&cj_x[CL_X_OFFSET]);
-                                    MD_SIMD_FLOAT yj_tmp = simd_load(&cj_x[CL_Y_OFFSET]);
-                                    MD_SIMD_FLOAT zj_tmp = simd_load(&cj_x[CL_Z_OFFSET]);
+                                    MD_SIMD_FLOAT xj_tmp = simd_real_load(
+                                        &cj_x[CL_X_OFFSET]);
+                                    MD_SIMD_FLOAT yj_tmp = simd_real_load(
+                                        &cj_x[CL_Y_OFFSET]);
+                                    MD_SIMD_FLOAT zj_tmp = simd_real_load(
+                                        &cj_x[CL_Z_OFFSET]);
 #ifndef ONE_ATOM_TYPE
-                                    MD_SIMD_INT tj_tmp   = simd_int_load(cj_t);
-                                    MD_SIMD_INT tvec0    = simd_int_add(tbase0, tj_tmp);
-                                    MD_SIMD_INT tvec1    = simd_int_add(tbase1, tj_tmp);
-                                    MD_SIMD_INT tvec2    = simd_int_add(tbase2, tj_tmp);
-                                    MD_SIMD_INT tvec3    = simd_int_add(tbase3, tj_tmp);
+                                    MD_SIMD_INT tj_tmp = simd_i32_load(cj_t);
+                                    MD_SIMD_INT tvec0  = simd_i32_add(tbase0, tj_tmp);
+                                    MD_SIMD_INT tvec1  = simd_i32_add(tbase1, tj_tmp);
+                                    MD_SIMD_INT tvec2  = simd_i32_add(tbase2, tj_tmp);
+                                    MD_SIMD_INT tvec3  = simd_i32_add(tbase3, tj_tmp);
 
-                                    MD_SIMD_FLOAT cutneighsq0 = simd_gather(tvec0,
+                                    MD_SIMD_FLOAT cutneighsq0 = simd_real_gather(tvec0,
                                         atom->cutneighsq,
                                         sizeof(MD_FLOAT));
-                                    MD_SIMD_FLOAT cutneighsq1 = simd_gather(tvec1,
+                                    MD_SIMD_FLOAT cutneighsq1 = simd_real_gather(tvec1,
                                         atom->cutneighsq,
                                         sizeof(MD_FLOAT));
-                                    MD_SIMD_FLOAT cutneighsq2 = simd_gather(tvec2,
+                                    MD_SIMD_FLOAT cutneighsq2 = simd_real_gather(tvec2,
                                         atom->cutneighsq,
                                         sizeof(MD_FLOAT));
-                                    MD_SIMD_FLOAT cutneighsq3 = simd_gather(tvec3,
+                                    MD_SIMD_FLOAT cutneighsq3 = simd_real_gather(tvec3,
                                         atom->cutneighsq,
                                         sizeof(MD_FLOAT));
 #else
@@ -488,18 +491,18 @@ void buildNeighborCPU(Atom* atom, Neighbor* neighbor)
                                     MD_SIMD_FLOAT dely3 = yi3_tmp - yj_tmp;
                                     MD_SIMD_FLOAT delz3 = zi3_tmp - zj_tmp;
 
-                                    MD_SIMD_FLOAT rsq0 = simd_fma(delx0,
+                                    MD_SIMD_FLOAT rsq0 = simd_real_fma(delx0,
                                         delx0,
-                                        simd_fma(dely0, dely0, delz0 * delz0));
-                                    MD_SIMD_FLOAT rsq1 = simd_fma(delx1,
+                                        simd_real_fma(dely0, dely0, delz0 * delz0));
+                                    MD_SIMD_FLOAT rsq1 = simd_real_fma(delx1,
                                         delx1,
-                                        simd_fma(dely1, dely1, delz1 * delz1));
-                                    MD_SIMD_FLOAT rsq2 = simd_fma(delx2,
+                                        simd_real_fma(dely1, dely1, delz1 * delz1));
+                                    MD_SIMD_FLOAT rsq2 = simd_real_fma(delx2,
                                         delx2,
-                                        simd_fma(dely2, dely2, delz2 * delz2));
-                                    MD_SIMD_FLOAT rsq3 = simd_fma(delx3,
+                                        simd_real_fma(dely2, dely2, delz2 * delz2));
+                                    MD_SIMD_FLOAT rsq3 = simd_real_fma(delx3,
                                         delx3,
-                                        simd_fma(dely3, dely3, delz3 * delz3));
+                                        simd_real_fma(dely3, dely3, delz3 * delz3));
 
                                     MD_SIMD_MASK cutoff_mask0 = simd_mask_cond_lt(rsq0,
                                         cutneighsq0);
@@ -677,27 +680,27 @@ void pruneNeighbor(Parameter* param, Atom* atom, Neighbor* neighbor)
         MD_FLOAT* ci_x             = &atom->cl_x[ci_vec_base];
 
 #if defined(CLUSTERPAIR_KERNEL_2XNN)
-        MD_SIMD_FLOAT cutneighsq_vec = simd_broadcast(cutsq);
-        MD_SIMD_FLOAT xi0_tmp        = simd_load_h_dual(&ci_x[CL_X_OFFSET + 0]);
-        MD_SIMD_FLOAT xi2_tmp        = simd_load_h_dual(&ci_x[CL_X_OFFSET + 2]);
-        MD_SIMD_FLOAT yi0_tmp        = simd_load_h_dual(&ci_x[CL_Y_OFFSET + 0]);
-        MD_SIMD_FLOAT yi2_tmp        = simd_load_h_dual(&ci_x[CL_Y_OFFSET + 2]);
-        MD_SIMD_FLOAT zi0_tmp        = simd_load_h_dual(&ci_x[CL_Z_OFFSET + 0]);
-        MD_SIMD_FLOAT zi2_tmp        = simd_load_h_dual(&ci_x[CL_Z_OFFSET + 2]);
+        MD_SIMD_FLOAT cutneighsq_vec = simd_real_broadcast(cutsq);
+        MD_SIMD_FLOAT xi0_tmp        = simd_real_load_h_dual(&ci_x[CL_X_OFFSET + 0]);
+        MD_SIMD_FLOAT xi2_tmp        = simd_real_load_h_dual(&ci_x[CL_X_OFFSET + 2]);
+        MD_SIMD_FLOAT yi0_tmp        = simd_real_load_h_dual(&ci_x[CL_Y_OFFSET + 0]);
+        MD_SIMD_FLOAT yi2_tmp        = simd_real_load_h_dual(&ci_x[CL_Y_OFFSET + 2]);
+        MD_SIMD_FLOAT zi0_tmp        = simd_real_load_h_dual(&ci_x[CL_Z_OFFSET + 0]);
+        MD_SIMD_FLOAT zi2_tmp        = simd_real_load_h_dual(&ci_x[CL_Z_OFFSET + 2]);
 #elif defined(CLUSTERPAIR_KERNEL_4XN)
-        MD_SIMD_FLOAT cutneighsq_vec = simd_broadcast(cutsq);
-        MD_SIMD_FLOAT xi0_tmp        = simd_broadcast(ci_x[CL_X_OFFSET + 0]);
-        MD_SIMD_FLOAT xi1_tmp        = simd_broadcast(ci_x[CL_X_OFFSET + 1]);
-        MD_SIMD_FLOAT xi2_tmp        = simd_broadcast(ci_x[CL_X_OFFSET + 2]);
-        MD_SIMD_FLOAT xi3_tmp        = simd_broadcast(ci_x[CL_X_OFFSET + 3]);
-        MD_SIMD_FLOAT yi0_tmp        = simd_broadcast(ci_x[CL_Y_OFFSET + 0]);
-        MD_SIMD_FLOAT yi1_tmp        = simd_broadcast(ci_x[CL_Y_OFFSET + 1]);
-        MD_SIMD_FLOAT yi2_tmp        = simd_broadcast(ci_x[CL_Y_OFFSET + 2]);
-        MD_SIMD_FLOAT yi3_tmp        = simd_broadcast(ci_x[CL_Y_OFFSET + 3]);
-        MD_SIMD_FLOAT zi0_tmp        = simd_broadcast(ci_x[CL_Z_OFFSET + 0]);
-        MD_SIMD_FLOAT zi1_tmp        = simd_broadcast(ci_x[CL_Z_OFFSET + 1]);
-        MD_SIMD_FLOAT zi2_tmp        = simd_broadcast(ci_x[CL_Z_OFFSET + 2]);
-        MD_SIMD_FLOAT zi3_tmp        = simd_broadcast(ci_x[CL_Z_OFFSET + 3]);
+        MD_SIMD_FLOAT cutneighsq_vec = simd_real_broadcast(cutsq);
+        MD_SIMD_FLOAT xi0_tmp        = simd_real_broadcast(ci_x[CL_X_OFFSET + 0]);
+        MD_SIMD_FLOAT xi1_tmp        = simd_real_broadcast(ci_x[CL_X_OFFSET + 1]);
+        MD_SIMD_FLOAT xi2_tmp        = simd_real_broadcast(ci_x[CL_X_OFFSET + 2]);
+        MD_SIMD_FLOAT xi3_tmp        = simd_real_broadcast(ci_x[CL_X_OFFSET + 3]);
+        MD_SIMD_FLOAT yi0_tmp        = simd_real_broadcast(ci_x[CL_Y_OFFSET + 0]);
+        MD_SIMD_FLOAT yi1_tmp        = simd_real_broadcast(ci_x[CL_Y_OFFSET + 1]);
+        MD_SIMD_FLOAT yi2_tmp        = simd_real_broadcast(ci_x[CL_Y_OFFSET + 2]);
+        MD_SIMD_FLOAT yi3_tmp        = simd_real_broadcast(ci_x[CL_Y_OFFSET + 3]);
+        MD_SIMD_FLOAT zi0_tmp        = simd_real_broadcast(ci_x[CL_Z_OFFSET + 0]);
+        MD_SIMD_FLOAT zi1_tmp        = simd_real_broadcast(ci_x[CL_Z_OFFSET + 1]);
+        MD_SIMD_FLOAT zi2_tmp        = simd_real_broadcast(ci_x[CL_Z_OFFSET + 2]);
+        MD_SIMD_FLOAT zi3_tmp        = simd_real_broadcast(ci_x[CL_Z_OFFSET + 3]);
 #endif
 
         // Remove dummy clusters if necessary
@@ -715,22 +718,21 @@ void pruneNeighbor(Parameter* param, Atom* atom, Neighbor* neighbor)
 
 #if defined(CLUSTERPAIR_KERNEL_2XNN)
 
-            MD_SIMD_FLOAT xj_tmp = simd_load_h_duplicate(&cj_x[CL_X_OFFSET]);
-            MD_SIMD_FLOAT yj_tmp = simd_load_h_duplicate(&cj_x[CL_Y_OFFSET]);
-            MD_SIMD_FLOAT zj_tmp = simd_load_h_duplicate(&cj_x[CL_Z_OFFSET]);
-
-            MD_SIMD_FLOAT delx0 = xi0_tmp - xj_tmp;
-            MD_SIMD_FLOAT dely0 = yi0_tmp - yj_tmp;
-            MD_SIMD_FLOAT delz0 = zi0_tmp - zj_tmp;
-            MD_SIMD_FLOAT delx2 = xi2_tmp - xj_tmp;
-            MD_SIMD_FLOAT dely2 = yi2_tmp - yj_tmp;
-            MD_SIMD_FLOAT delz2 = zi2_tmp - zj_tmp;
-            MD_SIMD_FLOAT rsq0  = simd_fma(delx0,
+            MD_SIMD_FLOAT xj_tmp = simd_real_load_h_duplicate(&cj_x[CL_X_OFFSET]);
+            MD_SIMD_FLOAT yj_tmp = simd_real_load_h_duplicate(&cj_x[CL_Y_OFFSET]);
+            MD_SIMD_FLOAT zj_tmp = simd_real_load_h_duplicate(&cj_x[CL_Z_OFFSET]);
+            MD_SIMD_FLOAT delx0  = simd_real_sub(xi0_tmp, xj_tmp);
+            MD_SIMD_FLOAT dely0  = simd_real_sub(yi0_tmp, yj_tmp);
+            MD_SIMD_FLOAT delz0  = simd_real_sub(zi0_tmp, zj_tmp);
+            MD_SIMD_FLOAT delx2  = simd_real_sub(xi2_tmp, xj_tmp);
+            MD_SIMD_FLOAT dely2  = simd_real_sub(yi2_tmp, yj_tmp);
+            MD_SIMD_FLOAT delz2  = simd_real_sub(zi2_tmp, zj_tmp);
+            MD_SIMD_FLOAT rsq0   = simd_real_fma(delx0,
                 delx0,
-                simd_fma(dely0, dely0, delz0 * delz0));
-            MD_SIMD_FLOAT rsq2  = simd_fma(delx2,
+                simd_real_fma(dely0, dely0, simd_real_mul(delz0, delz0)));
+            MD_SIMD_FLOAT rsq2   = simd_real_fma(delx2,
                 delx2,
-                simd_fma(dely2, dely2, delz2 * delz2));
+                simd_real_fma(dely2, dely2, simd_real_mul(delz2, delz2)));
 
             MD_SIMD_MASK cutoff_mask0 = simd_mask_cond_lt(rsq0, cutneighsq_vec);
             MD_SIMD_MASK cutoff_mask2 = simd_mask_cond_lt(rsq2, cutneighsq_vec);
@@ -741,35 +743,34 @@ void pruneNeighbor(Parameter* param, Atom* atom, Neighbor* neighbor)
 
 #elif defined(CLUSTERPAIR_KERNEL_4XN)
 
-            MD_SIMD_FLOAT xj_tmp = simd_load(&cj_x[CL_X_OFFSET]);
-            MD_SIMD_FLOAT yj_tmp = simd_load(&cj_x[CL_Y_OFFSET]);
-            MD_SIMD_FLOAT zj_tmp = simd_load(&cj_x[CL_Z_OFFSET]);
+            MD_SIMD_FLOAT xj_tmp = simd_real_load(&cj_x[CL_X_OFFSET]);
+            MD_SIMD_FLOAT yj_tmp = simd_real_load(&cj_x[CL_Y_OFFSET]);
+            MD_SIMD_FLOAT zj_tmp = simd_real_load(&cj_x[CL_Z_OFFSET]);
+            MD_SIMD_FLOAT delx0  = simd_real_sub(xi0_tmp, xj_tmp);
+            MD_SIMD_FLOAT dely0  = simd_real_sub(yi0_tmp, yj_tmp);
+            MD_SIMD_FLOAT delz0  = simd_real_sub(zi0_tmp, zj_tmp);
+            MD_SIMD_FLOAT delx1  = simd_real_sub(xi1_tmp, xj_tmp);
+            MD_SIMD_FLOAT dely1  = simd_real_sub(yi1_tmp, yj_tmp);
+            MD_SIMD_FLOAT delz1  = simd_real_sub(zi1_tmp, zj_tmp);
+            MD_SIMD_FLOAT delx2  = simd_real_sub(xi2_tmp, xj_tmp);
+            MD_SIMD_FLOAT dely2  = simd_real_sub(yi2_tmp, yj_tmp);
+            MD_SIMD_FLOAT delz2  = simd_real_sub(zi2_tmp, zj_tmp);
+            MD_SIMD_FLOAT delx3  = simd_real_sub(xi3_tmp, xj_tmp);
+            MD_SIMD_FLOAT dely3  = simd_real_sub(yi3_tmp, yj_tmp);
+            MD_SIMD_FLOAT delz3  = simd_real_sub(zi3_tmp, zj_tmp);
 
-            MD_SIMD_FLOAT delx0 = xi0_tmp - xj_tmp;
-            MD_SIMD_FLOAT dely0 = yi0_tmp - yj_tmp;
-            MD_SIMD_FLOAT delz0 = zi0_tmp - zj_tmp;
-            MD_SIMD_FLOAT delx1 = xi1_tmp - xj_tmp;
-            MD_SIMD_FLOAT dely1 = yi1_tmp - yj_tmp;
-            MD_SIMD_FLOAT delz1 = zi1_tmp - zj_tmp;
-            MD_SIMD_FLOAT delx2 = xi2_tmp - xj_tmp;
-            MD_SIMD_FLOAT dely2 = yi2_tmp - yj_tmp;
-            MD_SIMD_FLOAT delz2 = zi2_tmp - zj_tmp;
-            MD_SIMD_FLOAT delx3 = xi3_tmp - xj_tmp;
-            MD_SIMD_FLOAT dely3 = yi3_tmp - yj_tmp;
-            MD_SIMD_FLOAT delz3 = zi3_tmp - zj_tmp;
-
-            MD_SIMD_FLOAT rsq0 = simd_fma(delx0,
+            MD_SIMD_FLOAT rsq0 = simd_real_fma(delx0,
                 delx0,
-                simd_fma(dely0, dely0, delz0 * delz0));
-            MD_SIMD_FLOAT rsq1 = simd_fma(delx1,
+                simd_real_fma(dely0, dely0, simd_real_mul(delz0, delz0)));
+            MD_SIMD_FLOAT rsq1 = simd_real_fma(delx1,
                 delx1,
-                simd_fma(dely1, dely1, delz1 * delz1));
-            MD_SIMD_FLOAT rsq2 = simd_fma(delx2,
+                simd_real_fma(dely1, dely1, simd_real_mul(delz1, delz1)));
+            MD_SIMD_FLOAT rsq2 = simd_real_fma(delx2,
                 delx2,
-                simd_fma(dely2, dely2, delz2 * delz2));
-            MD_SIMD_FLOAT rsq3 = simd_fma(delx3,
+                simd_real_fma(dely2, dely2, simd_real_mul(delz2, delz2)));
+            MD_SIMD_FLOAT rsq3 = simd_real_fma(delx3,
                 delx3,
-                simd_fma(dely3, dely3, delz3 * delz3));
+                simd_real_fma(dely3, dely3, simd_real_mul(delz3, delz3)));
 
             MD_SIMD_MASK cutoff_mask0 = simd_mask_cond_lt(rsq0, cutneighsq_vec);
             MD_SIMD_MASK cutoff_mask1 = simd_mask_cond_lt(rsq1, cutneighsq_vec);

--- a/src/clusterpair/pbc.c
+++ b/src/clusterpair/pbc.c
@@ -152,7 +152,6 @@ void updateAtomsPbcCPU(Atom* atom, Parameter* param, bool dummy)
  * only creates mapping and coordinate corrections
  * that are then enforced in updatePbc */
 #define ADDGHOST(dx, dy, dz)                                                             \
-    ;                                                                                    \
     Nghost++;                                                                            \
     const int cg               = ncj + Nghost;                                           \
     const int cj_natoms        = atom->jclusters[cj].natoms;                             \

--- a/src/clusterpair/pbc.c
+++ b/src/clusterpair/pbc.c
@@ -60,7 +60,7 @@ void updatePbcCPU(Atom* atom, Parameter* param, bool firstUpdate)
         int* cjT        = &atom->cl_t[cjScaBase];
         MD_FLOAT* cjX   = &atom->cl_x[cjVecBase];
         MD_FLOAT* bmapX = &atom->cl_x[bmapVecBase];
-        MD_FLOAT* bmapT = &atom->cl_t[bmapScaBase];
+        int* bmapT      = &atom->cl_t[bmapScaBase];
         MD_FLOAT bbminx = INFINITY, bbmaxx = -INFINITY;
         MD_FLOAT bbminy = INFINITY, bbmaxy = -INFINITY;
         MD_FLOAT bbminz = INFINITY, bbmaxz = -INFINITY;

--- a/src/clusterpair/stats.c
+++ b/src/clusterpair/stats.c
@@ -40,10 +40,10 @@ void displayStatistics(Atom* atom, Parameter* param, Stats* stats, double* timer
     double avgSimd = stats->force_iters / (double)(atom->Nlocal * (param->ntimes + 1));
 
 #ifndef ONE_ATOM_TYPE
-    force_useful_volume += 1e-9 *
-                           (double)((atom->Nlocal * (param->ntimes + 1)) +
-                                    stats->num_neighs) *
-                           sizeof(int);
+    forceUsefulVolume += 1e-9 *
+                         (double)((atom->Nlocal * (param->ntimes + 1)) +
+                                   stats->num_neighs) *
+                         sizeof(int);
 #endif
 
     printf("Statistics:\n");

--- a/src/clusterpair/stats.c
+++ b/src/clusterpair/stats.c
@@ -42,7 +42,7 @@ void displayStatistics(Atom* atom, Parameter* param, Stats* stats, double* timer
 #ifndef ONE_ATOM_TYPE
     forceUsefulVolume += 1e-9 *
                          (double)((atom->Nlocal * (param->ntimes + 1)) +
-                                   stats->num_neighs) *
+                                  stats->num_neighs) *
                          sizeof(int);
 #endif
 

--- a/src/clusterpair/stats.c
+++ b/src/clusterpair/stats.c
@@ -39,7 +39,7 @@ void displayStatistics(Atom* atom, Parameter* param, Stats* stats, double* timer
                              (double)(stats->calculated_forces);
     double avgSimd = stats->force_iters / (double)(atom->Nlocal * (param->ntimes + 1));
 
-#ifdef EXPLICIT_TYPES
+#ifndef ONE_ATOM_TYPE
     force_useful_volume += 1e-9 *
                            (double)((atom->Nlocal * (param->ntimes + 1)) +
                                     stats->num_neighs) *

--- a/src/clusterpair/tracing.c
+++ b/src/clusterpair/tracing.c
@@ -27,7 +27,7 @@ void traceAddresses(Parameter* param, Atom* atom, Neighbor* neighbor, int timest
         MEM_TRACE(atom_z(i), 'R');
         INDEX_TRACE_ATOM(i);
 
-#ifdef EXPLICIT_TYPES
+#ifndef ONE_ATOM_TYPE
         MEM_TRACE(atom->type[i], 'R');
 #endif
 
@@ -42,7 +42,7 @@ void traceAddresses(Parameter* param, Atom* atom, Neighbor* neighbor, int timest
             MEM_TRACE(atom_y(j), 'R');
             MEM_TRACE(atom_z(j), 'R');
 
-#ifdef EXPLICIT_TYPES
+#ifndef ONE_ATOM_TYPE
             MEM_TRACE(atom->type[j], 'R');
 #endif
         }

--- a/src/common/parameter.h
+++ b/src/common/parameter.h
@@ -13,14 +13,14 @@
 #define MD_UINT  unsigned int
 #ifdef USE_REFERENCE_VERSION
 #define MD_SIMD_FLOAT float
-#define MD_SIMD_MASK uint16_t
+#define MD_SIMD_MASK  uint16_t
 #endif
 #else
 #define MD_FLOAT double
 #define MD_UINT  unsigned long long int
 #ifdef USE_REFERENCE_VERSION
 #define MD_SIMD_FLOAT double
-#define MD_SIMD_MASK uint8_t
+#define MD_SIMD_MASK  uint8_t
 #endif
 #endif
 

--- a/src/common/simd.h
+++ b/src/common/simd.h
@@ -46,13 +46,32 @@
 #endif
 #endif
 
-#ifdef __ARM_NEON
+#if (defined (__ARM_NEON) || defined(__ARM_FEATURE_SVE))
 #include <arm_acle.h>
+
+#ifdef __ARM_NEON
 #include <arm_neon.h>
 #endif
+
 #ifdef __ARM_FEATURE_SVE
-#include <arm_acle.h>
 #include <arm_sve.h>
+#endif
+
+#if defined(__ISA_NEON__)
+#if PRECISION == 2
+#include "simd/neon_double.h"
+#else
+#include "simd/neon_float.h"
+#endif
+#endif
+
+#if defined(__ISA_SVE__) || defined(__ISA_SVE2__)
+#if PRECISION == 2
+#include "simd/sve_double.h"
+#else
+#include "simd/sve_float.h"
+#endif
+#endif
 #endif
 
 #include <stdio.h>

--- a/src/common/simd/avx2_double.h
+++ b/src/common/simd/avx2_double.h
@@ -13,54 +13,57 @@
 #define MD_SIMD_MASK  __m256d
 
 static inline int simd_test_any(MD_SIMD_MASK a) { return _mm256_movemask_pd(a) != 0; }
-static inline MD_SIMD_FLOAT simd_broadcast(MD_FLOAT scalar)
+static inline MD_SIMD_FLOAT simd_real_broadcast(MD_FLOAT scalar)
 {
     return _mm256_set1_pd(scalar);
 }
-static inline MD_SIMD_FLOAT simd_zero(void) { return _mm256_set1_pd(0.0); }
-static inline MD_SIMD_FLOAT simd_add(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+static inline MD_SIMD_FLOAT simd_real_zero(void) { return _mm256_set1_pd(0.0); }
+static inline MD_SIMD_FLOAT simd_real_add(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
 {
     return _mm256_add_pd(a, b);
 }
-static inline MD_SIMD_FLOAT simd_sub(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+static inline MD_SIMD_FLOAT simd_real_sub(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
 {
     return _mm256_sub_pd(a, b);
 }
-static inline MD_SIMD_FLOAT simd_mul(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+static inline MD_SIMD_FLOAT simd_real_mul(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
 {
     return _mm256_mul_pd(a, b);
 }
-static inline MD_SIMD_FLOAT simd_load(MD_FLOAT* p) { return _mm256_load_pd(p); }
-static inline void simd_store(MD_FLOAT* p, MD_SIMD_FLOAT a) { _mm256_store_pd(p, a); }
-static inline MD_SIMD_FLOAT simd_load_h_duplicate(const MD_FLOAT* m)
+static inline MD_SIMD_FLOAT simd_real_load(MD_FLOAT* p) { return _mm256_load_pd(p); }
+static inline void simd_real_store(MD_FLOAT* p, MD_SIMD_FLOAT a)
+{
+    _mm256_store_pd(p, a);
+}
+static inline MD_SIMD_FLOAT simd_real_load_h_duplicate(const MD_FLOAT* m)
 {
     MD_SIMD_FLOAT ret;
     fprintf(stderr,
-        "simd_load_h_duplicate(): Not implemented for AVX2 with double precision!");
+        "simd_real_load_h_duplicate(): Not implemented for AVX2 with double precision!");
     exit(-1);
     return ret;
 }
 
-static inline MD_SIMD_FLOAT simd_load_h_dual(const MD_FLOAT* m)
+static inline MD_SIMD_FLOAT simd_real_load_h_dual(const MD_FLOAT* m)
 {
     MD_SIMD_FLOAT ret;
     fprintf(stderr,
-        "simd_load_h_dual(): Not implemented for AVX2 with double precision!");
+        "simd_real_load_h_dual(): Not implemented for AVX2 with double precision!");
     exit(-1);
     return ret;
 }
 
-static inline MD_FLOAT simd_h_dual_incr_reduced_sum(
+static inline MD_FLOAT simd_real_h_dual_incr_reduced_sum(
     MD_FLOAT* m, MD_SIMD_FLOAT v0, MD_SIMD_FLOAT v1)
 {
     fprintf(stderr,
-        "simd_h_dual_incr_reduced_sum(): Not implemented for AVX2 with double "
+        "simd_real_h_dual_incr_reduced_sum(): Not implemented for AVX2 with double "
         "precision!");
     exit(-1);
     return 0.0;
 }
 
-static inline MD_FLOAT simd_incr_reduced_sum(
+static inline MD_FLOAT simd_real_incr_reduced_sum(
     MD_FLOAT* m, MD_SIMD_FLOAT v0, MD_SIMD_FLOAT v1, MD_SIMD_FLOAT v2, MD_SIMD_FLOAT v3)
 {
     __m256d t0, t1, t2;
@@ -84,24 +87,25 @@ static inline MD_FLOAT simd_incr_reduced_sum(
     return *((MD_FLOAT*)&a0);
 }
 
-static inline MD_SIMD_FLOAT select_by_mask(MD_SIMD_FLOAT a, MD_SIMD_MASK m)
+static inline MD_SIMD_FLOAT simd_real_select_by_mask(MD_SIMD_FLOAT a, MD_SIMD_MASK m)
 {
     return _mm256_and_pd(a, m);
 }
-static inline MD_SIMD_FLOAT simd_reciprocal(MD_SIMD_FLOAT a)
+static inline MD_SIMD_FLOAT simd_real_reciprocal(MD_SIMD_FLOAT a)
 {
     return _mm256_cvtps_pd(_mm_rcp_ps(_mm256_cvtpd_ps(a)));
 }
 // static inline MD_SIMD_FLOAT simd_reciprocal(MD_SIMD_FLOAT a) { return
 // _mm256_rcp14_pd(a); }
-static inline MD_SIMD_FLOAT simd_fma(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_FLOAT c)
+static inline MD_SIMD_FLOAT simd_real_fma(
+    MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_FLOAT c)
 {
     return _mm256_fmadd_pd(a, b, c);
 }
-static inline MD_SIMD_FLOAT simd_masked_add(
+static inline MD_SIMD_FLOAT simd_real_masked_add(
     MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_MASK m)
 {
-    return simd_add(a, _mm256_and_pd(b, m));
+    return simd_real_add(a, _mm256_and_pd(b, m));
 }
 static inline MD_SIMD_MASK simd_mask_cond_lt(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
 {
@@ -128,7 +132,7 @@ static inline MD_SIMD_MASK simd_mask_from_u32(unsigned int a)
 }
 // TODO: Implement this, althrough it is just required for debugging
 static inline int simd_mask_to_u32(MD_SIMD_MASK a) { return 0; }
-static inline MD_FLOAT simd_h_reduce_sum(MD_SIMD_FLOAT a)
+static inline MD_FLOAT simd_real_h_reduce_sum(MD_SIMD_FLOAT a)
 {
     __m128d a0, a1;
     // test with shuffle & add as an alternative to hadd later
@@ -139,55 +143,56 @@ static inline MD_FLOAT simd_h_reduce_sum(MD_SIMD_FLOAT a)
     return *((MD_FLOAT*)&a0);
 }
 
-static inline void simd_h_decr3(
+static inline void simd_real_h_decr3(
     MD_FLOAT* m, MD_SIMD_FLOAT a0, MD_SIMD_FLOAT a1, MD_SIMD_FLOAT a2)
 {
     fprintf(stderr, "simd_h_decr3(): Not implemented for AVX2 with double precision!");
     exit(-1);
 }
 
-static inline MD_SIMD_INT simd_int_broadcast(int scalar)
+static inline MD_SIMD_INT simd_i32_broadcast(int scalar)
 {
     return _mm_set1_epi32(scalar);
 }
-static inline MD_SIMD_INT simd_int_zero(void) { return _mm_setzero_si128(); }
-static inline MD_SIMD_INT simd_int_seq(void) { return _mm_set_epi32(3, 2, 1, 0); }
-static inline MD_SIMD_INT simd_int_add(MD_SIMD_INT a, MD_SIMD_INT b)
+static inline MD_SIMD_INT simd_i32_zero(void) { return _mm_setzero_si128(); }
+static inline MD_SIMD_INT simd_i32_seq(void) { return _mm_set_epi32(3, 2, 1, 0); }
+static inline MD_SIMD_INT simd_i32_add(MD_SIMD_INT a, MD_SIMD_INT b)
 {
     return _mm_add_epi32(a, b);
 }
-static inline MD_SIMD_INT simd_int_mul(MD_SIMD_INT a, MD_SIMD_INT b)
+static inline MD_SIMD_INT simd_i32_mul(MD_SIMD_INT a, MD_SIMD_INT b)
 {
     return _mm_mul_epi32(a, b);
 }
-static inline MD_SIMD_INT simd_int_load(const int* m)
+static inline MD_SIMD_INT simd_i32_load(const int* m)
 {
     return _mm_load_si128((__m128i const*)m);
 }
-static inline MD_SIMD_INT simd_int_mask_load(const int* m, MD_SIMD_MASK k)
+static inline MD_SIMD_INT simd_i32_mask_load(const int* m, MD_SIMD_MASK k)
 {
-    return simd_int_load(m) & _mm256_cvtpd_epi32(k);
+    return simd_i32_load(m) & _mm256_cvtpd_epi32(k);
 }
 
-static inline MD_SIMD_INT simd_int_load_h_duplicate(const int* m)
+static inline MD_SIMD_INT simd_i32_load_h_duplicate(const int* m)
 {
     MD_SIMD_INT ret;
     fprintf(stderr,
-        "simd_int_load_h_duplicate(): Not implemented for AVX2 with double precision!");
+        "simd_i32_load_h_duplicate(): Not implemented for AVX2 with double precision!");
     exit(-1);
     return ret;
 }
 
-static inline MD_SIMD_INT simd_int_load_h_dual_scaled(const int* m, int scale)
+static inline MD_SIMD_INT simd_i32_load_h_dual_scaled(const int* m, int scale)
 {
     MD_SIMD_INT ret;
     fprintf(stderr,
-        "simd_int_load_h_dual_scaled(): Not implemented for AVX2 with double precision!");
+        "simd_i32_load_h_dual_scaled(): Not implemented for AVX2 with double precision!");
     exit(-1);
     return ret;
 }
 
-static inline MD_SIMD_FLOAT simd_gather(MD_SIMD_INT vidx, MD_FLOAT* base, const int scale)
+static inline MD_SIMD_FLOAT simd_real_gather(
+    MD_SIMD_INT vidx, MD_FLOAT* base, const int scale)
 {
     return _mm256_i32gather_pd(base, vidx, scale);
 }

--- a/src/common/simd/avx2_double.h
+++ b/src/common/simd/avx2_double.h
@@ -146,28 +146,15 @@ static inline void simd_h_decr3(
     exit(-1);
 }
 
-// Functions used in LAMMPS kernel
-#define simd_gather(vidx, m, s) _mm256_i32gather_pd(m, vidx, s);
-static inline MD_SIMD_INT simd_int_broadcast(int scalar)
-{
-    return _mm_set1_epi32(scalar);
-}
+static inline MD_SIMD_INT simd_int_broadcast(int scalar) { return _mm_set1_epi32(scalar); }
 static inline MD_SIMD_INT simd_int_zero(void) { return _mm_setzero_si128(); }
 static inline MD_SIMD_INT simd_int_seq(void) { return _mm_set_epi32(3, 2, 1, 0); }
-static inline MD_SIMD_INT simd_int_load(const int* m)
-{
+static inline MD_SIMD_INT simd_int_add(MD_SIMD_INT a, MD_SIMD_INT b) { return _mm_add_epi32(a, b); }
+static inline MD_SIMD_INT simd_int_mul(MD_SIMD_INT a, MD_SIMD_INT b) { return _mm_mul_epi32(a, b); }
+static inline MD_SIMD_INT simd_int_load(const int* m) {
     return _mm_load_si128((__m128i const*)m);
 }
-static inline MD_SIMD_INT simd_int_add(MD_SIMD_INT a, MD_SIMD_INT b)
-{
-    return _mm_add_epi32(a, b);
-}
-static inline MD_SIMD_INT simd_int_mul(MD_SIMD_INT a, MD_SIMD_INT b)
-{
-    return _mm_mul_epi32(a, b);
-}
-static inline MD_SIMD_INT simd_int_mask_load(const int* m, MD_SIMD_MASK k)
-{
+static inline MD_SIMD_INT simd_int_mask_load(const int* m, MD_SIMD_MASK k) {
     return simd_int_load(m) & _mm256_cvtpd_epi32(k);
 }
 
@@ -180,11 +167,15 @@ static inline MD_SIMD_INT simd_int_load_h_duplicate(const int *m)
     return ret;
 }
 
-static inline MD_SIMD_INT simd_int_load_h_dual(const int *m)
+static inline MD_SIMD_INT simd_int_load_h_dual_scaled(const int *m, int scale)
 {
     MD_SIMD_INT ret;
     fprintf(stderr,
-        "simd_int_load_h_dual(): Not implemented for AVX2 with double precision!");
+        "simd_int_load_h_dual_scaled(): Not implemented for AVX2 with double precision!");
     exit(-1);
     return ret;
+}
+
+static inline MD_SIMD_FLOAT simd_gather(MD_SIMD_INT vidx, MD_FLOAT *base, const int scale) {
+    return _mm256_i32gather_pd(base, vidx, scale);
 }

--- a/src/common/simd/avx2_double.h
+++ b/src/common/simd/avx2_double.h
@@ -146,19 +146,30 @@ static inline void simd_h_decr3(
     exit(-1);
 }
 
-static inline MD_SIMD_INT simd_int_broadcast(int scalar) { return _mm_set1_epi32(scalar); }
+static inline MD_SIMD_INT simd_int_broadcast(int scalar)
+{
+    return _mm_set1_epi32(scalar);
+}
 static inline MD_SIMD_INT simd_int_zero(void) { return _mm_setzero_si128(); }
 static inline MD_SIMD_INT simd_int_seq(void) { return _mm_set_epi32(3, 2, 1, 0); }
-static inline MD_SIMD_INT simd_int_add(MD_SIMD_INT a, MD_SIMD_INT b) { return _mm_add_epi32(a, b); }
-static inline MD_SIMD_INT simd_int_mul(MD_SIMD_INT a, MD_SIMD_INT b) { return _mm_mul_epi32(a, b); }
-static inline MD_SIMD_INT simd_int_load(const int* m) {
+static inline MD_SIMD_INT simd_int_add(MD_SIMD_INT a, MD_SIMD_INT b)
+{
+    return _mm_add_epi32(a, b);
+}
+static inline MD_SIMD_INT simd_int_mul(MD_SIMD_INT a, MD_SIMD_INT b)
+{
+    return _mm_mul_epi32(a, b);
+}
+static inline MD_SIMD_INT simd_int_load(const int* m)
+{
     return _mm_load_si128((__m128i const*)m);
 }
-static inline MD_SIMD_INT simd_int_mask_load(const int* m, MD_SIMD_MASK k) {
+static inline MD_SIMD_INT simd_int_mask_load(const int* m, MD_SIMD_MASK k)
+{
     return simd_int_load(m) & _mm256_cvtpd_epi32(k);
 }
 
-static inline MD_SIMD_INT simd_int_load_h_duplicate(const int *m)
+static inline MD_SIMD_INT simd_int_load_h_duplicate(const int* m)
 {
     MD_SIMD_INT ret;
     fprintf(stderr,
@@ -167,7 +178,7 @@ static inline MD_SIMD_INT simd_int_load_h_duplicate(const int *m)
     return ret;
 }
 
-static inline MD_SIMD_INT simd_int_load_h_dual_scaled(const int *m, int scale)
+static inline MD_SIMD_INT simd_int_load_h_dual_scaled(const int* m, int scale)
 {
     MD_SIMD_INT ret;
     fprintf(stderr,
@@ -176,6 +187,7 @@ static inline MD_SIMD_INT simd_int_load_h_dual_scaled(const int *m, int scale)
     return ret;
 }
 
-static inline MD_SIMD_FLOAT simd_gather(MD_SIMD_INT vidx, MD_FLOAT *base, const int scale) {
+static inline MD_SIMD_FLOAT simd_gather(MD_SIMD_INT vidx, MD_FLOAT* base, const int scale)
+{
     return _mm256_i32gather_pd(base, vidx, scale);
 }

--- a/src/common/simd/avx2_double.h
+++ b/src/common/simd/avx2_double.h
@@ -12,6 +12,12 @@
 #define MD_SIMD_INT   __m128i
 #define MD_SIMD_MASK  __m256d
 
+static inline int simd_test_any(MD_SIMD_MASK a)
+{
+    __m256i a_si256 = _mm256_castpd_si256(a);
+    return _mm256_testz_si256(a_si256, a_si256) != 0;
+}
+
 static inline MD_SIMD_FLOAT simd_broadcast(MD_FLOAT scalar)
 {
     return _mm256_set1_pd(scalar);

--- a/src/common/simd/avx2_double.h
+++ b/src/common/simd/avx2_double.h
@@ -15,7 +15,7 @@
 static inline int simd_test_any(MD_SIMD_MASK a)
 {
     __m256i a_si256 = _mm256_castpd_si256(a);
-    return _mm256_testz_si256(a_si256, a_si256) != 0;
+    return _mm256_testz_si256(a_si256, a_si256) == 0;
 }
 
 static inline MD_SIMD_FLOAT simd_broadcast(MD_FLOAT scalar)

--- a/src/common/simd/avx2_double.h
+++ b/src/common/simd/avx2_double.h
@@ -12,12 +12,7 @@
 #define MD_SIMD_INT   __m128i
 #define MD_SIMD_MASK  __m256d
 
-static inline int simd_test_any(MD_SIMD_MASK a)
-{
-    __m256i a_si256 = _mm256_castpd_si256(a);
-    return _mm256_testz_si256(a_si256, a_si256) == 0;
-}
-
+static inline int simd_test_any(MD_SIMD_MASK a) { return _mm256_movemask_pd(a) != 0; }
 static inline MD_SIMD_FLOAT simd_broadcast(MD_FLOAT scalar)
 {
     return _mm256_set1_pd(scalar);
@@ -174,4 +169,22 @@ static inline MD_SIMD_INT simd_int_mul(MD_SIMD_INT a, MD_SIMD_INT b)
 static inline MD_SIMD_INT simd_int_mask_load(const int* m, MD_SIMD_MASK k)
 {
     return simd_int_load(m) & _mm256_cvtpd_epi32(k);
+}
+
+static inline MD_SIMD_INT simd_int_load_h_duplicate(const int *m)
+{
+    MD_SIMD_INT ret;
+    fprintf(stderr,
+        "simd_int_load_h_duplicate(): Not implemented for AVX2 with double precision!");
+    exit(-1);
+    return ret;
+}
+
+static inline MD_SIMD_INT simd_int_load_h_dual(const int *m)
+{
+    MD_SIMD_INT ret;
+    fprintf(stderr,
+        "simd_int_load_h_dual(): Not implemented for AVX2 with double precision!");
+    exit(-1);
+    return ret;
 }

--- a/src/common/simd/avx2_float.h
+++ b/src/common/simd/avx2_float.h
@@ -100,14 +100,18 @@ static inline MD_SIMD_INT simd_int_load_h_duplicate(const int *m) {
     return _mm256_broadcastsi128_si256(_mm_load_si128((const __m128i *)(m)));
 }
 
-static inline MD_SIMD_INT simd_int_load_h_dual(const int *m)
+static inline MD_SIMD_INT simd_int_load_h_dual_scaled(const int *m, int scale)
 {
     __m128i t0, t1;
-    t0 = _mm_broadcastd_epi32(_mm_load_epi32(m));
-    t1 = _mm_broadcastd_epi32(_mm_load_epi32(m + 1));
+    t0 = _mm_set1_epi32(m[0] * scale);
+    t1 = _mm_set1_epi32(m[1] * scale);
     return _mm256_inserti128_si256(_mm256_castsi128_si256(t0), t1, 0x1);
 }
 
 static inline MD_SIMD_FLOAT simd_gather(MD_SIMD_INT vidx, MD_FLOAT *base, const int scale) {
     return _mm256_i32gather_ps(base, vidx, scale);
+}
+
+static inline MD_SIMD_INT simd_int_add(MD_SIMD_INT a, MD_SIMD_INT b) {
+    return _mm256_add_epi32(a, b);
 }

--- a/src/common/simd/avx2_float.h
+++ b/src/common/simd/avx2_float.h
@@ -7,44 +7,79 @@
 #include <immintrin.h>
 #include <zmmintrin.h>
 
-#define MD_SIMD_FLOAT   __m256
-#define MD_SIMD_MASK    __m256
-#define MD_SIMD_INT     __m256i
+#define MD_SIMD_FLOAT __m256
+#define MD_SIMD_MASK  __m256
+#define MD_SIMD_INT   __m256i
 
 static inline int simd_test_any(MD_SIMD_MASK a) { return _mm256_movemask_ps(a) != 0; }
-static inline MD_SIMD_FLOAT simd_broadcast(MD_FLOAT scalar) { return _mm256_set1_ps(scalar); }
+static inline MD_SIMD_FLOAT simd_broadcast(MD_FLOAT scalar)
+{
+    return _mm256_set1_ps(scalar);
+}
 static inline MD_SIMD_FLOAT simd_zero() { return _mm256_set1_ps(0.0); }
-static inline MD_SIMD_FLOAT simd_add(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b) { return _mm256_add_ps(a, b); }
-static inline MD_SIMD_FLOAT simd_sub(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b) { return _mm256_sub_ps(a, b); }
-static inline MD_SIMD_FLOAT simd_mul(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b) { return _mm256_mul_ps(a, b); }
-static inline MD_SIMD_FLOAT simd_load(MD_FLOAT *p) { return _mm256_load_ps(p); }
-static inline void simd_store(MD_FLOAT *p, MD_SIMD_FLOAT a) { _mm256_store_ps(p, a); }
-static inline MD_SIMD_FLOAT select_by_mask(MD_SIMD_FLOAT a, MD_SIMD_MASK m) { return _mm256_and_ps(a, m); }
+static inline MD_SIMD_FLOAT simd_add(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+{
+    return _mm256_add_ps(a, b);
+}
+static inline MD_SIMD_FLOAT simd_sub(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+{
+    return _mm256_sub_ps(a, b);
+}
+static inline MD_SIMD_FLOAT simd_mul(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+{
+    return _mm256_mul_ps(a, b);
+}
+static inline MD_SIMD_FLOAT simd_load(MD_FLOAT* p) { return _mm256_load_ps(p); }
+static inline void simd_store(MD_FLOAT* p, MD_SIMD_FLOAT a) { _mm256_store_ps(p, a); }
+static inline MD_SIMD_FLOAT select_by_mask(MD_SIMD_FLOAT a, MD_SIMD_MASK m)
+{
+    return _mm256_and_ps(a, m);
+}
 static inline MD_SIMD_FLOAT simd_reciprocal(MD_SIMD_FLOAT a) { return _mm256_rcp_ps(a); }
-static inline MD_SIMD_FLOAT simd_fma(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_FLOAT c) { return _mm256_fmadd_ps(a, b, c); }
-static inline MD_SIMD_FLOAT simd_masked_add(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_MASK m) { return _mm256_add_ps(a, _mm256_and_ps(b, m)); }
-static inline MD_SIMD_MASK simd_mask_cond_lt(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b) { return _mm256_cmp_ps(a, b, _CMP_LT_OQ); }
-static inline MD_SIMD_MASK simd_mask_and(MD_SIMD_MASK a, MD_SIMD_MASK b) { return _mm256_and_ps(a, b); }
+static inline MD_SIMD_FLOAT simd_fma(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_FLOAT c)
+{
+    return _mm256_fmadd_ps(a, b, c);
+}
+static inline MD_SIMD_FLOAT simd_masked_add(
+    MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_MASK m)
+{
+    return _mm256_add_ps(a, _mm256_and_ps(b, m));
+}
+static inline MD_SIMD_MASK simd_mask_cond_lt(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+{
+    return _mm256_cmp_ps(a, b, _CMP_LT_OQ);
+}
+static inline MD_SIMD_MASK simd_mask_and(MD_SIMD_MASK a, MD_SIMD_MASK b)
+{
+    return _mm256_and_ps(a, b);
+}
 
 static inline MD_SIMD_MASK simd_mask_from_u32(unsigned int a)
 {
     __m256i broadcast_mask = _mm256_set1_epi32(a);
-    __m256i index = _mm256_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7);
-    __m256i shift = _mm256_and_si256(broadcast_mask, _mm256_sllv_epi32(_mm256_set1_epi32(1), index));
-    __m256i result = _mm256_cmpgt_epi32(shift, _mm256_setzero_si256());
+    __m256i index          = _mm256_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7);
+    __m256i shift          = _mm256_and_si256(broadcast_mask,
+        _mm256_sllv_epi32(_mm256_set1_epi32(1), index));
+    __m256i result         = _mm256_cmpgt_epi32(shift, _mm256_setzero_si256());
     return _mm256_castsi256_ps(result);
 }
 
-static inline unsigned int simd_mask_to_u32(MD_SIMD_MASK a) { return _mm256_movemask_ps(a); }
-static inline MD_FLOAT simd_h_reduce_sum(MD_SIMD_FLOAT a) {
+static inline unsigned int simd_mask_to_u32(MD_SIMD_MASK a)
+{
+    return _mm256_movemask_ps(a);
+}
+static inline MD_FLOAT simd_h_reduce_sum(MD_SIMD_FLOAT a)
+{
     __m128 t0;
     t0 = _mm_add_ps(_mm256_castps256_ps128(a), _mm256_extractf128_ps(a, 0x1));
     t0 = _mm_add_ps(t0, _mm_permute_ps(t0, _MM_SHUFFLE(1, 0, 3, 2)));
     t0 = _mm_add_ss(t0, _mm_permute_ps(t0, _MM_SHUFFLE(0, 3, 2, 1)));
-    return *((MD_FLOAT *) &t0);
+    return *((MD_FLOAT*)&t0);
 }
 
-static inline MD_FLOAT simd_incr_reduced_sum(MD_FLOAT *m, MD_SIMD_FLOAT v0, MD_SIMD_FLOAT v1, MD_SIMD_FLOAT v2, MD_SIMD_FLOAT v3) {
+static inline MD_FLOAT simd_incr_reduced_sum(
+    MD_FLOAT* m, MD_SIMD_FLOAT v0, MD_SIMD_FLOAT v1, MD_SIMD_FLOAT v2, MD_SIMD_FLOAT v3)
+{
     __m128 t0, t2;
     v0 = _mm256_hadd_ps(v0, v1);
     v2 = _mm256_hadd_ps(v2, v3);
@@ -55,21 +90,25 @@ static inline MD_FLOAT simd_incr_reduced_sum(MD_FLOAT *m, MD_SIMD_FLOAT v0, MD_S
 
     t0 = _mm_add_ps(t0, _mm_permute_ps(t0, _MM_SHUFFLE(1, 0, 3, 2)));
     t0 = _mm_add_ss(t0, _mm_permute_ps(t0, _MM_SHUFFLE(0, 3, 2, 1)));
-    return *((MD_FLOAT *) &t0);
+    return *((MD_FLOAT*)&t0);
 }
 
-static inline MD_SIMD_FLOAT simd_load_h_duplicate(const MD_FLOAT *m) {
-    return _mm256_broadcast_ps((const __m128 *)(m));
+static inline MD_SIMD_FLOAT simd_load_h_duplicate(const MD_FLOAT* m)
+{
+    return _mm256_broadcast_ps((const __m128*)(m));
 }
 
-static inline MD_SIMD_FLOAT simd_load_h_dual(const MD_FLOAT *m) {
+static inline MD_SIMD_FLOAT simd_load_h_dual(const MD_FLOAT* m)
+{
     __m128 t0, t1;
     t0 = _mm_broadcast_ss(m);
     t1 = _mm_broadcast_ss(m + 1);
     return _mm256_insertf128_ps(_mm256_castps128_ps256(t0), t1, 0x1);
 }
 
-static inline MD_FLOAT simd_h_dual_incr_reduced_sum(MD_FLOAT *m, MD_SIMD_FLOAT v0, MD_SIMD_FLOAT v1) {
+static inline MD_FLOAT simd_h_dual_incr_reduced_sum(
+    MD_FLOAT* m, MD_SIMD_FLOAT v0, MD_SIMD_FLOAT v1)
+{
     __m128 t0, t1;
     v0 = _mm256_hadd_ps(v0, v1);
     t0 = _mm256_extractf128_ps(v0, 0x1);
@@ -80,27 +119,37 @@ static inline MD_FLOAT simd_h_dual_incr_reduced_sum(MD_FLOAT *m, MD_SIMD_FLOAT v
 
     t0 = _mm_add_ps(t0, _mm_permute_ps(t0, _MM_SHUFFLE(1, 0, 3, 2)));
     t0 = _mm_add_ss(t0, _mm_permute_ps(t0, _MM_SHUFFLE(0, 3, 2, 1)));
-    return *((MD_FLOAT *) &t0);
+    return *((MD_FLOAT*)&t0);
 }
 
-inline void simd_h_decr(MD_FLOAT *m, MD_SIMD_FLOAT a) {
+inline void simd_h_decr(MD_FLOAT* m, MD_SIMD_FLOAT a)
+{
     __m128 asum = _mm_add_ps(_mm256_castps256_ps128(a), _mm256_extractf128_ps(a, 0x1));
     _mm_store_ps(m, _mm_sub_ps(_mm_load_ps(m), asum));
 }
 
-static inline void simd_h_decr3(MD_FLOAT *m, MD_SIMD_FLOAT a0, MD_SIMD_FLOAT a1, MD_SIMD_FLOAT a2) {
+static inline void simd_h_decr3(
+    MD_FLOAT* m, MD_SIMD_FLOAT a0, MD_SIMD_FLOAT a1, MD_SIMD_FLOAT a2)
+{
     simd_h_decr(m, a0);
     simd_h_decr(m + CLUSTER_N, a1);
     simd_h_decr(m + CLUSTER_N * 2, a2);
 }
 
-static inline MD_SIMD_INT simd_int_broadcast(int scalar) { return _mm256_set1_epi32(scalar); }
-static inline MD_SIMD_INT simd_int_load(const int *m) { return _mm256_load_si256((MD_SIMD_INT *) m); }
-static inline MD_SIMD_INT simd_int_load_h_duplicate(const int *m) {
-    return _mm256_broadcastsi128_si256(_mm_load_si128((const __m128i *)(m)));
+static inline MD_SIMD_INT simd_int_broadcast(int scalar)
+{
+    return _mm256_set1_epi32(scalar);
+}
+static inline MD_SIMD_INT simd_int_load(const int* m)
+{
+    return _mm256_load_si256((MD_SIMD_INT*)m);
+}
+static inline MD_SIMD_INT simd_int_load_h_duplicate(const int* m)
+{
+    return _mm256_broadcastsi128_si256(_mm_load_si128((const __m128i*)(m)));
 }
 
-static inline MD_SIMD_INT simd_int_load_h_dual_scaled(const int *m, int scale)
+static inline MD_SIMD_INT simd_int_load_h_dual_scaled(const int* m, int scale)
 {
     __m128i t0, t1;
     t0 = _mm_set1_epi32(m[0] * scale);
@@ -108,10 +157,12 @@ static inline MD_SIMD_INT simd_int_load_h_dual_scaled(const int *m, int scale)
     return _mm256_inserti128_si256(_mm256_castsi128_si256(t0), t1, 0x1);
 }
 
-static inline MD_SIMD_FLOAT simd_gather(MD_SIMD_INT vidx, MD_FLOAT *base, const int scale) {
+static inline MD_SIMD_FLOAT simd_gather(MD_SIMD_INT vidx, MD_FLOAT* base, const int scale)
+{
     return _mm256_i32gather_ps(base, vidx, scale);
 }
 
-static inline MD_SIMD_INT simd_int_add(MD_SIMD_INT a, MD_SIMD_INT b) {
+static inline MD_SIMD_INT simd_int_add(MD_SIMD_INT a, MD_SIMD_INT b)
+{
     return _mm256_add_epi32(a, b);
 }

--- a/src/common/simd/avx2_float.h
+++ b/src/common/simd/avx2_float.h
@@ -11,12 +11,7 @@
 #define MD_SIMD_MASK    __m256
 #define MD_SIMD_INT     __m256i
 
-static inline int simd_test_any(MD_SIMD_MASK a)
-{
-    __m256i a_si256 = _mm256_castps_si256(a);
-    return _mm256_testz_si256(a_si256, a_si256) == 0;
-}
-
+static inline int simd_test_any(MD_SIMD_MASK a) { return _mm256_movemask_ps(a) != 0; }
 static inline MD_SIMD_FLOAT simd_broadcast(MD_FLOAT scalar) { return _mm256_set1_ps(scalar); }
 static inline MD_SIMD_FLOAT simd_zero() { return _mm256_set1_ps(0.0); }
 static inline MD_SIMD_FLOAT simd_add(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b) { return _mm256_add_ps(a, b); }

--- a/src/common/simd/avx2_float.h
+++ b/src/common/simd/avx2_float.h
@@ -12,35 +12,42 @@
 #define MD_SIMD_INT   __m256i
 
 static inline int simd_test_any(MD_SIMD_MASK a) { return _mm256_movemask_ps(a) != 0; }
-static inline MD_SIMD_FLOAT simd_broadcast(MD_FLOAT scalar)
+static inline MD_SIMD_FLOAT simd_real_broadcast(MD_FLOAT scalar)
 {
     return _mm256_set1_ps(scalar);
 }
-static inline MD_SIMD_FLOAT simd_zero() { return _mm256_set1_ps(0.0); }
-static inline MD_SIMD_FLOAT simd_add(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+static inline MD_SIMD_FLOAT simd_real_zero() { return _mm256_set1_ps(0.0); }
+static inline MD_SIMD_FLOAT simd_real_add(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
 {
     return _mm256_add_ps(a, b);
 }
-static inline MD_SIMD_FLOAT simd_sub(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+static inline MD_SIMD_FLOAT simd_real_sub(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
 {
     return _mm256_sub_ps(a, b);
 }
-static inline MD_SIMD_FLOAT simd_mul(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+static inline MD_SIMD_FLOAT simd_real_mul(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
 {
     return _mm256_mul_ps(a, b);
 }
-static inline MD_SIMD_FLOAT simd_load(MD_FLOAT* p) { return _mm256_load_ps(p); }
-static inline void simd_store(MD_FLOAT* p, MD_SIMD_FLOAT a) { _mm256_store_ps(p, a); }
-static inline MD_SIMD_FLOAT select_by_mask(MD_SIMD_FLOAT a, MD_SIMD_MASK m)
+static inline MD_SIMD_FLOAT simd_real_load(MD_FLOAT* p) { return _mm256_load_ps(p); }
+static inline void simd_real_store(MD_FLOAT* p, MD_SIMD_FLOAT a)
+{
+    _mm256_store_ps(p, a);
+}
+static inline MD_SIMD_FLOAT simd_real_select_by_mask(MD_SIMD_FLOAT a, MD_SIMD_MASK m)
 {
     return _mm256_and_ps(a, m);
 }
-static inline MD_SIMD_FLOAT simd_reciprocal(MD_SIMD_FLOAT a) { return _mm256_rcp_ps(a); }
-static inline MD_SIMD_FLOAT simd_fma(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_FLOAT c)
+static inline MD_SIMD_FLOAT simd_real_reciprocal(MD_SIMD_FLOAT a)
+{
+    return _mm256_rcp_ps(a);
+}
+static inline MD_SIMD_FLOAT simd_real_fma(
+    MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_FLOAT c)
 {
     return _mm256_fmadd_ps(a, b, c);
 }
-static inline MD_SIMD_FLOAT simd_masked_add(
+static inline MD_SIMD_FLOAT simd_real_masked_add(
     MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_MASK m)
 {
     return _mm256_add_ps(a, _mm256_and_ps(b, m));
@@ -68,7 +75,7 @@ static inline unsigned int simd_mask_to_u32(MD_SIMD_MASK a)
 {
     return _mm256_movemask_ps(a);
 }
-static inline MD_FLOAT simd_h_reduce_sum(MD_SIMD_FLOAT a)
+static inline MD_FLOAT simd_real_h_reduce_sum(MD_SIMD_FLOAT a)
 {
     __m128 t0;
     t0 = _mm_add_ps(_mm256_castps256_ps128(a), _mm256_extractf128_ps(a, 0x1));
@@ -77,7 +84,7 @@ static inline MD_FLOAT simd_h_reduce_sum(MD_SIMD_FLOAT a)
     return *((MD_FLOAT*)&t0);
 }
 
-static inline MD_FLOAT simd_incr_reduced_sum(
+static inline MD_FLOAT simd_real_incr_reduced_sum(
     MD_FLOAT* m, MD_SIMD_FLOAT v0, MD_SIMD_FLOAT v1, MD_SIMD_FLOAT v2, MD_SIMD_FLOAT v3)
 {
     __m128 t0, t2;
@@ -93,12 +100,12 @@ static inline MD_FLOAT simd_incr_reduced_sum(
     return *((MD_FLOAT*)&t0);
 }
 
-static inline MD_SIMD_FLOAT simd_load_h_duplicate(const MD_FLOAT* m)
+static inline MD_SIMD_FLOAT simd_real_load_h_duplicate(const MD_FLOAT* m)
 {
     return _mm256_broadcast_ps((const __m128*)(m));
 }
 
-static inline MD_SIMD_FLOAT simd_load_h_dual(const MD_FLOAT* m)
+static inline MD_SIMD_FLOAT simd_real_load_h_dual(const MD_FLOAT* m)
 {
     __m128 t0, t1;
     t0 = _mm_broadcast_ss(m);
@@ -106,7 +113,7 @@ static inline MD_SIMD_FLOAT simd_load_h_dual(const MD_FLOAT* m)
     return _mm256_insertf128_ps(_mm256_castps128_ps256(t0), t1, 0x1);
 }
 
-static inline MD_FLOAT simd_h_dual_incr_reduced_sum(
+static inline MD_FLOAT simd_real_h_dual_incr_reduced_sum(
     MD_FLOAT* m, MD_SIMD_FLOAT v0, MD_SIMD_FLOAT v1)
 {
     __m128 t0, t1;
@@ -128,7 +135,7 @@ inline void simd_h_decr(MD_FLOAT* m, MD_SIMD_FLOAT a)
     _mm_store_ps(m, _mm_sub_ps(_mm_load_ps(m), asum));
 }
 
-static inline void simd_h_decr3(
+static inline void simd_real_h_decr3(
     MD_FLOAT* m, MD_SIMD_FLOAT a0, MD_SIMD_FLOAT a1, MD_SIMD_FLOAT a2)
 {
     simd_h_decr(m, a0);
@@ -136,20 +143,20 @@ static inline void simd_h_decr3(
     simd_h_decr(m + CLUSTER_N * 2, a2);
 }
 
-static inline MD_SIMD_INT simd_int_broadcast(int scalar)
+static inline MD_SIMD_INT simd_i32_broadcast(int scalar)
 {
     return _mm256_set1_epi32(scalar);
 }
-static inline MD_SIMD_INT simd_int_load(const int* m)
+static inline MD_SIMD_INT simd_i32_load(const int* m)
 {
     return _mm256_load_si256((MD_SIMD_INT*)m);
 }
-static inline MD_SIMD_INT simd_int_load_h_duplicate(const int* m)
+static inline MD_SIMD_INT simd_i32_load_h_duplicate(const int* m)
 {
     return _mm256_broadcastsi128_si256(_mm_load_si128((const __m128i*)(m)));
 }
 
-static inline MD_SIMD_INT simd_int_load_h_dual_scaled(const int* m, int scale)
+static inline MD_SIMD_INT simd_i32_load_h_dual_scaled(const int* m, int scale)
 {
     __m128i t0, t1;
     t0 = _mm_set1_epi32(m[0] * scale);
@@ -157,12 +164,13 @@ static inline MD_SIMD_INT simd_int_load_h_dual_scaled(const int* m, int scale)
     return _mm256_inserti128_si256(_mm256_castsi128_si256(t0), t1, 0x1);
 }
 
-static inline MD_SIMD_FLOAT simd_gather(MD_SIMD_INT vidx, MD_FLOAT* base, const int scale)
+static inline MD_SIMD_FLOAT simd_real_gather(
+    MD_SIMD_INT vidx, MD_FLOAT* base, const int scale)
 {
     return _mm256_i32gather_ps(base, vidx, scale);
 }
 
-static inline MD_SIMD_INT simd_int_add(MD_SIMD_INT a, MD_SIMD_INT b)
+static inline MD_SIMD_INT simd_i32_add(MD_SIMD_INT a, MD_SIMD_INT b)
 {
     return _mm256_add_epi32(a, b);
 }

--- a/src/common/simd/avx2_float.h
+++ b/src/common/simd/avx2_float.h
@@ -13,7 +13,7 @@
 static inline int simd_test_any(MD_SIMD_MASK a)
 {
     __m256i a_si256 = _mm256_castps_si256(a);
-    return _mm256_testz_si256(a_si256, a_si256) != 0;
+    return _mm256_testz_si256(a_si256, a_si256) == 0;
 }
 
 static inline MD_SIMD_FLOAT simd_broadcast(MD_FLOAT scalar) { return _mm256_set1_ps(scalar); }

--- a/src/common/simd/avx2_float.h
+++ b/src/common/simd/avx2_float.h
@@ -10,6 +10,12 @@
 #define MD_SIMD_FLOAT   __m256
 #define MD_SIMD_MASK    __mmask8
 
+static inline int simd_test_any(MD_SIMD_MASK a)
+{
+    __m256i a_si256 = _mm256_castps_si256(a);
+    return _mm256_testz_si256(a_si256, a_si256) != 0;
+}
+
 static inline MD_SIMD_FLOAT simd_broadcast(MD_FLOAT scalar) { return _mm256_set1_ps(scalar); }
 static inline MD_SIMD_FLOAT simd_zero() { return _mm256_set1_ps(0.0); }
 static inline MD_SIMD_FLOAT simd_add(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b) { return _mm256_add_ps(a, b); }

--- a/src/common/simd/avx512_double.h
+++ b/src/common/simd/avx512_double.h
@@ -15,6 +15,7 @@
 #define MD_SIMD_BITMASK MD_SIMD_INT
 #define MD_SIMD_IBOOL   __mmask16
 
+static inline int simd_test_any(MD_SIMD_MASK a) { return _mm512_kortestz(a, a) != 0; }
 static inline MD_SIMD_MASK cvtIB2B(MD_SIMD_IBOOL a) { return (__mmask8)(a); }
 static inline MD_SIMD_FLOAT simd_broadcast(MD_FLOAT scalar)
 {

--- a/src/common/simd/avx512_double.h
+++ b/src/common/simd/avx512_double.h
@@ -156,10 +156,6 @@ static inline void simd_h_decr3(
     simd_h_decr(m + CLUSTER_N * 2, a2);
 }
 
-// Functions used in LAMMPS kernel
-// static inline MD_SIMD_FLOAT simd_gather(MD_SIMD_INT vidx, const MD_FLOAT *m, int s) {
-// return _mm512_i32gather_pd(vidx, m, s); }
-#define simd_gather(vidx, m, s) (_mm512_i32gather_pd(vidx, m, s))
 static inline MD_SIMD_INT simd_int_broadcast(int scalar)
 {
     return _mm256_set1_epi32(scalar);
@@ -173,7 +169,6 @@ static inline MD_SIMD_INT simd_int_load(const int* m)
 {
     return _mm256_load_si256((const MD_SIMD_INT*)m);
 }
-// static inline MD_SIMD_INT simd_int_load(const int *m) { return _mm256_load_epi32(m); }
 static inline MD_SIMD_INT simd_int_add(MD_SIMD_INT a, MD_SIMD_INT b)
 {
     return _mm256_add_epi32(a, b);
@@ -196,7 +191,12 @@ static inline MD_SIMD_INT simd_int_load_h_duplicate(const int* m)
     return _mm256_broadcast_i32x4(_mm_load_epi32(m));
 }
 
-static inline MD_SIMD_INT simd_int_load_h_dual(const int* m)
+static inline MD_SIMD_INT simd_int_load_h_dual_scaled(const int* m, int scale)
 {
-    return _mm256_inserti32x4(_mm256_broadcastd_epi32(_mm_load_epi32(m)), _mm_load_epi32(m + 1), 1);
+    return _mm256_inserti32x4(_mm256_set1_epi32(m[0] * scale), _mm_set1_epi32(m[1] * scale), 1);
+}
+
+static inline MD_SIMD_FLOAT simd_gather(MD_SIMD_INT vidx, MD_FLOAT *base, const int scale)
+{
+    return _mm512_i32gather_pd(vidx, base, scale);
 }

--- a/src/common/simd/avx512_double.h
+++ b/src/common/simd/avx512_double.h
@@ -17,32 +17,32 @@
 
 static inline int simd_test_any(MD_SIMD_MASK a) { return _mm512_kortestz(a, a) == 0; }
 static inline MD_SIMD_MASK cvtIB2B(MD_SIMD_IBOOL a) { return (__mmask8)(a); }
-static inline MD_SIMD_FLOAT simd_broadcast(MD_FLOAT scalar)
+static inline MD_SIMD_FLOAT simd_real_broadcast(MD_FLOAT scalar)
 {
     return _mm512_set1_pd(scalar);
 }
-static inline MD_SIMD_FLOAT simd_zero(void) { return _mm512_set1_pd(0.0); }
-static inline MD_SIMD_FLOAT simd_add(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+static inline MD_SIMD_FLOAT simd_real_zero(void) { return _mm512_set1_pd(0.0); }
+static inline MD_SIMD_FLOAT simd_real_add(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
 {
     return _mm512_add_pd(a, b);
 }
-static inline MD_SIMD_FLOAT simd_sub(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+static inline MD_SIMD_FLOAT simd_real_sub(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
 {
     return _mm512_sub_pd(a, b);
 }
-static inline MD_SIMD_FLOAT simd_mul(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+static inline MD_SIMD_FLOAT simd_real_mul(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
 {
     return _mm512_mul_pd(a, b);
 }
-static inline MD_SIMD_FLOAT simd_fma(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_FLOAT c)
+static inline MD_SIMD_FLOAT simd_real_fma(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_FLOAT c)
 {
     return _mm512_fmadd_pd(a, b, c);
 }
-static inline MD_SIMD_FLOAT simd_reciprocal(MD_SIMD_FLOAT a)
+static inline MD_SIMD_FLOAT simd_real_reciprocal(MD_SIMD_FLOAT a)
 {
     return _mm512_rcp14_pd(a);
 }
-static inline MD_SIMD_FLOAT simd_masked_add(
+static inline MD_SIMD_FLOAT simd_real_masked_add(
     MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_MASK m)
 {
     return _mm512_mask_add_pd(a, m, a, b);
@@ -57,13 +57,13 @@ static inline MD_SIMD_MASK simd_mask_cond_lt(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
 }
 static inline MD_SIMD_MASK simd_mask_from_u32(unsigned int a) { return _cvtu32_mask8(a); }
 static inline unsigned int simd_mask_to_u32(MD_SIMD_MASK a) { return _cvtmask8_u32(a); }
-static inline MD_SIMD_FLOAT simd_load(MD_FLOAT* p) { return _mm512_load_pd(p); }
-static inline void simd_store(MD_FLOAT* p, MD_SIMD_FLOAT a) { _mm512_store_pd(p, a); }
-static inline MD_SIMD_FLOAT select_by_mask(MD_SIMD_FLOAT a, MD_SIMD_MASK m)
+static inline MD_SIMD_FLOAT simd_real_load(MD_FLOAT* p) { return _mm512_load_pd(p); }
+static inline void simd_real_store(MD_FLOAT* p, MD_SIMD_FLOAT a) { _mm512_store_pd(p, a); }
+static inline MD_SIMD_FLOAT simd_real_select_by_mask(MD_SIMD_FLOAT a, MD_SIMD_MASK m)
 {
     return _mm512_mask_mov_pd(_mm512_setzero_pd(), m, a);
 }
-static inline MD_FLOAT simd_h_reduce_sum(MD_SIMD_FLOAT a)
+static inline MD_FLOAT simd_real_h_reduce_sum(MD_SIMD_FLOAT a)
 {
     MD_SIMD_FLOAT x = _mm512_add_pd(a, _mm512_shuffle_f64x2(a, a, 0xee));
     x               = _mm512_add_pd(x, _mm512_shuffle_f64x2(x, x, 0x11));
@@ -71,7 +71,7 @@ static inline MD_FLOAT simd_h_reduce_sum(MD_SIMD_FLOAT a)
     return *((MD_FLOAT*)&x);
 }
 
-static inline MD_FLOAT simd_incr_reduced_sum(
+static inline MD_FLOAT simd_real_incr_reduced_sum(
     MD_FLOAT* m, MD_SIMD_FLOAT v0, MD_SIMD_FLOAT v1, MD_SIMD_FLOAT v2, MD_SIMD_FLOAT v3)
 {
     __m512d t0, t2;
@@ -104,19 +104,19 @@ static inline MD_FLOAT simd_incr_reduced_sum(
     return _mm_cvtsd_f64(_mm512_castpd512_pd128(t0));
 }
 
-static inline MD_SIMD_FLOAT simd_load_h_duplicate(const MD_FLOAT* m)
+static inline MD_SIMD_FLOAT simd_real_load_h_duplicate(const MD_FLOAT* m)
 {
     return _mm512_broadcast_f64x4(_mm256_load_pd(m));
 }
 
-static inline MD_SIMD_FLOAT simd_load_h_dual(const MD_FLOAT* m)
+static inline MD_SIMD_FLOAT simd_real_load_h_dual(const MD_FLOAT* m)
 {
     return _mm512_insertf64x4(_mm512_broadcastsd_pd(_mm_load_sd(m)),
         _mm256_broadcastsd_pd(_mm_load_sd(m + 1)),
         1);
 }
 
-static inline MD_FLOAT simd_h_dual_incr_reduced_sum(
+static inline MD_FLOAT simd_real_h_dual_incr_reduced_sum(
     MD_FLOAT* m, MD_SIMD_FLOAT v0, MD_SIMD_FLOAT v1)
 {
     __m512d t0;
@@ -148,7 +148,7 @@ static inline void simd_h_decr(MD_FLOAT* m, MD_SIMD_FLOAT a)
     _mm256_store_pd(m, t);
 }
 
-static inline void simd_h_decr3(
+static inline void simd_real_h_decr3(
     MD_FLOAT* m, MD_SIMD_FLOAT a0, MD_SIMD_FLOAT a1, MD_SIMD_FLOAT a2)
 {
     simd_h_decr(m, a0);
@@ -156,49 +156,49 @@ static inline void simd_h_decr3(
     simd_h_decr(m + CLUSTER_N * 2, a2);
 }
 
-static inline MD_SIMD_INT simd_int_broadcast(int scalar)
+static inline MD_SIMD_INT simd_i32_broadcast(int scalar)
 {
     return _mm256_set1_epi32(scalar);
 }
-static inline MD_SIMD_INT simd_int_zero(void) { return _mm256_setzero_si256(); }
-static inline MD_SIMD_INT simd_int_seq(void)
+static inline MD_SIMD_INT simd_i32_zero(void) { return _mm256_setzero_si256(); }
+static inline MD_SIMD_INT simd_i32_seq(void)
 {
     return _mm256_set_epi32(7, 6, 5, 4, 3, 2, 1, 0);
 }
-static inline MD_SIMD_INT simd_int_load(const int* m)
+static inline MD_SIMD_INT simd_i32_load(const int* m)
 {
     return _mm256_load_si256((const MD_SIMD_INT*)m);
 }
-static inline MD_SIMD_INT simd_int_add(MD_SIMD_INT a, MD_SIMD_INT b)
+static inline MD_SIMD_INT simd_i32_add(MD_SIMD_INT a, MD_SIMD_INT b)
 {
     return _mm256_add_epi32(a, b);
 }
-static inline MD_SIMD_INT simd_int_mul(MD_SIMD_INT a, MD_SIMD_INT b)
+static inline MD_SIMD_INT simd_i32_mul(MD_SIMD_INT a, MD_SIMD_INT b)
 {
     return _mm256_mul_epi32(a, b);
 }
-static inline MD_SIMD_INT simd_int_mask_load(const int* m, MD_SIMD_MASK k)
+static inline MD_SIMD_INT simd_i32_mask_load(const int* m, MD_SIMD_MASK k)
 {
-    return _mm256_mask_load_epi32(simd_int_zero(), k, m);
+    return _mm256_mask_load_epi32(simd_i32_zero(), k, m);
 }
 static inline MD_SIMD_MASK simd_mask_int_cond_lt(MD_SIMD_INT a, MD_SIMD_INT b)
 {
     return _mm256_cmp_epi32_mask(a, b, _MM_CMPINT_LT);
 }
 
-static inline MD_SIMD_INT simd_int_load_h_duplicate(const int* m)
+static inline MD_SIMD_INT simd_i32_load_h_duplicate(const int* m)
 {
     return _mm256_broadcast_i32x4(_mm_load_epi32(m));
 }
 
-static inline MD_SIMD_INT simd_int_load_h_dual_scaled(const int* m, int scale)
+static inline MD_SIMD_INT simd_i32_load_h_dual_scaled(const int* m, int scale)
 {
     return _mm256_inserti32x4(_mm256_set1_epi32(m[0] * scale),
         _mm_set1_epi32(m[1] * scale),
         1);
 }
 
-static inline MD_SIMD_FLOAT simd_gather(MD_SIMD_INT vidx, MD_FLOAT* base, const int scale)
+static inline MD_SIMD_FLOAT simd_real_gather(MD_SIMD_INT vidx, MD_FLOAT* base, const int scale)
 {
     return _mm512_i32gather_pd(vidx, base, scale);
 }

--- a/src/common/simd/avx512_double.h
+++ b/src/common/simd/avx512_double.h
@@ -34,7 +34,8 @@ static inline MD_SIMD_FLOAT simd_real_mul(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
 {
     return _mm512_mul_pd(a, b);
 }
-static inline MD_SIMD_FLOAT simd_real_fma(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_FLOAT c)
+static inline MD_SIMD_FLOAT simd_real_fma(
+    MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_FLOAT c)
 {
     return _mm512_fmadd_pd(a, b, c);
 }
@@ -58,7 +59,10 @@ static inline MD_SIMD_MASK simd_mask_cond_lt(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
 static inline MD_SIMD_MASK simd_mask_from_u32(unsigned int a) { return _cvtu32_mask8(a); }
 static inline unsigned int simd_mask_to_u32(MD_SIMD_MASK a) { return _cvtmask8_u32(a); }
 static inline MD_SIMD_FLOAT simd_real_load(MD_FLOAT* p) { return _mm512_load_pd(p); }
-static inline void simd_real_store(MD_FLOAT* p, MD_SIMD_FLOAT a) { _mm512_store_pd(p, a); }
+static inline void simd_real_store(MD_FLOAT* p, MD_SIMD_FLOAT a)
+{
+    _mm512_store_pd(p, a);
+}
 static inline MD_SIMD_FLOAT simd_real_select_by_mask(MD_SIMD_FLOAT a, MD_SIMD_MASK m)
 {
     return _mm512_mask_mov_pd(_mm512_setzero_pd(), m, a);
@@ -198,7 +202,8 @@ static inline MD_SIMD_INT simd_i32_load_h_dual_scaled(const int* m, int scale)
         1);
 }
 
-static inline MD_SIMD_FLOAT simd_real_gather(MD_SIMD_INT vidx, MD_FLOAT* base, const int scale)
+static inline MD_SIMD_FLOAT simd_real_gather(
+    MD_SIMD_INT vidx, MD_FLOAT* base, const int scale)
 {
     return _mm512_i32gather_pd(vidx, base, scale);
 }

--- a/src/common/simd/avx512_double.h
+++ b/src/common/simd/avx512_double.h
@@ -15,7 +15,7 @@
 #define MD_SIMD_BITMASK MD_SIMD_INT
 #define MD_SIMD_IBOOL   __mmask16
 
-static inline int simd_test_any(MD_SIMD_MASK a) { return _mm512_kortestz(a, a) != 0; }
+static inline int simd_test_any(MD_SIMD_MASK a) { return _mm512_kortestz(a, a) == 0; }
 static inline MD_SIMD_MASK cvtIB2B(MD_SIMD_IBOOL a) { return (__mmask8)(a); }
 static inline MD_SIMD_FLOAT simd_broadcast(MD_FLOAT scalar)
 {

--- a/src/common/simd/avx512_double.h
+++ b/src/common/simd/avx512_double.h
@@ -193,10 +193,12 @@ static inline MD_SIMD_INT simd_int_load_h_duplicate(const int* m)
 
 static inline MD_SIMD_INT simd_int_load_h_dual_scaled(const int* m, int scale)
 {
-    return _mm256_inserti32x4(_mm256_set1_epi32(m[0] * scale), _mm_set1_epi32(m[1] * scale), 1);
+    return _mm256_inserti32x4(_mm256_set1_epi32(m[0] * scale),
+        _mm_set1_epi32(m[1] * scale),
+        1);
 }
 
-static inline MD_SIMD_FLOAT simd_gather(MD_SIMD_INT vidx, MD_FLOAT *base, const int scale)
+static inline MD_SIMD_FLOAT simd_gather(MD_SIMD_INT vidx, MD_FLOAT* base, const int scale)
 {
     return _mm512_i32gather_pd(vidx, base, scale);
 }

--- a/src/common/simd/avx512_double.h
+++ b/src/common/simd/avx512_double.h
@@ -190,3 +190,13 @@ static inline MD_SIMD_MASK simd_mask_int_cond_lt(MD_SIMD_INT a, MD_SIMD_INT b)
 {
     return _mm256_cmp_epi32_mask(a, b, _MM_CMPINT_LT);
 }
+
+static inline MD_SIMD_INT simd_int_load_h_duplicate(const int* m)
+{
+    return _mm256_broadcast_i32x4(_mm_load_epi32(m));
+}
+
+static inline MD_SIMD_INT simd_int_load_h_dual(const int* m)
+{
+    return _mm256_inserti32x4(_mm256_broadcastd_epi32(_mm_load_epi32(m)), _mm_load_epi32(m + 1), 1);
+}

--- a/src/common/simd/avx512_float.h
+++ b/src/common/simd/avx512_float.h
@@ -163,3 +163,8 @@ static inline MD_SIMD_INT simd_int_load_h_dual(const int* m)
 {
     return _mm512_inserti32x8(_mm512_broadcastd_epi32(_mm_load_epi32(m)), _mm256_broadcastd_epi32(_mm_load_epi32(m + 1)), 1);
 }
+
+static inline MD_SIMD_INT simd_int_load(const int* m)
+{
+    return _mm512_load_si512((const MD_SIMD_INT*)m);
+}

--- a/src/common/simd/avx512_float.h
+++ b/src/common/simd/avx512_float.h
@@ -18,6 +18,7 @@
 #define MD_SIMD_INT32   __m512i
 #define MD_SIMD_BITMASK MD_SIMD_INT32
 
+static inline int simd_test_any(MD_SIMD_MASK a) { return _mm512_kortestz(a, a) != 0; }
 static inline MD_SIMD_BITMASK simd_load_bitmask(const int* m)
 {
     return _mm512_load_si512(m);

--- a/src/common/simd/avx512_float.h
+++ b/src/common/simd/avx512_float.h
@@ -23,7 +23,6 @@ static inline MD_SIMD_BITMASK simd_load_bitmask(const int* m)
     return _mm512_load_si512(m);
 }
 
-#define simd_gather(vidx, m, s) (_mm512_i32gather_ps(vidx, m, s))
 static inline MD_SIMD_INT simd_int_broadcast(int a) { return _mm512_set1_epi32(a); }
 
 static inline MD_SIMD_IBOOL simd_test_bits(MD_SIMD_FLOAT a)
@@ -153,18 +152,27 @@ static inline void simd_h_decr3(
     simd_h_decr(m + CLUSTER_N * 2, a2);
 }
 
+static inline MD_SIMD_INT simd_int_add(MD_SIMD_INT a, MD_SIMD_INT b)
+{
+    return _mm512_add_epi32(a, b);
+}
+
 static inline MD_SIMD_INT simd_int_load_h_duplicate(const int* m)
 {
-    //return _mm512_broadcast_i32x8(_mm256_load_epi32(m));
     return _mm512_broadcast_i32x8(_mm256_load_si256((const __m256i *)m));
 }
 
-static inline MD_SIMD_INT simd_int_load_h_dual(const int* m)
+static inline MD_SIMD_INT simd_int_load_h_dual_scaled(const int* m, int scale)
 {
-    return _mm512_inserti32x8(_mm512_broadcastd_epi32(_mm_load_epi32(m)), _mm256_broadcastd_epi32(_mm_load_epi32(m + 1)), 1);
+    return _mm512_inserti32x8(_mm512_set1_epi32(m[0] * scale), _mm256_set1_epi32(m[1] * scale), 1);
 }
 
 static inline MD_SIMD_INT simd_int_load(const int* m)
 {
     return _mm512_load_si512((const MD_SIMD_INT*)m);
+}
+
+static inline MD_SIMD_FLOAT simd_gather(MD_SIMD_INT vidx, MD_FLOAT *base, const int scale)
+{
+    return _mm512_i32gather_ps(vidx, base, scale);
 }

--- a/src/common/simd/avx512_float.h
+++ b/src/common/simd/avx512_float.h
@@ -13,10 +13,9 @@
 
 #define MD_SIMD_FLOAT   __m512
 #define MD_SIMD_MASK    __mmask16
-#define MD_SIMD_INT     __m256i
 #define MD_SIMD_IBOOL   __mmask16
-#define MD_SIMD_INT32   __m512i
-#define MD_SIMD_BITMASK MD_SIMD_INT32
+#define MD_SIMD_INT     __m512i
+#define MD_SIMD_BITMASK __m512i
 
 static inline int simd_test_any(MD_SIMD_MASK a) { return _mm512_kortestz(a, a) == 0; }
 static inline MD_SIMD_BITMASK simd_load_bitmask(const int* m)
@@ -24,7 +23,8 @@ static inline MD_SIMD_BITMASK simd_load_bitmask(const int* m)
     return _mm512_load_si512(m);
 }
 
-static inline MD_SIMD_INT32 simd_int32_broadcast(int a) { return _mm512_set1_epi32(a); }
+#define simd_gather(vidx, m, s) (_mm512_i32gather_ps(vidx, m, s))
+static inline MD_SIMD_INT simd_int_broadcast(int a) { return _mm512_set1_epi32(a); }
 
 static inline MD_SIMD_IBOOL simd_test_bits(MD_SIMD_FLOAT a)
 {
@@ -151,4 +151,15 @@ static inline void simd_h_decr3(
     simd_h_decr(m, a0);
     simd_h_decr(m + CLUSTER_N, a1);
     simd_h_decr(m + CLUSTER_N * 2, a2);
+}
+
+static inline MD_SIMD_INT simd_int_load_h_duplicate(const int* m)
+{
+    //return _mm512_broadcast_i32x8(_mm256_load_epi32(m));
+    return _mm512_broadcast_i32x8(_mm256_load_si256((const __m256i *)m));
+}
+
+static inline MD_SIMD_INT simd_int_load_h_dual(const int* m)
+{
+    return _mm512_inserti32x8(_mm512_broadcastd_epi32(_mm_load_epi32(m)), _mm256_broadcastd_epi32(_mm_load_epi32(m + 1)), 1);
 }

--- a/src/common/simd/avx512_float.h
+++ b/src/common/simd/avx512_float.h
@@ -18,7 +18,7 @@
 #define MD_SIMD_INT32   __m512i
 #define MD_SIMD_BITMASK MD_SIMD_INT32
 
-static inline int simd_test_any(MD_SIMD_MASK a) { return _mm512_kortestz(a, a) != 0; }
+static inline int simd_test_any(MD_SIMD_MASK a) { return _mm512_kortestz(a, a) == 0; }
 static inline MD_SIMD_BITMASK simd_load_bitmask(const int* m)
 {
     return _mm512_load_si512(m);

--- a/src/common/simd/avx512_float.h
+++ b/src/common/simd/avx512_float.h
@@ -159,12 +159,14 @@ static inline MD_SIMD_INT simd_int_add(MD_SIMD_INT a, MD_SIMD_INT b)
 
 static inline MD_SIMD_INT simd_int_load_h_duplicate(const int* m)
 {
-    return _mm512_broadcast_i32x8(_mm256_load_si256((const __m256i *)m));
+    return _mm512_broadcast_i32x8(_mm256_load_si256((const __m256i*)m));
 }
 
 static inline MD_SIMD_INT simd_int_load_h_dual_scaled(const int* m, int scale)
 {
-    return _mm512_inserti32x8(_mm512_set1_epi32(m[0] * scale), _mm256_set1_epi32(m[1] * scale), 1);
+    return _mm512_inserti32x8(_mm512_set1_epi32(m[0] * scale),
+        _mm256_set1_epi32(m[1] * scale),
+        1);
 }
 
 static inline MD_SIMD_INT simd_int_load(const int* m)
@@ -172,7 +174,7 @@ static inline MD_SIMD_INT simd_int_load(const int* m)
     return _mm512_load_si512((const MD_SIMD_INT*)m);
 }
 
-static inline MD_SIMD_FLOAT simd_gather(MD_SIMD_INT vidx, MD_FLOAT *base, const int scale)
+static inline MD_SIMD_FLOAT simd_gather(MD_SIMD_INT vidx, MD_FLOAT* base, const int scale)
 {
     return _mm512_i32gather_ps(vidx, base, scale);
 }

--- a/src/common/simd/avx512_float.h
+++ b/src/common/simd/avx512_float.h
@@ -23,7 +23,7 @@ static inline MD_SIMD_BITMASK simd_load_bitmask(const int* m)
     return _mm512_load_si512(m);
 }
 
-static inline MD_SIMD_INT simd_int_broadcast(int a) { return _mm512_set1_epi32(a); }
+static inline MD_SIMD_INT simd_i32_broadcast(int a) { return _mm512_set1_epi32(a); }
 
 static inline MD_SIMD_IBOOL simd_test_bits(MD_SIMD_FLOAT a)
 {
@@ -31,32 +31,33 @@ static inline MD_SIMD_IBOOL simd_test_bits(MD_SIMD_FLOAT a)
 }
 
 static inline MD_SIMD_MASK cvtIB2B(MD_SIMD_IBOOL a) { return a; }
-static inline MD_SIMD_FLOAT simd_broadcast(float scalar)
+static inline MD_SIMD_FLOAT simd_real_broadcast(float scalar)
 {
     return _mm512_set1_ps(scalar);
 }
-static inline MD_SIMD_FLOAT simd_zero(void) { return _mm512_set1_ps(0.0f); }
-static inline MD_SIMD_FLOAT simd_add(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+static inline MD_SIMD_FLOAT simd_real_zero(void) { return _mm512_set1_ps(0.0f); }
+static inline MD_SIMD_FLOAT simd_real_add(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
 {
     return _mm512_add_ps(a, b);
 }
-static inline MD_SIMD_FLOAT simd_sub(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+static inline MD_SIMD_FLOAT simd_real_sub(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
 {
     return _mm512_sub_ps(a, b);
 }
-static inline MD_SIMD_FLOAT simd_mul(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+static inline MD_SIMD_FLOAT simd_real_mul(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
 {
     return _mm512_mul_ps(a, b);
 }
-static inline MD_SIMD_FLOAT simd_fma(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_FLOAT c)
+static inline MD_SIMD_FLOAT simd_real_fma(
+    MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_FLOAT c)
 {
     return _mm512_fmadd_ps(a, b, c);
 }
-static inline MD_SIMD_FLOAT simd_reciprocal(MD_SIMD_FLOAT a)
+static inline MD_SIMD_FLOAT simd_real_reciprocal(MD_SIMD_FLOAT a)
 {
     return _mm512_rcp14_ps(a);
 }
-static inline MD_SIMD_FLOAT simd_masked_add(
+static inline MD_SIMD_FLOAT simd_real_masked_add(
     MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_MASK m)
 {
     return _mm512_mask_add_ps(a, m, a, b);
@@ -74,13 +75,16 @@ static inline MD_SIMD_MASK simd_mask_from_u32(unsigned int a)
     return _cvtu32_mask16(a);
 }
 static inline unsigned int simd_mask_to_u32(MD_SIMD_MASK a) { return _cvtmask16_u32(a); }
-static inline MD_SIMD_FLOAT simd_load(MD_FLOAT* p) { return _mm512_load_ps(p); }
-static inline void simd_store(MD_FLOAT* p, MD_SIMD_FLOAT a) { _mm512_store_ps(p, a); }
-static inline MD_SIMD_FLOAT select_by_mask(MD_SIMD_FLOAT a, MD_SIMD_MASK m)
+static inline MD_SIMD_FLOAT simd_real_load(MD_FLOAT* p) { return _mm512_load_ps(p); }
+static inline void simd_real_store(MD_FLOAT* p, MD_SIMD_FLOAT a)
+{
+    _mm512_store_ps(p, a);
+}
+static inline MD_SIMD_FLOAT simd_real_select_by_mask(MD_SIMD_FLOAT a, MD_SIMD_MASK m)
 {
     return _mm512_mask_mov_ps(_mm512_setzero_ps(), m, a);
 }
-static inline MD_FLOAT simd_h_reduce_sum(MD_SIMD_FLOAT a)
+static inline MD_FLOAT simd_real_h_reduce_sum(MD_SIMD_FLOAT a)
 {
     // This would only be called in a Mx16 configuration, which is not valid in GROMACS
     fprintf(stderr,
@@ -90,7 +94,7 @@ static inline MD_FLOAT simd_h_reduce_sum(MD_SIMD_FLOAT a)
     return 0.0;
 }
 
-static inline MD_FLOAT simd_incr_reduced_sum(
+static inline MD_FLOAT simd_real_incr_reduced_sum(
     MD_FLOAT* m, MD_SIMD_FLOAT v0, MD_SIMD_FLOAT v1, MD_SIMD_FLOAT v2, MD_SIMD_FLOAT v3)
 {
     // This would only be called in a Mx16 configuration, which is not valid in GROMACS
@@ -101,19 +105,19 @@ static inline MD_FLOAT simd_incr_reduced_sum(
     return 0.0;
 }
 
-static inline MD_SIMD_FLOAT simd_load_h_duplicate(const float* m)
+static inline MD_SIMD_FLOAT simd_real_load_h_duplicate(const float* m)
 {
     return _mm512_castpd_ps(_mm512_broadcast_f64x4(_mm256_load_pd((const double*)(m))));
 }
 
-static inline MD_SIMD_FLOAT simd_load_h_dual(const float* m)
+static inline MD_SIMD_FLOAT simd_real_load_h_dual(const float* m)
 {
     return _mm512_shuffle_f32x4(_mm512_broadcastss_ps(_mm_load_ss(m)),
         _mm512_broadcastss_ps(_mm_load_ss(m + 1)),
         0x44);
 }
 
-static inline MD_FLOAT simd_h_dual_incr_reduced_sum(
+static inline MD_FLOAT simd_real_h_dual_incr_reduced_sum(
     float* m, MD_SIMD_FLOAT v0, MD_SIMD_FLOAT v1)
 {
     __m512 t0, t1;
@@ -144,7 +148,7 @@ static inline void simd_h_decr(MD_FLOAT* m, MD_SIMD_FLOAT a)
     _mm256_store_ps(m, t);
 }
 
-static inline void simd_h_decr3(
+static inline void simd_real_h_decr3(
     MD_FLOAT* m, MD_SIMD_FLOAT a0, MD_SIMD_FLOAT a1, MD_SIMD_FLOAT a2)
 {
     simd_h_decr(m, a0);
@@ -152,29 +156,30 @@ static inline void simd_h_decr3(
     simd_h_decr(m + CLUSTER_N * 2, a2);
 }
 
-static inline MD_SIMD_INT simd_int_add(MD_SIMD_INT a, MD_SIMD_INT b)
+static inline MD_SIMD_INT simd_i32_add(MD_SIMD_INT a, MD_SIMD_INT b)
 {
     return _mm512_add_epi32(a, b);
 }
 
-static inline MD_SIMD_INT simd_int_load_h_duplicate(const int* m)
+static inline MD_SIMD_INT simd_i32_load_h_duplicate(const int* m)
 {
     return _mm512_broadcast_i32x8(_mm256_load_si256((const __m256i*)m));
 }
 
-static inline MD_SIMD_INT simd_int_load_h_dual_scaled(const int* m, int scale)
+static inline MD_SIMD_INT simd_i32_load_h_dual_scaled(const int* m, int scale)
 {
     return _mm512_inserti32x8(_mm512_set1_epi32(m[0] * scale),
         _mm256_set1_epi32(m[1] * scale),
         1);
 }
 
-static inline MD_SIMD_INT simd_int_load(const int* m)
+static inline MD_SIMD_INT simd_i32_load(const int* m)
 {
     return _mm512_load_si512((const MD_SIMD_INT*)m);
 }
 
-static inline MD_SIMD_FLOAT simd_gather(MD_SIMD_INT vidx, MD_FLOAT* base, const int scale)
+static inline MD_SIMD_FLOAT simd_real_gather(
+    MD_SIMD_INT vidx, MD_FLOAT* base, const int scale)
 {
     return _mm512_i32gather_ps(vidx, base, scale);
 }

--- a/src/common/simd/avx_double.h
+++ b/src/common/simd/avx_double.h
@@ -98,7 +98,6 @@ static inline void simd_h_decr3(MD_FLOAT *m, MD_SIMD_FLOAT a0, MD_SIMD_FLOAT a1,
     exit(-1);
 }
 
-static inline MD_SIMD_FLOAT simd_gather(MD_SIMD_INT vidx, const MD_FLOAT *m, int s) { return _mm256_i32gather_pd(m, vidx, s); }
 static inline MD_SIMD_INT simd_int_broadcast(int scalar) { return _mm_set1_epi32(scalar); }
 static inline MD_SIMD_INT simd_int_zero() { return _mm_setzero_si128(); }
 static inline MD_SIMD_INT simd_int_seq() { return _mm_set_epi32(3, 2, 1, 0); }
@@ -116,11 +115,20 @@ static inline MD_SIMD_INT simd_int_load_h_duplicate(const int *m)
     return ret;
 }
 
-static inline MD_SIMD_INT simd_int_load_h_dual(const int *m)
+static inline MD_SIMD_INT simd_int_load_h_dual_scaled(const int *m, int scale)
 {
     MD_SIMD_INT ret;
     fprintf(stderr,
-        "simd_int_load_h_dual(): Not implemented for AVX2 with double precision!");
+        "simd_int_load_h_dual_scaled(): Not implemented for AVX2 with double precision!");
     exit(-1);
     return ret;
+}
+
+static inline MD_SIMD_FLOAT simd_gather(MD_SIMD_INT vidx, MD_FLOAT *base, const int scale) {
+    __m128i scaled = vidx; // _mm_mullo_epi32(vidx, _mm_set1_epi32(scale));
+    int i0 = _mm_extract_epi32(scaled, 0);
+    int i1 = _mm_extract_epi32(scaled, 1);
+    int i2 = _mm_extract_epi32(scaled, 2);
+    int i3 = _mm_extract_epi32(scaled, 3);
+    return _mm256_set_pd(base[i3], base[i2], base[i1], base[i0]);
 }

--- a/src/common/simd/avx_double.h
+++ b/src/common/simd/avx_double.h
@@ -15,7 +15,7 @@
 static inline int simd_test_any(MD_SIMD_MASK a)
 {
     __m256i a_si256 = _mm256_castpd_si256(a);
-    return _mm256_testz_si256(a_si256, a_si256) != 0;
+    return _mm256_testz_si256(a_si256, a_si256) == 0;
 }
 
 static inline MD_SIMD_FLOAT simd_broadcast(MD_FLOAT scalar) { return _mm256_set1_pd(scalar); }

--- a/src/common/simd/avx_double.h
+++ b/src/common/simd/avx_double.h
@@ -98,7 +98,6 @@ static inline void simd_h_decr3(MD_FLOAT *m, MD_SIMD_FLOAT a0, MD_SIMD_FLOAT a1,
     exit(-1);
 }
 
-// Functions used in LAMMPS kernel
 static inline MD_SIMD_FLOAT simd_gather(MD_SIMD_INT vidx, const MD_FLOAT *m, int s) { return _mm256_i32gather_pd(m, vidx, s); }
 static inline MD_SIMD_INT simd_int_broadcast(int scalar) { return _mm_set1_epi32(scalar); }
 static inline MD_SIMD_INT simd_int_zero() { return _mm_setzero_si128(); }
@@ -107,3 +106,21 @@ static inline MD_SIMD_INT simd_int_load(const int *m) { return _mm_load_si128((_
 static inline MD_SIMD_INT simd_int_add(MD_SIMD_INT a, MD_SIMD_INT b) { return _mm_add_epi32(a, b); }
 static inline MD_SIMD_INT simd_int_mul(MD_SIMD_INT a, MD_SIMD_INT b) { return _mm_mul_epi32(a, b); }
 static inline MD_SIMD_INT simd_int_mask_load(const int *m, MD_SIMD_MASK k) { return simd_int_load(m) & _mm256_cvtpd_epi32(k); }
+
+static inline MD_SIMD_INT simd_int_load_h_duplicate(const int *m)
+{
+    MD_SIMD_INT ret;
+    fprintf(stderr,
+        "simd_int_load_h_duplicate(): Not implemented for AVX2 with double precision!");
+    exit(-1);
+    return ret;
+}
+
+static inline MD_SIMD_INT simd_int_load_h_dual(const int *m)
+{
+    MD_SIMD_INT ret;
+    fprintf(stderr,
+        "simd_int_load_h_dual(): Not implemented for AVX2 with double precision!");
+    exit(-1);
+    return ret;
+}

--- a/src/common/simd/avx_double.h
+++ b/src/common/simd/avx_double.h
@@ -18,26 +18,29 @@ static inline int simd_test_any(MD_SIMD_MASK a)
     return _mm256_testz_si256(a_si256, a_si256) == 0;
 }
 
-static inline MD_SIMD_FLOAT simd_broadcast(MD_FLOAT scalar)
+static inline MD_SIMD_FLOAT simd_real_broadcast(MD_FLOAT scalar)
 {
     return _mm256_set1_pd(scalar);
 }
-static inline MD_SIMD_FLOAT simd_zero() { return _mm256_set1_pd(0.0); }
-static inline MD_SIMD_FLOAT simd_add(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+static inline MD_SIMD_FLOAT simd_real_zero() { return _mm256_set1_pd(0.0); }
+static inline MD_SIMD_FLOAT simd_real_add(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
 {
     return _mm256_add_pd(a, b);
 }
-static inline MD_SIMD_FLOAT simd_sub(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+static inline MD_SIMD_FLOAT simd_real_sub(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
 {
     return _mm256_sub_pd(a, b);
 }
-static inline MD_SIMD_FLOAT simd_mul(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+static inline MD_SIMD_FLOAT simd_real_mul(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
 {
     return _mm256_mul_pd(a, b);
 }
-static inline MD_SIMD_FLOAT simd_load(MD_FLOAT* p) { return _mm256_load_pd(p); }
-static inline void simd_store(MD_FLOAT* p, MD_SIMD_FLOAT a) { _mm256_store_pd(p, a); }
-static inline MD_SIMD_FLOAT simd_load_h_duplicate(const MD_FLOAT* m)
+static inline MD_SIMD_FLOAT simd_real_load(MD_FLOAT* p) { return _mm256_load_pd(p); }
+static inline void simd_real_store(MD_FLOAT* p, MD_SIMD_FLOAT a)
+{
+    _mm256_store_pd(p, a);
+}
+static inline MD_SIMD_FLOAT simd_real_load_h_duplicate(const MD_FLOAT* m)
 {
     MD_SIMD_FLOAT ret;
     fprintf(stderr,
@@ -46,24 +49,26 @@ static inline MD_SIMD_FLOAT simd_load_h_duplicate(const MD_FLOAT* m)
     return ret;
 }
 
-static inline MD_SIMD_FLOAT simd_load_h_dual(const MD_FLOAT* m)
+static inline MD_SIMD_FLOAT simd_real_load_h_dual(const MD_FLOAT* m)
 {
     MD_SIMD_FLOAT ret;
-    fprintf(stderr, "simd_load_h_dual(): Not implemented for AVX with double precision!");
+    fprintf(stderr,
+        "simd_real_load_h_dual(): Not implemented for AVX with double precision!");
     exit(-1);
     return ret;
 }
 
-static inline MD_FLOAT simd_h_dual_incr_reduced_sum(
+static inline MD_FLOAT simd_real_h_dual_incr_reduced_sum(
     MD_FLOAT* m, MD_SIMD_FLOAT v0, MD_SIMD_FLOAT v1)
 {
     fprintf(stderr,
-        "simd_h_dual_incr_reduced_sum(): Not implemented for AVX with double precision!");
+        "simd_real_h_dual_incr_reduced_sum(): Not implemented for AVX with double "
+        "precision!");
     exit(-1);
     return 0.0;
 }
 
-static inline MD_FLOAT simd_incr_reduced_sum(
+static inline MD_FLOAT simd_real_incr_reduced_sum(
     MD_FLOAT* m, MD_SIMD_FLOAT v0, MD_SIMD_FLOAT v1, MD_SIMD_FLOAT v2, MD_SIMD_FLOAT v3)
 {
     __m256d t0, t1, t2;
@@ -85,29 +90,31 @@ static inline MD_FLOAT simd_incr_reduced_sum(
     return *((MD_FLOAT*)&a0);
 }
 
-static inline MD_SIMD_FLOAT select_by_mask(MD_SIMD_FLOAT a, MD_SIMD_MASK m)
+static inline MD_SIMD_FLOAT simd_real_select_by_mask(MD_SIMD_FLOAT a, MD_SIMD_MASK m)
 {
     return _mm256_and_pd(a, m);
 }
-static inline MD_SIMD_FLOAT simd_reciprocal(MD_SIMD_FLOAT a)
+static inline MD_SIMD_FLOAT simd_real_reciprocal(MD_SIMD_FLOAT a)
 {
     return _mm256_cvtps_pd(_mm_rcp_ps(_mm256_cvtpd_ps(a)));
 }
 #ifdef __ISA_AVX_FMA__
-static inline MD_SIMD_FLOAT simd_fma(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_FLOAT c)
+static inline MD_SIMD_FLOAT simd_real_fma(
+    MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_FLOAT c)
 {
     return _mm256_fmadd_pd(a, b, c);
 }
 #else
-static inline MD_SIMD_FLOAT simd_fma(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_FLOAT c)
+static inline MD_SIMD_FLOAT simd_real_fma(
+    MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_FLOAT c)
 {
-    return simd_add(simd_mul(a, b), c);
+    return simd_real_add(simd_real_mul(a, b), c);
 }
 #endif
-static inline MD_SIMD_FLOAT simd_masked_add(
+static inline MD_SIMD_FLOAT simd_real_masked_add(
     MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_MASK m)
 {
-    return simd_add(a, _mm256_and_pd(b, m));
+    return simd_real_add(a, _mm256_and_pd(b, m));
 }
 static inline MD_SIMD_MASK simd_mask_cond_lt(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
 {
@@ -134,7 +141,7 @@ static inline MD_SIMD_MASK simd_mask_from_u32(unsigned int a)
 }
 // TODO: Implement this, althrough it is just required for debugging
 static inline int simd_mask_to_u32(MD_SIMD_MASK a) { return 0; }
-static inline MD_FLOAT simd_h_reduce_sum(MD_SIMD_FLOAT a)
+static inline MD_FLOAT simd_real_h_reduce_sum(MD_SIMD_FLOAT a)
 {
     __m128d a0, a1;
     a  = _mm256_add_pd(a, _mm256_permute_pd(a, 0b0101));
@@ -144,55 +151,57 @@ static inline MD_FLOAT simd_h_reduce_sum(MD_SIMD_FLOAT a)
     return *((MD_FLOAT*)&a0);
 }
 
-static inline void simd_h_decr3(
+static inline void simd_real_h_decr3(
     MD_FLOAT* m, MD_SIMD_FLOAT a0, MD_SIMD_FLOAT a1, MD_SIMD_FLOAT a2)
 {
-    fprintf(stderr, "simd_h_decr3(): Not implemented for AVX with double precision!");
+    fprintf(stderr,
+        "simd_real_h_decr3(): Not implemented for AVX with double precision!");
     exit(-1);
 }
 
-static inline MD_SIMD_INT simd_int_broadcast(int scalar)
+static inline MD_SIMD_INT simd_i32_broadcast(int scalar)
 {
     return _mm_set1_epi32(scalar);
 }
-static inline MD_SIMD_INT simd_int_zero() { return _mm_setzero_si128(); }
-static inline MD_SIMD_INT simd_int_seq() { return _mm_set_epi32(3, 2, 1, 0); }
-static inline MD_SIMD_INT simd_int_load(const int* m)
+static inline MD_SIMD_INT simd_i32_zero() { return _mm_setzero_si128(); }
+static inline MD_SIMD_INT simd_i32_seq() { return _mm_set_epi32(3, 2, 1, 0); }
+static inline MD_SIMD_INT simd_i32_load(const int* m)
 {
     return _mm_load_si128((__m128i const*)m);
 }
-static inline MD_SIMD_INT simd_int_add(MD_SIMD_INT a, MD_SIMD_INT b)
+static inline MD_SIMD_INT simd_i32_add(MD_SIMD_INT a, MD_SIMD_INT b)
 {
     return _mm_add_epi32(a, b);
 }
-static inline MD_SIMD_INT simd_int_mul(MD_SIMD_INT a, MD_SIMD_INT b)
+static inline MD_SIMD_INT simd_i32_mul(MD_SIMD_INT a, MD_SIMD_INT b)
 {
     return _mm_mul_epi32(a, b);
 }
-static inline MD_SIMD_INT simd_int_mask_load(const int* m, MD_SIMD_MASK k)
+static inline MD_SIMD_INT simd_i32_mask_load(const int* m, MD_SIMD_MASK k)
 {
-    return simd_int_load(m) & _mm256_cvtpd_epi32(k);
+    return simd_i32_load(m) & _mm256_cvtpd_epi32(k);
 }
 
-static inline MD_SIMD_INT simd_int_load_h_duplicate(const int* m)
+static inline MD_SIMD_INT simd_i32_load_h_duplicate(const int* m)
 {
     MD_SIMD_INT ret;
     fprintf(stderr,
-        "simd_int_load_h_duplicate(): Not implemented for AVX2 with double precision!");
+        "simd_i32_load_h_duplicate(): Not implemented for AVX2 with double precision!");
     exit(-1);
     return ret;
 }
 
-static inline MD_SIMD_INT simd_int_load_h_dual_scaled(const int* m, int scale)
+static inline MD_SIMD_INT simd_i32_load_h_dual_scaled(const int* m, int scale)
 {
     MD_SIMD_INT ret;
     fprintf(stderr,
-        "simd_int_load_h_dual_scaled(): Not implemented for AVX2 with double precision!");
+        "simd_i32_load_h_dual_scaled(): Not implemented for AVX2 with double precision!");
     exit(-1);
     return ret;
 }
 
-static inline MD_SIMD_FLOAT simd_gather(MD_SIMD_INT vidx, MD_FLOAT* base, const int scale)
+static inline MD_SIMD_FLOAT simd_real_gather(
+    MD_SIMD_INT vidx, MD_FLOAT* base, const int scale)
 {
     __m128i scaled = vidx; // _mm_mullo_epi32(vidx, _mm_set1_epi32(scale));
     int i0         = _mm_extract_epi32(scaled, 0);

--- a/src/common/simd/avx_double.h
+++ b/src/common/simd/avx_double.h
@@ -4,13 +4,13 @@
  * Use of this source code is governed by a LGPL-3.0
  * license that can be found in the LICENSE file.
  */
+#include <immintrin.h>
 #include <stdlib.h>
 #include <string.h>
-#include <immintrin.h>
 
-#define MD_SIMD_FLOAT   __m256d
-#define MD_SIMD_INT     __m128i
-#define MD_SIMD_MASK    __m256d
+#define MD_SIMD_FLOAT __m256d
+#define MD_SIMD_INT   __m128i
+#define MD_SIMD_MASK  __m256d
 
 static inline int simd_test_any(MD_SIMD_MASK a)
 {
@@ -18,34 +18,54 @@ static inline int simd_test_any(MD_SIMD_MASK a)
     return _mm256_testz_si256(a_si256, a_si256) == 0;
 }
 
-static inline MD_SIMD_FLOAT simd_broadcast(MD_FLOAT scalar) { return _mm256_set1_pd(scalar); }
+static inline MD_SIMD_FLOAT simd_broadcast(MD_FLOAT scalar)
+{
+    return _mm256_set1_pd(scalar);
+}
 static inline MD_SIMD_FLOAT simd_zero() { return _mm256_set1_pd(0.0); }
-static inline MD_SIMD_FLOAT simd_add(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b) { return _mm256_add_pd(a, b); }
-static inline MD_SIMD_FLOAT simd_sub(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b) { return _mm256_sub_pd(a, b); }
-static inline MD_SIMD_FLOAT simd_mul(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b) { return _mm256_mul_pd(a, b); }
-static inline MD_SIMD_FLOAT simd_load(MD_FLOAT *p) { return _mm256_load_pd(p); }
-static inline void simd_store(MD_FLOAT *p, MD_SIMD_FLOAT a) { _mm256_store_pd(p, a); }
-static inline MD_SIMD_FLOAT simd_load_h_duplicate(const MD_FLOAT *m) {
+static inline MD_SIMD_FLOAT simd_add(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+{
+    return _mm256_add_pd(a, b);
+}
+static inline MD_SIMD_FLOAT simd_sub(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+{
+    return _mm256_sub_pd(a, b);
+}
+static inline MD_SIMD_FLOAT simd_mul(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+{
+    return _mm256_mul_pd(a, b);
+}
+static inline MD_SIMD_FLOAT simd_load(MD_FLOAT* p) { return _mm256_load_pd(p); }
+static inline void simd_store(MD_FLOAT* p, MD_SIMD_FLOAT a) { _mm256_store_pd(p, a); }
+static inline MD_SIMD_FLOAT simd_load_h_duplicate(const MD_FLOAT* m)
+{
     MD_SIMD_FLOAT ret;
-    fprintf(stderr, "simd_load_h_duplicate(): Not implemented for AVX with double precision!");
+    fprintf(stderr,
+        "simd_load_h_duplicate(): Not implemented for AVX with double precision!");
     exit(-1);
     return ret;
 }
 
-static inline MD_SIMD_FLOAT simd_load_h_dual(const MD_FLOAT *m) {
+static inline MD_SIMD_FLOAT simd_load_h_dual(const MD_FLOAT* m)
+{
     MD_SIMD_FLOAT ret;
     fprintf(stderr, "simd_load_h_dual(): Not implemented for AVX with double precision!");
     exit(-1);
     return ret;
 }
 
-static inline MD_FLOAT simd_h_dual_incr_reduced_sum(MD_FLOAT *m, MD_SIMD_FLOAT v0, MD_SIMD_FLOAT v1) {
-    fprintf(stderr, "simd_h_dual_incr_reduced_sum(): Not implemented for AVX with double precision!");
+static inline MD_FLOAT simd_h_dual_incr_reduced_sum(
+    MD_FLOAT* m, MD_SIMD_FLOAT v0, MD_SIMD_FLOAT v1)
+{
+    fprintf(stderr,
+        "simd_h_dual_incr_reduced_sum(): Not implemented for AVX with double precision!");
     exit(-1);
     return 0.0;
 }
 
-static inline MD_FLOAT simd_incr_reduced_sum(MD_FLOAT *m, MD_SIMD_FLOAT v0, MD_SIMD_FLOAT v1, MD_SIMD_FLOAT v2, MD_SIMD_FLOAT v3) {
+static inline MD_FLOAT simd_incr_reduced_sum(
+    MD_FLOAT* m, MD_SIMD_FLOAT v0, MD_SIMD_FLOAT v1, MD_SIMD_FLOAT v2, MD_SIMD_FLOAT v3)
+{
     __m256d t0, t1, t2;
     __m128d a0, a1;
 
@@ -62,51 +82,99 @@ static inline MD_FLOAT simd_incr_reduced_sum(MD_FLOAT *m, MD_SIMD_FLOAT v0, MD_S
     a0 = _mm256_castpd256_pd128(t0);
     a1 = _mm256_extractf128_pd(t0, 0x1);
     a0 = _mm_add_sd(a0, a1);
-    return *((MD_FLOAT *) &a0);
+    return *((MD_FLOAT*)&a0);
 }
 
-static inline MD_SIMD_FLOAT select_by_mask(MD_SIMD_FLOAT a, MD_SIMD_MASK m) { return _mm256_and_pd(a, m); }
-static inline MD_SIMD_FLOAT simd_reciprocal(MD_SIMD_FLOAT a) { return _mm256_cvtps_pd(_mm_rcp_ps(_mm256_cvtpd_ps(a))); }
+static inline MD_SIMD_FLOAT select_by_mask(MD_SIMD_FLOAT a, MD_SIMD_MASK m)
+{
+    return _mm256_and_pd(a, m);
+}
+static inline MD_SIMD_FLOAT simd_reciprocal(MD_SIMD_FLOAT a)
+{
+    return _mm256_cvtps_pd(_mm_rcp_ps(_mm256_cvtpd_ps(a)));
+}
 #ifdef __ISA_AVX_FMA__
-static inline MD_SIMD_FLOAT simd_fma(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_FLOAT c) { return _mm256_fmadd_pd(a, b, c); }
+static inline MD_SIMD_FLOAT simd_fma(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_FLOAT c)
+{
+    return _mm256_fmadd_pd(a, b, c);
+}
 #else
-static inline MD_SIMD_FLOAT simd_fma(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_FLOAT c) { return simd_add(simd_mul(a, b), c); }
+static inline MD_SIMD_FLOAT simd_fma(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_FLOAT c)
+{
+    return simd_add(simd_mul(a, b), c);
+}
 #endif
-static inline MD_SIMD_FLOAT simd_masked_add(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_MASK m) { return simd_add(a, _mm256_and_pd(b, m)); }
-static inline MD_SIMD_MASK simd_mask_cond_lt(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b) { return _mm256_cmp_pd(a, b, _CMP_LT_OQ); }
-static inline MD_SIMD_MASK simd_mask_int_cond_lt(MD_SIMD_INT a, MD_SIMD_INT b) { return _mm256_cvtepi32_pd(_mm_cmplt_epi32(a, b)); }
-static inline MD_SIMD_MASK simd_mask_and(MD_SIMD_MASK a, MD_SIMD_MASK b) { return _mm256_and_pd(a, b); }
-// TODO: Initialize all diagonal cases and just select the proper one (all bits set or diagonal) based on cond0
-static inline MD_SIMD_MASK simd_mask_from_u32(unsigned int a) {
-    const unsigned long long int all = 0xFFFFFFFFFFFFFFFF;
+static inline MD_SIMD_FLOAT simd_masked_add(
+    MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_MASK m)
+{
+    return simd_add(a, _mm256_and_pd(b, m));
+}
+static inline MD_SIMD_MASK simd_mask_cond_lt(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+{
+    return _mm256_cmp_pd(a, b, _CMP_LT_OQ);
+}
+static inline MD_SIMD_MASK simd_mask_int_cond_lt(MD_SIMD_INT a, MD_SIMD_INT b)
+{
+    return _mm256_cvtepi32_pd(_mm_cmplt_epi32(a, b));
+}
+static inline MD_SIMD_MASK simd_mask_and(MD_SIMD_MASK a, MD_SIMD_MASK b)
+{
+    return _mm256_and_pd(a, b);
+}
+// TODO: Initialize all diagonal cases and just select the proper one (all bits set or
+// diagonal) based on cond0
+static inline MD_SIMD_MASK simd_mask_from_u32(unsigned int a)
+{
+    const unsigned long long int all  = 0xFFFFFFFFFFFFFFFF;
     const unsigned long long int none = 0x0;
-    return _mm256_castsi256_pd(_mm256_set_epi64x((a & 0x8) ? all : none, (a & 0x4) ? all : none, (a & 0x2) ? all : none, (a & 0x1) ? all : none));
+    return _mm256_castsi256_pd(_mm256_set_epi64x((a & 0x8) ? all : none,
+        (a & 0x4) ? all : none,
+        (a & 0x2) ? all : none,
+        (a & 0x1) ? all : none));
 }
 // TODO: Implement this, althrough it is just required for debugging
 static inline int simd_mask_to_u32(MD_SIMD_MASK a) { return 0; }
-static inline MD_FLOAT simd_h_reduce_sum(MD_SIMD_FLOAT a) {
+static inline MD_FLOAT simd_h_reduce_sum(MD_SIMD_FLOAT a)
+{
     __m128d a0, a1;
-    a = _mm256_add_pd(a, _mm256_permute_pd(a, 0b0101));
+    a  = _mm256_add_pd(a, _mm256_permute_pd(a, 0b0101));
     a0 = _mm256_castpd256_pd128(a);
     a1 = _mm256_extractf128_pd(a, 0x1);
     a0 = _mm_add_sd(a0, a1);
-    return *((MD_FLOAT *) &a0);
+    return *((MD_FLOAT*)&a0);
 }
 
-static inline void simd_h_decr3(MD_FLOAT *m, MD_SIMD_FLOAT a0, MD_SIMD_FLOAT a1, MD_SIMD_FLOAT a2) {
+static inline void simd_h_decr3(
+    MD_FLOAT* m, MD_SIMD_FLOAT a0, MD_SIMD_FLOAT a1, MD_SIMD_FLOAT a2)
+{
     fprintf(stderr, "simd_h_decr3(): Not implemented for AVX with double precision!");
     exit(-1);
 }
 
-static inline MD_SIMD_INT simd_int_broadcast(int scalar) { return _mm_set1_epi32(scalar); }
+static inline MD_SIMD_INT simd_int_broadcast(int scalar)
+{
+    return _mm_set1_epi32(scalar);
+}
 static inline MD_SIMD_INT simd_int_zero() { return _mm_setzero_si128(); }
 static inline MD_SIMD_INT simd_int_seq() { return _mm_set_epi32(3, 2, 1, 0); }
-static inline MD_SIMD_INT simd_int_load(const int *m) { return _mm_load_si128((__m128i const *) m); }
-static inline MD_SIMD_INT simd_int_add(MD_SIMD_INT a, MD_SIMD_INT b) { return _mm_add_epi32(a, b); }
-static inline MD_SIMD_INT simd_int_mul(MD_SIMD_INT a, MD_SIMD_INT b) { return _mm_mul_epi32(a, b); }
-static inline MD_SIMD_INT simd_int_mask_load(const int *m, MD_SIMD_MASK k) { return simd_int_load(m) & _mm256_cvtpd_epi32(k); }
+static inline MD_SIMD_INT simd_int_load(const int* m)
+{
+    return _mm_load_si128((__m128i const*)m);
+}
+static inline MD_SIMD_INT simd_int_add(MD_SIMD_INT a, MD_SIMD_INT b)
+{
+    return _mm_add_epi32(a, b);
+}
+static inline MD_SIMD_INT simd_int_mul(MD_SIMD_INT a, MD_SIMD_INT b)
+{
+    return _mm_mul_epi32(a, b);
+}
+static inline MD_SIMD_INT simd_int_mask_load(const int* m, MD_SIMD_MASK k)
+{
+    return simd_int_load(m) & _mm256_cvtpd_epi32(k);
+}
 
-static inline MD_SIMD_INT simd_int_load_h_duplicate(const int *m)
+static inline MD_SIMD_INT simd_int_load_h_duplicate(const int* m)
 {
     MD_SIMD_INT ret;
     fprintf(stderr,
@@ -115,7 +183,7 @@ static inline MD_SIMD_INT simd_int_load_h_duplicate(const int *m)
     return ret;
 }
 
-static inline MD_SIMD_INT simd_int_load_h_dual_scaled(const int *m, int scale)
+static inline MD_SIMD_INT simd_int_load_h_dual_scaled(const int* m, int scale)
 {
     MD_SIMD_INT ret;
     fprintf(stderr,
@@ -124,11 +192,12 @@ static inline MD_SIMD_INT simd_int_load_h_dual_scaled(const int *m, int scale)
     return ret;
 }
 
-static inline MD_SIMD_FLOAT simd_gather(MD_SIMD_INT vidx, MD_FLOAT *base, const int scale) {
+static inline MD_SIMD_FLOAT simd_gather(MD_SIMD_INT vidx, MD_FLOAT* base, const int scale)
+{
     __m128i scaled = vidx; // _mm_mullo_epi32(vidx, _mm_set1_epi32(scale));
-    int i0 = _mm_extract_epi32(scaled, 0);
-    int i1 = _mm_extract_epi32(scaled, 1);
-    int i2 = _mm_extract_epi32(scaled, 2);
-    int i3 = _mm_extract_epi32(scaled, 3);
+    int i0         = _mm_extract_epi32(scaled, 0);
+    int i1         = _mm_extract_epi32(scaled, 1);
+    int i2         = _mm_extract_epi32(scaled, 2);
+    int i3         = _mm_extract_epi32(scaled, 3);
     return _mm256_set_pd(base[i3], base[i2], base[i1], base[i0]);
 }

--- a/src/common/simd/avx_double.h
+++ b/src/common/simd/avx_double.h
@@ -12,6 +12,12 @@
 #define MD_SIMD_INT     __m128i
 #define MD_SIMD_MASK    __m256d
 
+static inline int simd_test_any(MD_SIMD_MASK a)
+{
+    __m256i a_si256 = _mm256_castpd_si256(a);
+    return _mm256_testz_si256(a_si256, a_si256) != 0;
+}
+
 static inline MD_SIMD_FLOAT simd_broadcast(MD_FLOAT scalar) { return _mm256_set1_pd(scalar); }
 static inline MD_SIMD_FLOAT simd_zero() { return _mm256_set1_pd(0.0); }
 static inline MD_SIMD_FLOAT simd_add(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b) { return _mm256_add_pd(a, b); }

--- a/src/common/simd/avx_float.h
+++ b/src/common/simd/avx_float.h
@@ -12,44 +12,52 @@
 #define MD_SIMD_INT   __m256i
 
 static inline int simd_test_any(MD_SIMD_MASK a) { return _mm256_movemask_ps(a) != 0; }
-static inline MD_SIMD_FLOAT simd_broadcast(MD_FLOAT scalar)
+static inline MD_SIMD_FLOAT simd_real_broadcast(MD_FLOAT scalar)
 {
     return _mm256_set1_ps(scalar);
 }
-static inline MD_SIMD_FLOAT simd_zero(void) { return _mm256_set1_ps(0.0); }
-static inline MD_SIMD_FLOAT simd_add(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+static inline MD_SIMD_FLOAT simd_real_zero(void) { return _mm256_set1_ps(0.0); }
+static inline MD_SIMD_FLOAT simd_real_add(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
 {
     return _mm256_add_ps(a, b);
 }
-static inline MD_SIMD_FLOAT simd_sub(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+static inline MD_SIMD_FLOAT simd_real_sub(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
 {
     return _mm256_sub_ps(a, b);
 }
-static inline MD_SIMD_FLOAT simd_mul(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+static inline MD_SIMD_FLOAT simd_real_mul(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
 {
     return _mm256_mul_ps(a, b);
 }
-static inline MD_SIMD_FLOAT simd_load(MD_FLOAT* p) { return _mm256_load_ps(p); }
-static inline void simd_store(MD_FLOAT* p, MD_SIMD_FLOAT a) { _mm256_store_ps(p, a); }
-static inline MD_SIMD_FLOAT select_by_mask(MD_SIMD_FLOAT a, MD_SIMD_MASK m)
+static inline MD_SIMD_FLOAT simd_real_load(MD_FLOAT* p) { return _mm256_load_ps(p); }
+static inline void simd_real_store(MD_FLOAT* p, MD_SIMD_FLOAT a)
+{
+    _mm256_store_ps(p, a);
+}
+static inline MD_SIMD_FLOAT simd_real_select_by_mask(MD_SIMD_FLOAT a, MD_SIMD_MASK m)
 {
     return _mm256_and_ps(a, m);
 }
-static inline MD_SIMD_FLOAT simd_reciprocal(MD_SIMD_FLOAT a) { return _mm256_rcp_ps(a); }
+static inline MD_SIMD_FLOAT simd_real_reciprocal(MD_SIMD_FLOAT a)
+{
+    return _mm256_rcp_ps(a);
+}
 
 #ifdef __ISA_AVX_FMA__
-static inline MD_SIMD_FLOAT simd_fma(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_FLOAT c)
+static inline MD_SIMD_FLOAT simd_real_fma(
+    MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_FLOAT c)
 {
     return _mm256_fmadd_ps(a, b, c);
 }
 #else
-static inline MD_SIMD_FLOAT simd_fma(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_FLOAT c)
+static inline MD_SIMD_FLOAT simd_real_fma(
+    MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_FLOAT c)
 {
-    return simd_add(simd_mul(a, b), c);
+    return simd_real_add(simd_real_mul(a, b), c);
 }
 #endif
 
-static inline MD_SIMD_FLOAT simd_masked_add(
+static inline MD_SIMD_FLOAT simd_real_masked_add(
     MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_MASK m)
 {
     return _mm256_add_ps(a, _mm256_and_ps(b, m));
@@ -81,7 +89,7 @@ static inline unsigned int simd_mask_to_u32(MD_SIMD_MASK a)
 {
     return _mm256_movemask_ps(a);
 }
-static inline MD_FLOAT simd_h_reduce_sum(MD_SIMD_FLOAT a)
+static inline MD_FLOAT simd_real_h_reduce_sum(MD_SIMD_FLOAT a)
 {
     __m128 t0;
     t0 = _mm_add_ps(_mm256_castps256_ps128(a), _mm256_extractf128_ps(a, 0x1));
@@ -90,7 +98,7 @@ static inline MD_FLOAT simd_h_reduce_sum(MD_SIMD_FLOAT a)
     return *((MD_FLOAT*)&t0);
 }
 
-static inline MD_FLOAT simd_incr_reduced_sum(
+static inline MD_FLOAT simd_real_incr_reduced_sum(
     MD_FLOAT* m, MD_SIMD_FLOAT v0, MD_SIMD_FLOAT v1, MD_SIMD_FLOAT v2, MD_SIMD_FLOAT v3)
 {
     __m128 t0, t2;
@@ -106,12 +114,12 @@ static inline MD_FLOAT simd_incr_reduced_sum(
     return *((MD_FLOAT*)&t0);
 }
 
-static inline MD_SIMD_FLOAT simd_load_h_duplicate(const MD_FLOAT* m)
+static inline MD_SIMD_FLOAT simd_real_load_h_duplicate(const MD_FLOAT* m)
 {
     return _mm256_broadcast_ps((const __m128*)(m));
 }
 
-static inline MD_SIMD_FLOAT simd_load_h_dual(const MD_FLOAT* m)
+static inline MD_SIMD_FLOAT simd_real_load_h_dual(const MD_FLOAT* m)
 {
     __m128 t0, t1;
     t0 = _mm_broadcast_ss(m);
@@ -119,7 +127,7 @@ static inline MD_SIMD_FLOAT simd_load_h_dual(const MD_FLOAT* m)
     return _mm256_insertf128_ps(_mm256_castps128_ps256(t0), t1, 0x1);
 }
 
-static inline MD_FLOAT simd_h_dual_incr_reduced_sum(
+static inline MD_FLOAT simd_real_h_dual_incr_reduced_sum(
     MD_FLOAT* m, MD_SIMD_FLOAT v0, MD_SIMD_FLOAT v1)
 {
     __m128 t0, t1;
@@ -141,7 +149,7 @@ inline void simd_h_decr(MD_FLOAT* m, MD_SIMD_FLOAT a)
     _mm_store_ps(m, _mm_sub_ps(_mm_load_ps(m), asum));
 }
 
-static inline void simd_h_decr3(
+static inline void simd_real_h_decr3(
     MD_FLOAT* m, MD_SIMD_FLOAT a0, MD_SIMD_FLOAT a1, MD_SIMD_FLOAT a2)
 {
     simd_h_decr(m, a0);
@@ -149,22 +157,22 @@ static inline void simd_h_decr3(
     simd_h_decr(m + CLUSTER_N * 2, a2);
 }
 
-static inline MD_SIMD_INT simd_int_broadcast(int scalar)
+static inline MD_SIMD_INT simd_i32_broadcast(int scalar)
 {
     return _mm256_set1_epi32(scalar);
 }
-static inline MD_SIMD_INT simd_int_load(const int* m)
+static inline MD_SIMD_INT simd_i32_load(const int* m)
 {
     return _mm256_load_si256((MD_SIMD_INT*)m);
 }
-static inline MD_SIMD_INT simd_int_load_h_duplicate(const int* m)
+static inline MD_SIMD_INT simd_i32_load_h_duplicate(const int* m)
 {
     __m128i val = _mm_load_si128((const __m128i*)(m));
     __m256i res = _mm256_castsi128_si256(val);
     return _mm256_insertf128_si256(res, val, 1);
 }
 
-static inline MD_SIMD_INT simd_int_load_h_dual_scaled(const int* m, int scale)
+static inline MD_SIMD_INT simd_i32_load_h_dual_scaled(const int* m, int scale)
 {
     __m128i t0     = _mm_set1_epi32(m[0] * scale);
     __m128i t1     = _mm_set1_epi32(m[1] * scale);
@@ -172,7 +180,8 @@ static inline MD_SIMD_INT simd_int_load_h_dual_scaled(const int* m, int scale)
     return _mm256_insertf128_si256(result, t1, 0x1);
 }
 
-static inline MD_SIMD_FLOAT simd_gather(MD_SIMD_INT vidx, MD_FLOAT* base, const int scale)
+static inline MD_SIMD_FLOAT simd_real_gather(
+    MD_SIMD_INT vidx, MD_FLOAT* base, const int scale)
 {
     __m128i vidx_lo   = _mm256_castsi256_si128(vidx);
     __m128i vidx_hi   = _mm256_extractf128_si256(vidx, 1);
@@ -193,7 +202,7 @@ static inline MD_SIMD_FLOAT simd_gather(MD_SIMD_INT vidx, MD_FLOAT* base, const 
     return _mm256_insertf128_ps(_mm256_castps128_ps256(gath_lo), gath_hi, 1);
 }
 
-static inline MD_SIMD_INT simd_int_add(MD_SIMD_INT a, MD_SIMD_INT b)
+static inline MD_SIMD_INT simd_i32_add(MD_SIMD_INT a, MD_SIMD_INT b)
 {
     __m128i low_add  = _mm_add_epi32(_mm256_extractf128_si256(a, 0),
         _mm256_extractf128_si256(b, 0));

--- a/src/common/simd/avx_float.h
+++ b/src/common/simd/avx_float.h
@@ -7,55 +7,80 @@
 #include <immintrin.h>
 #include <zmmintrin.h>
 
-#define MD_SIMD_FLOAT   __m256
-#define MD_SIMD_MASK    __m256
-#define MD_SIMD_INT     __m256i
+#define MD_SIMD_FLOAT __m256
+#define MD_SIMD_MASK  __m256
+#define MD_SIMD_INT   __m256i
 
 static inline int simd_test_any(MD_SIMD_MASK a) { return _mm256_movemask_ps(a) != 0; }
-static inline MD_SIMD_FLOAT simd_broadcast(MD_FLOAT scalar) { return _mm256_set1_ps(scalar); }
+static inline MD_SIMD_FLOAT simd_broadcast(MD_FLOAT scalar)
+{
+    return _mm256_set1_ps(scalar);
+}
 static inline MD_SIMD_FLOAT simd_zero(void) { return _mm256_set1_ps(0.0); }
-static inline MD_SIMD_FLOAT simd_add(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b) { return _mm256_add_ps(a, b); }
-static inline MD_SIMD_FLOAT simd_sub(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b) { return _mm256_sub_ps(a, b); }
-static inline MD_SIMD_FLOAT simd_mul(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b) { return _mm256_mul_ps(a, b); }
+static inline MD_SIMD_FLOAT simd_add(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+{
+    return _mm256_add_ps(a, b);
+}
+static inline MD_SIMD_FLOAT simd_sub(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+{
+    return _mm256_sub_ps(a, b);
+}
+static inline MD_SIMD_FLOAT simd_mul(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+{
+    return _mm256_mul_ps(a, b);
+}
 static inline MD_SIMD_FLOAT simd_load(MD_FLOAT* p) { return _mm256_load_ps(p); }
 static inline void simd_store(MD_FLOAT* p, MD_SIMD_FLOAT a) { _mm256_store_ps(p, a); }
-static inline MD_SIMD_FLOAT select_by_mask(MD_SIMD_FLOAT a, MD_SIMD_MASK m) { return _mm256_and_ps(a, m); }
+static inline MD_SIMD_FLOAT select_by_mask(MD_SIMD_FLOAT a, MD_SIMD_MASK m)
+{
+    return _mm256_and_ps(a, m);
+}
 static inline MD_SIMD_FLOAT simd_reciprocal(MD_SIMD_FLOAT a) { return _mm256_rcp_ps(a); }
 
 #ifdef __ISA_AVX_FMA__
-static inline MD_SIMD_FLOAT simd_fma(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_FLOAT c) {
+static inline MD_SIMD_FLOAT simd_fma(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_FLOAT c)
+{
     return _mm256_fmadd_ps(a, b, c);
 }
 #else
-static inline MD_SIMD_FLOAT simd_fma(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_FLOAT c) {
+static inline MD_SIMD_FLOAT simd_fma(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_FLOAT c)
+{
     return simd_add(simd_mul(a, b), c);
 }
 #endif
 
-static inline MD_SIMD_FLOAT simd_masked_add(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_MASK m) {
+static inline MD_SIMD_FLOAT simd_masked_add(
+    MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_MASK m)
+{
     return _mm256_add_ps(a, _mm256_and_ps(b, m));
 }
-static inline MD_SIMD_MASK simd_mask_cond_lt(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b) {
+static inline MD_SIMD_MASK simd_mask_cond_lt(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+{
     return _mm256_cmp_ps(a, b, _CMP_LT_OQ);
 }
-static inline MD_SIMD_MASK simd_mask_and(MD_SIMD_MASK a, MD_SIMD_MASK b) { return _mm256_and_ps(a, b); }
-
-static inline MD_SIMD_MASK simd_mask_from_u32(unsigned int a) {
-    const unsigned long int all = 0xFFFFFFFF;
-    const unsigned long int none = 0x0;
-    return _mm256_castsi256_ps(
-        _mm256_set_epi32(
-            (a & 0x80) ? all : none,
-            (a & 0x40) ? all : none,
-            (a & 0x20) ? all : none,
-            (a & 0x10) ? all : none,
-            (a & 0x8) ? all : none,
-            (a & 0x4) ? all : none,
-            (a & 0x2) ? all : none,
-            (a & 0x1) ? all : none));
+static inline MD_SIMD_MASK simd_mask_and(MD_SIMD_MASK a, MD_SIMD_MASK b)
+{
+    return _mm256_and_ps(a, b);
 }
 
-static inline unsigned int simd_mask_to_u32(MD_SIMD_MASK a) { return _mm256_movemask_ps(a); }
+static inline MD_SIMD_MASK simd_mask_from_u32(unsigned int a)
+{
+    const unsigned long int all  = 0xFFFFFFFF;
+    const unsigned long int none = 0x0;
+    return _mm256_castsi256_ps(_mm256_set_epi32((a & 0x80) ? all : none,
+        (a & 0x40) ? all : none,
+        (a & 0x20) ? all : none,
+        (a & 0x10) ? all : none,
+        (a & 0x8) ? all : none,
+        (a & 0x4) ? all : none,
+        (a & 0x2) ? all : none,
+        (a & 0x1) ? all : none));
+}
+
+static inline unsigned int simd_mask_to_u32(MD_SIMD_MASK a)
+{
+    return _mm256_movemask_ps(a);
+}
 static inline MD_FLOAT simd_h_reduce_sum(MD_SIMD_FLOAT a)
 {
     __m128 t0;
@@ -124,25 +149,33 @@ static inline void simd_h_decr3(
     simd_h_decr(m + CLUSTER_N * 2, a2);
 }
 
-static inline MD_SIMD_INT simd_int_broadcast(int scalar) { return _mm256_set1_epi32(scalar); }
-static inline MD_SIMD_INT simd_int_load(const int *m) { return _mm256_load_si256((MD_SIMD_INT *) m); }
-static inline MD_SIMD_INT simd_int_load_h_duplicate(const int *m) {
-    __m128i val = _mm_load_si128((const __m128i *)(m));
+static inline MD_SIMD_INT simd_int_broadcast(int scalar)
+{
+    return _mm256_set1_epi32(scalar);
+}
+static inline MD_SIMD_INT simd_int_load(const int* m)
+{
+    return _mm256_load_si256((MD_SIMD_INT*)m);
+}
+static inline MD_SIMD_INT simd_int_load_h_duplicate(const int* m)
+{
+    __m128i val = _mm_load_si128((const __m128i*)(m));
     __m256i res = _mm256_castsi128_si256(val);
     return _mm256_insertf128_si256(res, val, 1);
 }
 
-static inline MD_SIMD_INT simd_int_load_h_dual_scaled(const int *m, int scale)
+static inline MD_SIMD_INT simd_int_load_h_dual_scaled(const int* m, int scale)
 {
-    __m128i t0 = _mm_set1_epi32(m[0] * scale);
-    __m128i t1 = _mm_set1_epi32(m[1] * scale);
+    __m128i t0     = _mm_set1_epi32(m[0] * scale);
+    __m128i t1     = _mm_set1_epi32(m[1] * scale);
     __m256i result = _mm256_castsi128_si256(t0);
     return _mm256_insertf128_si256(result, t1, 0x1);
 }
 
-static inline MD_SIMD_FLOAT simd_gather(MD_SIMD_INT vidx, MD_FLOAT *base, const int scale) {
-    __m128i vidx_lo = _mm256_castsi256_si128(vidx);
-    __m128i vidx_hi = _mm256_extractf128_si256(vidx, 1);
+static inline MD_SIMD_FLOAT simd_gather(MD_SIMD_INT vidx, MD_FLOAT* base, const int scale)
+{
+    __m128i vidx_lo   = _mm256_castsi256_si128(vidx);
+    __m128i vidx_hi   = _mm256_extractf128_si256(vidx, 1);
     __m128i scaled_lo = vidx_lo; // _mm_mullo_epi32(vidx_lo, _mm_set1_epi32(scale));
     __m128i scaled_hi = vidx_hi; // _mm_mullo_epi32(vidx_hi, _mm_set1_epi32(scale));
 
@@ -160,11 +193,12 @@ static inline MD_SIMD_FLOAT simd_gather(MD_SIMD_INT vidx, MD_FLOAT *base, const 
     return _mm256_insertf128_ps(_mm256_castps128_ps256(gath_lo), gath_hi, 1);
 }
 
-static inline MD_SIMD_INT simd_int_add(MD_SIMD_INT a, MD_SIMD_INT b) {
-    __m128i low_add = _mm_add_epi32(
-        _mm256_extractf128_si256(a, 0), _mm256_extractf128_si256(b, 0));
-    __m128i high_add = _mm_add_epi32(
-        _mm256_extractf128_si256(a, 1), _mm256_extractf128_si256(b, 1));
+static inline MD_SIMD_INT simd_int_add(MD_SIMD_INT a, MD_SIMD_INT b)
+{
+    __m128i low_add  = _mm_add_epi32(_mm256_extractf128_si256(a, 0),
+        _mm256_extractf128_si256(b, 0));
+    __m128i high_add = _mm_add_epi32(_mm256_extractf128_si256(a, 1),
+        _mm256_extractf128_si256(b, 1));
 
     return _mm256_set_m128i(high_add, low_add);
 }

--- a/src/common/simd/avx_float.h
+++ b/src/common/simd/avx_float.h
@@ -10,6 +10,12 @@
 #define MD_SIMD_FLOAT __m256
 #define MD_SIMD_MASK  __mmask8
 
+static inline int simd_test_any(MD_SIMD_MASK a)
+{
+    __m256i a_si256 = _mm256_castps_si256(a);
+    return _mm256_testz_si256(a_si256, a_si256) != 0;
+}
+
 static inline MD_SIMD_FLOAT simd_broadcast(MD_FLOAT scalar)
 {
     return _mm256_set1_ps(scalar);

--- a/src/common/simd/avx_float.h
+++ b/src/common/simd/avx_float.h
@@ -13,7 +13,7 @@
 static inline int simd_test_any(MD_SIMD_MASK a)
 {
     __m256i a_si256 = _mm256_castps_si256(a);
-    return _mm256_testz_si256(a_si256, a_si256) != 0;
+    return _mm256_testz_si256(a_si256, a_si256) == 0;
 }
 
 static inline MD_SIMD_FLOAT simd_broadcast(MD_FLOAT scalar)

--- a/src/common/simd/avx_float.h
+++ b/src/common/simd/avx_float.h
@@ -7,61 +7,43 @@
 #include <immintrin.h>
 #include <zmmintrin.h>
 
-#define MD_SIMD_FLOAT __m256
-#define MD_SIMD_MASK  __mmask8
+#define MD_SIMD_FLOAT   __m256
+#define MD_SIMD_MASK    __m256
+#define MD_SIMD_INT     __m256i
 
-static inline int simd_test_any(MD_SIMD_MASK a)
-{
-    __m256i a_si256 = _mm256_castps_si256(a);
-    return _mm256_testz_si256(a_si256, a_si256) == 0;
-}
-
-static inline MD_SIMD_FLOAT simd_broadcast(MD_FLOAT scalar)
-{
-    return _mm256_set1_ps(scalar);
-}
+static inline int simd_test_any(MD_SIMD_MASK a) { return _mm256_movemask_ps(a) != 0; }
+static inline MD_SIMD_FLOAT simd_broadcast(MD_FLOAT scalar) { return _mm256_set1_ps(scalar); }
 static inline MD_SIMD_FLOAT simd_zero(void) { return _mm256_set1_ps(0.0); }
-static inline MD_SIMD_FLOAT simd_add(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
-{
-    return _mm256_add_ps(a, b);
-}
-static inline MD_SIMD_FLOAT simd_sub(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
-{
-    return _mm256_sub_ps(a, b);
-}
-static inline MD_SIMD_FLOAT simd_mul(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
-{
-    return _mm256_mul_ps(a, b);
-}
+static inline MD_SIMD_FLOAT simd_add(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b) { return _mm256_add_ps(a, b); }
+static inline MD_SIMD_FLOAT simd_sub(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b) { return _mm256_sub_ps(a, b); }
+static inline MD_SIMD_FLOAT simd_mul(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b) { return _mm256_mul_ps(a, b); }
 static inline MD_SIMD_FLOAT simd_load(MD_FLOAT* p) { return _mm256_load_ps(p); }
 static inline void simd_store(MD_FLOAT* p, MD_SIMD_FLOAT a) { _mm256_store_ps(p, a); }
-static inline MD_SIMD_FLOAT select_by_mask(MD_SIMD_FLOAT a, MD_SIMD_MASK m)
-{
-    return _mm256_mask_mov_ps(_mm256_setzero_ps(), m, a);
-}
-static inline MD_SIMD_FLOAT simd_reciprocal(MD_SIMD_FLOAT a)
-{
-    return _mm256_rcp14_ps(a);
-}
+static inline MD_SIMD_FLOAT select_by_mask(MD_SIMD_FLOAT a, MD_SIMD_MASK m) { return _mm256_and_ps(a, m); }
+static inline MD_SIMD_FLOAT simd_reciprocal(MD_SIMD_FLOAT a) { return _mm256_rcp_ps(a); }
 static inline MD_SIMD_FLOAT simd_fma(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_FLOAT c)
 {
     return _mm256_fmadd_ps(a, b, c);
 }
-static inline MD_SIMD_FLOAT simd_masked_add(
-    MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_MASK m)
+static inline MD_SIMD_FLOAT simd_masked_add(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_MASK m)
 {
-    return _mm256_mask_add_ps(a, m, a, b);
+    return _mm256_add_ps(a, _mm256_and_ps(b, m));
 }
-static inline MD_SIMD_MASK simd_mask_cond_lt(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+static inline MD_SIMD_MASK simd_mask_cond_lt(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b) {
+    return _mm256_cmp_ps(a, b, _CMP_LT_OQ);
+}
+static inline MD_SIMD_MASK simd_mask_and(MD_SIMD_MASK a, MD_SIMD_MASK b) { return _mm256_and_ps(a, b); }
+
+static inline MD_SIMD_MASK simd_mask_from_u32(unsigned int a)
 {
-    return _mm256_cmp_ps_mask(a, b, _CMP_LT_OQ);
+    __m256i broadcast_mask = _mm256_set1_epi32(a);
+    __m256i index = _mm256_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7);
+    __m256i shift = _mm256_and_si256(broadcast_mask, _mm256_sllv_epi32(_mm256_set1_epi32(1), index));
+    __m256i result = _mm256_cmpgt_epi32(shift, _mm256_setzero_si256());
+    return _mm256_castsi256_ps(result);
 }
-static inline MD_SIMD_MASK simd_mask_and(MD_SIMD_MASK a, MD_SIMD_MASK b)
-{
-    return _kand_mask8(a, b);
-}
-static inline MD_SIMD_MASK simd_mask_from_u32(unsigned int a) { return _cvtu32_mask8(a); }
-static inline unsigned int simd_mask_to_u32(MD_SIMD_MASK a) { return _cvtmask8_u32(a); }
+
+static inline unsigned int simd_mask_to_u32(MD_SIMD_MASK a) { return _mm256_movemask_ps(a); }
 static inline MD_FLOAT simd_h_reduce_sum(MD_SIMD_FLOAT a)
 {
     __m128 t0;
@@ -128,4 +110,22 @@ static inline void simd_h_decr3(
     simd_h_decr(m, a0);
     simd_h_decr(m + CLUSTER_N, a1);
     simd_h_decr(m + CLUSTER_N * 2, a2);
+}
+
+static inline MD_SIMD_INT simd_int_broadcast(int scalar) { return _mm256_set1_epi32(scalar); }
+static inline MD_SIMD_INT simd_int_load(const int *m) { return _mm256_load_si256((MD_SIMD_INT *) m); }
+static inline MD_SIMD_INT simd_int_load_h_duplicate(const int *m) {
+    return _mm256_broadcastsi128_si256(_mm_load_si128((const __m128i *)(m)));
+}
+
+static inline MD_SIMD_INT simd_int_load_h_dual(const int *m)
+{
+    __m128i t0, t1;
+    t0 = _mm_broadcastd_epi32(_mm_load_epi32(m));
+    t1 = _mm_broadcastd_epi32(_mm_load_epi32(m + 1));
+    return _mm256_inserti128_si256(_mm256_castsi128_si256(t0), t1, 0x1);
+}
+
+static inline MD_SIMD_FLOAT simd_gather(MD_SIMD_INT vidx, MD_FLOAT *base, const int scale) {
+    return _mm256_i32gather_ps(base, vidx, scale);
 }

--- a/src/common/simd/neon_double.h
+++ b/src/common/simd/neon_double.h
@@ -39,11 +39,13 @@ static inline MD_SIMD_FLOAT simd_real_fma(
 
 static inline MD_SIMD_MASK simd_mask_from_u32(uint32_t a)
 {
-    const uint64_t all  = 0xFFFFFFFFFFFFFFFF;
+    const uint64_t all  = 0xFFFFFFFFFFFFFFFFULL;
     const uint64_t none = 0x0;
-    return vsetq_lane_u64((a & 0x2) ? all : none,
-        vsetq_lane_u64((a & 0x1) ? all : none, vdupq_n_u64(0), 0),
-        1);
+    MD_SIMD_MASK result;
+
+    result = vsetq_lane_u64((a & 0x1) ? all : none, result, 0);
+    result = vsetq_lane_u64((a & 0x2) ? all : none, result, 1);
+    return result;
 }
 
 static inline uint32_t simd_mask_to_u32(MD_SIMD_MASK mask) { return 0; }

--- a/src/common/simd/neon_double.h
+++ b/src/common/simd/neon_double.h
@@ -1,0 +1,211 @@
+// #include <arm_acle.h>
+// #include <arm_neon.h>
+// #include <stdlib.h>
+// #include <stdio.h>
+#warning neon_double
+// Typedefs for MD_SIMD_FLOAT and MD_SIMD_MASK for double precision
+typedef float64x2x2_t MD_SIMD_FLOAT;
+typedef float64x2x2_t MD_SIMD_MASK;
+typedef float64x2_t   MD_SIMD_HALF;
+
+static inline MD_SIMD_FLOAT simd_broadcast(double value)
+{
+    // Create a vector with the broadcasted value
+    MD_SIMD_HALF v = vdupq_n_f64(value);
+    MD_SIMD_FLOAT result;
+    result.val[0] = v;
+    result.val[1] = v;
+    // Return the value replicated across both parts of the MD_SIMD_FLOAT structure
+    return result;
+}
+
+static inline MD_SIMD_FLOAT simd_zero(void)
+{
+    // Create a vector with the broadcasted value
+    MD_SIMD_HALF v = vdupq_n_f64(0.0);
+    MD_SIMD_FLOAT result;
+    result.val[0] = v;
+    result.val[1] = v;
+    // Return the value replicated across both parts of the MD_SIMD_FLOAT structure
+    return result;
+}
+
+// Helper function to subtract two MD_SIMD_FLOAT vectors
+static inline MD_SIMD_FLOAT simd_sub(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+{
+    MD_SIMD_FLOAT result;
+    result.val[0] = vsubq_f64(a.val[0], b.val[0]);
+    result.val[1] = vsubq_f64(a.val[1], b.val[1]);
+    return result;
+}
+
+static inline MD_SIMD_FLOAT simd_load(const double* ptr)
+{
+    // Load two 128-bit vectors in one instruction
+    return vld1q_f64_x2(ptr);
+}
+
+static inline void simd_store(double* ptr, MD_SIMD_FLOAT vec)
+{
+    // Store the first 128-bit vector (first two doubles)
+    vst1q_f64_x2(ptr, vec);
+}
+
+static inline MD_SIMD_FLOAT simd_add(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+{
+    MD_SIMD_FLOAT result;
+    result.val[0] = vaddq_f64(a.val[0], b.val[0]);
+    result.val[1] = vaddq_f64(a.val[1], b.val[1]);
+    return result;
+}
+static inline MD_SIMD_FLOAT simd_padd(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+{
+    MD_SIMD_FLOAT result;
+    result.val[0] = vpaddq_f64(a.val[0], a.val[1]);
+    result.val[1] = vpaddq_f64(b.val[0], b.val[1]);
+    return result;
+}
+
+static inline MD_SIMD_FLOAT simd_mul(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+{
+    MD_SIMD_FLOAT result;
+    result.val[0] = vmulq_f64(a.val[0], b.val[0]);
+    result.val[1] = vmulq_f64(a.val[1], b.val[1]);
+    return result;
+}
+
+static inline MD_SIMD_FLOAT simd_fma(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_FLOAT c)
+{
+    MD_SIMD_FLOAT result;
+    //@todo doublecheck this
+    result.val[0] = vfmaq_f64(c.val[0], a.val[0], b.val[0]);
+    result.val[1] = vfmaq_f64(c.val[1], a.val[1], b.val[1]);
+    return result;
+}
+
+static inline MD_SIMD_MASK simd_mask_from_u32(uint32_t a)
+{
+    const uint64_t all  = 0xFFFFFFFFFFFFFFFF;
+    const uint64_t none = 0x0;
+    MD_SIMD_MASK result;
+    // uint64x2_t mask     = vreinterpretq_u64_u32(vdupq_n_u32((a & 0x8) ? all : none));
+    // mask                = vsetq_lane_u64((a & 0x4) ? 0xFFFFFFFFFFFFFFFFULL : 0x0ULL, mask, 1);
+    // result = simd_broadcast(1.0);
+    result.val[0] = vsetq_lane_f64(vreinterpret_f64_u64(vdup_n_u64((a&0x1) ? all: none)), result.val[0], 0);
+    result.val[0] = vsetq_lane_f64(vreinterpret_f64_u64(vdup_n_u64((a&0x2) ? all: none)), result.val[0], 1);
+    result.val[1] = vsetq_lane_f64(vreinterpret_f64_u64(vdup_n_u64((a&0x4) ? all: none)), result.val[1], 0);
+    result.val[1] = vsetq_lane_f64(vreinterpret_f64_u64(vdup_n_u64((a&0x8) ? all: none)), result.val[1], 1);
+    return result;
+}
+
+
+static inline MD_SIMD_MASK simd_mask_and(MD_SIMD_MASK a, MD_SIMD_MASK b)
+{
+    uint64x2_t result0 = vandq_u64(a.val[0], b.val[0]);
+    uint64x2_t result1 = vandq_u64(a.val[1], b.val[1]);
+    MD_SIMD_MASK result;
+    result.val[0] = result0;
+    result.val[1] = result1;
+    return result;
+}
+
+
+static inline MD_SIMD_MASK simd_mask_cond_lt(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+{
+    uint64x2_t mask0 = vcltq_f64(a.val[0], b.val[0]);
+    uint64x2_t mask1 = vcltq_f64(a.val[1], b.val[1]);
+    MD_SIMD_MASK result;
+    result.val[0] = mask0;
+    result.val[1] = mask1;
+    return result;
+}
+
+static inline MD_SIMD_FLOAT simd_reciprocal(MD_SIMD_FLOAT a)
+{
+    // Estimate the reciprocal
+    MD_SIMD_FLOAT reciprocal_estimate;
+    reciprocal_estimate.val[0] = vrecpeq_f64(a.val[0]);
+    reciprocal_estimate.val[1] = vrecpeq_f64(a.val[1]);
+
+    // Compute the reciprocal correction
+    MD_SIMD_FLOAT reciprocal_correction;
+    reciprocal_correction.val[0] = vrecpsq_f64(reciprocal_estimate.val[0], a.val[0]);
+    reciprocal_correction.val[1] = vrecpsq_f64(reciprocal_estimate.val[1], a.val[1]);
+
+    // Multiply the estimate by the correction to improve accuracy
+    MD_SIMD_FLOAT reciprocal_result;
+    reciprocal_result.val[0] = vmulq_f64(reciprocal_estimate.val[0],
+        reciprocal_correction.val[0]);
+    reciprocal_result.val[1] = vmulq_f64(reciprocal_estimate.val[1],
+        reciprocal_correction.val[1]);
+
+    return reciprocal_result;
+}
+
+
+
+static inline double simd_incr_reduced_sum(
+    double* m, MD_SIMD_FLOAT v0, MD_SIMD_FLOAT v1, MD_SIMD_FLOAT v2, MD_SIMD_FLOAT v3)
+{
+
+    // Load existing values from memory and add to the sum
+    MD_SIMD_FLOAT sum0 = simd_padd(v0,v1);
+    MD_SIMD_FLOAT sum1 = simd_padd(v2,v3);
+
+    MD_SIMD_FLOAT sum = simd_padd(sum0,sum1);
+
+    MD_SIMD_FLOAT mem  = vld1q_f64_x2(m);
+    sum  = simd_add(sum,mem);
+
+    // Store the result back to memory
+    vst1q_f64_x2(m,sum);//? Here is a bubu??
+
+    // Reduce the final vector to a single double
+    MD_SIMD_HALF sum_parts = vpaddq_f64(sum.val [0], sum.val [1]); // Horizontal add
+    double final_sum = vgetq_lane_f64(sum_parts, 0) + vgetq_lane_f64(sum_parts, 1); // Extract and sum lanes
+    return final_sum;
+}
+
+
+
+static inline MD_SIMD_FLOAT select_by_mask(MD_SIMD_FLOAT a, MD_SIMD_MASK mask) {
+    // Select elements from 'a' based on the mask, and set other elements to 0.0
+    MD_SIMD_FLOAT result;
+    result.val[0] = vandq_u64( a.val[0], mask.val[0]);
+    result.val[1] = vandq_u64( a.val[1], mask.val[1]);
+    return result;
+}
+static inline MD_SIMD_FLOAT simd_masked_add(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_MASK m) {
+    return simd_add(a,select_by_mask(b,m));
+}
+
+static inline MD_SIMD_FLOAT simd_load_h_dual(const double* m) {
+    fprintf(stderr,
+        "simd_h_dual_incr_reduced_sum(): Not implemented for AVX2 with double "
+        "precision!");
+    return (MD_SIMD_FLOAT){vdupq_n_f64(0.0), vdupq_n_f64(0.0)};
+}
+
+static inline MD_SIMD_FLOAT simd_load_h_duplicate(const double* m) {
+    double value = *m;
+        fprintf(stderr,
+        "simd_load_h_duplicatem(): Not implemented for AVX2 with double "
+        "precision!");
+    return (MD_SIMD_FLOAT){vdupq_n_f64(value), vdupq_n_f64(value)};
+}
+
+static inline void simd_h_decr3(double* m, MD_SIMD_FLOAT a0, MD_SIMD_FLOAT a1, MD_SIMD_FLOAT a2) {
+    double value = *m;
+    fprintf(stderr,
+        "simd_h_decr3(): Not implemented for AVX2 with double "
+        "precision!");
+    return;
+}
+
+static inline double simd_h_dual_incr_reduced_sum(double* m, MD_SIMD_FLOAT v0, MD_SIMD_FLOAT v1) {
+    fprintf(stderr,
+        "simd_h_dual_incr_reduced_sum(): Not implemented for AVX2 with double "
+        "precision!");
+
+    return 0.0;
+}

--- a/src/common/simd/neon_float.h
+++ b/src/common/simd/neon_float.h
@@ -1,0 +1,159 @@
+// #include <arm_neon.h>
+#warning neon_float
+// Typedefs for MD_SIMD_FLOAT and MD_SIMD_MASK
+typedef float32x4_t MD_SIMD_FLOAT;
+typedef uint32x4_t MD_SIMD_MASK;
+
+// Broadcasting a scalar value to a SIMD vector
+static inline MD_SIMD_FLOAT simd_broadcast(float value) { return vdupq_n_f32(value); }
+
+// Zeroing a SIMD vector
+static inline MD_SIMD_FLOAT simd_zero(void) { return vdupq_n_f32(0.0f); }
+
+// Helper function to subtract two float64x2x2_t vectors
+static inline MD_SIMD_FLOAT simd_sub(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+{
+    MD_SIMD_FLOAT result;
+    result = vsubq_f32(a, b);
+    return result;
+}
+
+// Loading data into a SIMD vector
+static inline MD_SIMD_FLOAT simd_load(const float* ptr) { return vld1q_f32(ptr); }
+
+// Storing data from a SIMD vector
+static inline void simd_store(MD_FLOAT* ptr, MD_SIMD_FLOAT vec) { vst1q_f32(ptr, vec); }
+
+// Adding two SIMD vectors
+static inline MD_SIMD_FLOAT simd_add(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b) { return vaddq_f32(a, b); }
+
+// Multiplying two SIMD vectors
+static inline MD_SIMD_FLOAT simd_mul(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b) { return vmulq_f32(a, b); }
+
+// Fused multiply-add operation
+static inline MD_SIMD_FLOAT simd_fma(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_FLOAT c)
+{
+    return vfmaq_f32(c, a, b);
+}
+
+static inline MD_SIMD_FLOAT simd_mask_from_u32(uint32_t a)
+{
+    const uint32_t all  = 0xFFFFFFFF;
+    const uint32_t none = 0x0;
+    return vreinterpretq_f32_u32(vsetq_lane_u32((a & 0x8) ? all : none,
+        vsetq_lane_u32((a & 0x4) ? all : none,
+            vsetq_lane_u32((a & 0x2) ? all : none,
+                vsetq_lane_u32((a & 0x1) ? all : none, vdupq_n_u32(0), 0),
+                1),
+            2),
+        3));
+}
+
+static inline float32x4_t simd_mask_and(float32x4_t a, float32x4_t b) {
+    return vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(a), vreinterpretq_u32_f32(b)));
+}
+
+static inline float32x4_t simd_mask_cond_lt(float32x4_t a, float32x4_t b) {
+    return vreinterpretq_f32_u32(vcltq_f32(a, b));
+}
+
+static inline float32x4_t simd_reciprocal(float32x4_t a) {
+    float32x4_t reciprocal = vrecpeq_f32(a);
+    reciprocal = vmulq_f32(reciprocal, vrecpsq_f32(reciprocal, a));
+    return reciprocal;
+}
+
+static inline float simd_incr_reduced_sum(float *m, float32x4_t v0, float32x4_t v1, float32x4_t v2, float32x4_t v3) {
+    // Horizontal add pairs within each vector
+    float32x4_t sum0 = vpaddq_f32(v0, v1); // Add pairs in v0 and v1
+    float32x4_t sum1 = vpaddq_f32(v2, v3); // Add pairs in v2 and v3
+
+    // Combine the two resulting vectors
+    float32x4_t sum = vpaddq_f32(sum0, sum1); // Add pairs in sum0 and sum1
+
+    // Load existing values from memory and add to the sum
+    float32x4_t mem = vld1q_f32(m);
+    sum = vaddq_f32(sum, mem);
+
+    // Store the result back to memory
+    vst1q_f32(m, sum);
+
+    // Reduce the final vector to a single float
+    float32x2_t sum_low = vget_low_f32(sum);
+    float32x2_t sum_high = vget_high_f32(sum);
+    sum_low = vadd_f32(sum_low, sum_high); // Add high and low parts
+
+    sum_low = vpadd_f32(sum_low, sum_low); // Horizontal add
+    return vget_lane_f32(sum_low, 0); // Extract the final sum
+}
+
+static inline float32x4_t simd_masked_add(float32x4_t a, float32x4_t b, uint32x4_t m) {
+    // Perform bitwise AND operation on the mask and vector b
+    float32x4_t masked_b = vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(b), m));
+    // Add the result to vector a
+    return vaddq_f32(a, masked_b);
+}
+
+
+// // Reciprocal approximation
+// MD_SIMD_FLOAT simd_reciprocal(MD_SIMD_FLOAT a) {
+//     return vrecpeq_f32(a);
+// }
+
+// // Mask for comparison (less than)
+// MD_SIMD_MASK simd_mask_cond_lt(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b) {
+//     return vcltq_f32(a, b);
+// }
+
+// // Logical AND operation on masks
+// MD_SIMD_MASK simd_mask_and(MD_SIMD_MASK a, MD_SIMD_MASK b) {
+//     return vandq_u32(a, b);
+// }
+
+// Select elements based on mask
+MD_SIMD_FLOAT select_by_mask(MD_SIMD_FLOAT a, MD_SIMD_MASK mask) {
+    return vbslq_f32(mask, a, vdupq_n_f32(0.0f));
+}
+
+// // Mask creation from unsigned int
+// MD_SIMD_MASK simd_mask_from_u32(unsigned int value) {
+//     return vdupq_n_u32(value);
+// }
+
+// // Increment reduced sum
+// void simd_incr_reduced_sum(float* ptr, MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_FLOAT
+// c, MD_SIMD_FLOAT d) {
+//     MD_SIMD_FLOAT sum = vaddq_f32(vaddq_f32(a, b), vaddq_f32(c, d));
+//     float result[4];
+//     vst1q_f32(result, sum);
+//     for (int i = 0; i < 4; i++) {
+//         ptr[i] += result[i];
+//     }
+// }
+static inline MD_SIMD_FLOAT simd_load_h_dual(const MD_FLOAT* m)
+{
+    return vdupq_n_f32(0.0f);
+}
+
+static inline MD_SIMD_FLOAT simd_load_h_duplicate(const MD_FLOAT* m)
+{
+    return vdupq_n_f32(0.0f);
+}
+
+// static inline MD_SIMD_FLOAT simd_masked_add(
+//     MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_MASK m)
+// {
+//     return vdupq_n_f32(0.0f);
+// }
+
+static inline void simd_h_decr3(
+    MD_FLOAT* m, MD_SIMD_FLOAT a0, MD_SIMD_FLOAT a1, MD_SIMD_FLOAT a2)
+{
+    return;
+}
+
+static inline MD_FLOAT simd_h_dual_incr_reduced_sum(
+    MD_FLOAT* m, MD_SIMD_FLOAT v0, MD_SIMD_FLOAT v1)
+{
+    return 0.0f;
+}

--- a/src/common/simd/neon_float.h
+++ b/src/common/simd/neon_float.h
@@ -1,159 +1,175 @@
-// #include <arm_neon.h>
-#warning neon_float
-// Typedefs for MD_SIMD_FLOAT and MD_SIMD_MASK
-typedef float32x4_t MD_SIMD_FLOAT;
-typedef uint32x4_t MD_SIMD_MASK;
+#include <arm_neon.h>
+#include <stdlib.h>
 
-// Broadcasting a scalar value to a SIMD vector
-static inline MD_SIMD_FLOAT simd_broadcast(float value) { return vdupq_n_f32(value); }
+#define MD_SIMD_FLOAT float32x4_t
+#define MD_SIMD_MASK  uint32x4_t
+#define MD_SIMD_INT   int32x4_t
 
-// Zeroing a SIMD vector
-static inline MD_SIMD_FLOAT simd_zero(void) { return vdupq_n_f32(0.0f); }
-
-// Helper function to subtract two float64x2x2_t vectors
-static inline MD_SIMD_FLOAT simd_sub(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+static inline int simd_test_any(MD_SIMD_MASK a) { return vmaxvq_u32(a) != 0; }
+static inline MD_SIMD_FLOAT simd_real_broadcast(float value)
 {
-    MD_SIMD_FLOAT result;
-    result = vsubq_f32(a, b);
-    return result;
+    return vdupq_n_f32(value);
 }
-
-// Loading data into a SIMD vector
-static inline MD_SIMD_FLOAT simd_load(const float* ptr) { return vld1q_f32(ptr); }
-
-// Storing data from a SIMD vector
-static inline void simd_store(MD_FLOAT* ptr, MD_SIMD_FLOAT vec) { vst1q_f32(ptr, vec); }
-
-// Adding two SIMD vectors
-static inline MD_SIMD_FLOAT simd_add(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b) { return vaddq_f32(a, b); }
-
-// Multiplying two SIMD vectors
-static inline MD_SIMD_FLOAT simd_mul(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b) { return vmulq_f32(a, b); }
-
-// Fused multiply-add operation
-static inline MD_SIMD_FLOAT simd_fma(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_FLOAT c)
+static inline MD_SIMD_FLOAT simd_real_zero(void) { return vdupq_n_f32(0.0f); }
+static inline MD_SIMD_FLOAT simd_real_sub(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+{
+    return vsubq_f32(a, b);
+}
+static inline MD_SIMD_FLOAT simd_real_load(const float* ptr) { return vld1q_f32(ptr); }
+static inline void simd_real_store(MD_FLOAT* ptr, MD_SIMD_FLOAT vec)
+{
+    vst1q_f32(ptr, vec);
+}
+static inline MD_SIMD_FLOAT simd_real_add(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+{
+    return vaddq_f32(a, b);
+}
+static inline MD_SIMD_FLOAT simd_real_mul(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+{
+    return vmulq_f32(a, b);
+}
+static inline MD_SIMD_FLOAT simd_real_fma(
+    MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_FLOAT c)
 {
     return vfmaq_f32(c, a, b);
 }
 
-static inline MD_SIMD_FLOAT simd_mask_from_u32(uint32_t a)
+static inline MD_SIMD_MASK simd_mask_from_u32(uint32_t a)
 {
     const uint32_t all  = 0xFFFFFFFF;
     const uint32_t none = 0x0;
-    return vreinterpretq_f32_u32(vsetq_lane_u32((a & 0x8) ? all : none,
+    return vsetq_lane_u32((a & 0x8) ? all : none,
         vsetq_lane_u32((a & 0x4) ? all : none,
             vsetq_lane_u32((a & 0x2) ? all : none,
                 vsetq_lane_u32((a & 0x1) ? all : none, vdupq_n_u32(0), 0),
                 1),
             2),
-        3));
+        3);
 }
 
-static inline float32x4_t simd_mask_and(float32x4_t a, float32x4_t b) {
-    return vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(a), vreinterpretq_u32_f32(b)));
+static inline uint32_t simd_mask_to_u32(MD_SIMD_MASK mask) { return 0; }
+
+static inline MD_SIMD_MASK simd_mask_and(MD_SIMD_MASK a, MD_SIMD_MASK b)
+{
+    return vandq_u32(a, b);
 }
 
-static inline float32x4_t simd_mask_cond_lt(float32x4_t a, float32x4_t b) {
-    return vreinterpretq_f32_u32(vcltq_f32(a, b));
+static inline MD_SIMD_MASK simd_mask_cond_lt(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+{
+    return vcltq_f32(a, b);
 }
 
-static inline float32x4_t simd_reciprocal(float32x4_t a) {
-    float32x4_t reciprocal = vrecpeq_f32(a);
-    reciprocal = vmulq_f32(reciprocal, vrecpsq_f32(reciprocal, a));
+static inline MD_SIMD_FLOAT simd_real_reciprocal(MD_SIMD_FLOAT a)
+{
+    MD_SIMD_FLOAT reciprocal = vrecpeq_f32(a);
+    reciprocal               = vmulq_f32(reciprocal, vrecpsq_f32(reciprocal, a));
     return reciprocal;
 }
 
-static inline float simd_incr_reduced_sum(float *m, float32x4_t v0, float32x4_t v1, float32x4_t v2, float32x4_t v3) {
-    // Horizontal add pairs within each vector
-    float32x4_t sum0 = vpaddq_f32(v0, v1); // Add pairs in v0 and v1
-    float32x4_t sum1 = vpaddq_f32(v2, v3); // Add pairs in v2 and v3
+static inline float simd_real_incr_reduced_sum(
+    float* m, MD_SIMD_FLOAT v0, MD_SIMD_FLOAT v1, MD_SIMD_FLOAT v2, MD_SIMD_FLOAT v3)
+{
+    float32x4_t sum0 = vpaddq_f32(v0, v1);
+    float32x4_t sum1 = vpaddq_f32(v2, v3);
+    float32x4_t sum  = vpaddq_f32(sum0, sum1);
 
-    // Combine the two resulting vectors
-    float32x4_t sum = vpaddq_f32(sum0, sum1); // Add pairs in sum0 and sum1
-
-    // Load existing values from memory and add to the sum
     float32x4_t mem = vld1q_f32(m);
-    sum = vaddq_f32(sum, mem);
-
-    // Store the result back to memory
+    sum             = vaddq_f32(sum, mem);
     vst1q_f32(m, sum);
 
-    // Reduce the final vector to a single float
-    float32x2_t sum_low = vget_low_f32(sum);
+    float32x2_t sum_low  = vget_low_f32(sum);
     float32x2_t sum_high = vget_high_f32(sum);
-    sum_low = vadd_f32(sum_low, sum_high); // Add high and low parts
-
-    sum_low = vpadd_f32(sum_low, sum_low); // Horizontal add
-    return vget_lane_f32(sum_low, 0); // Extract the final sum
+    sum_low              = vadd_f32(sum_low, sum_high);
+    sum_low              = vpadd_f32(sum_low, sum_low);
+    return vget_lane_f32(sum_low, 0);
 }
 
-static inline float32x4_t simd_masked_add(float32x4_t a, float32x4_t b, uint32x4_t m) {
-    // Perform bitwise AND operation on the mask and vector b
-    float32x4_t masked_b = vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(b), m));
-    // Add the result to vector a
+static inline MD_SIMD_FLOAT simd_real_masked_add(
+    MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_MASK m)
+{
+    MD_SIMD_FLOAT masked_b = vreinterpretq_f32_u32(
+        vandq_u32(vreinterpretq_u32_f32(b), m));
     return vaddq_f32(a, masked_b);
 }
 
-
-// // Reciprocal approximation
-// MD_SIMD_FLOAT simd_reciprocal(MD_SIMD_FLOAT a) {
-//     return vrecpeq_f32(a);
-// }
-
-// // Mask for comparison (less than)
-// MD_SIMD_MASK simd_mask_cond_lt(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b) {
-//     return vcltq_f32(a, b);
-// }
-
-// // Logical AND operation on masks
-// MD_SIMD_MASK simd_mask_and(MD_SIMD_MASK a, MD_SIMD_MASK b) {
-//     return vandq_u32(a, b);
-// }
-
-// Select elements based on mask
-MD_SIMD_FLOAT select_by_mask(MD_SIMD_FLOAT a, MD_SIMD_MASK mask) {
+static inline MD_SIMD_FLOAT simd_real_select_by_mask(MD_SIMD_FLOAT a, MD_SIMD_MASK mask)
+{
     return vbslq_f32(mask, a, vdupq_n_f32(0.0f));
 }
 
-// // Mask creation from unsigned int
-// MD_SIMD_MASK simd_mask_from_u32(unsigned int value) {
-//     return vdupq_n_u32(value);
-// }
-
-// // Increment reduced sum
-// void simd_incr_reduced_sum(float* ptr, MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_FLOAT
-// c, MD_SIMD_FLOAT d) {
-//     MD_SIMD_FLOAT sum = vaddq_f32(vaddq_f32(a, b), vaddq_f32(c, d));
-//     float result[4];
-//     vst1q_f32(result, sum);
-//     for (int i = 0; i < 4; i++) {
-//         ptr[i] += result[i];
-//     }
-// }
-static inline MD_SIMD_FLOAT simd_load_h_dual(const MD_FLOAT* m)
+static inline MD_SIMD_INT simd_i32_load(const int* ptr) { return vld1q_s32(ptr); }
+static inline MD_SIMD_INT simd_i32_broadcast(int value) { return vdupq_n_s32(value); }
+static inline MD_SIMD_INT simd_i32_add(MD_SIMD_INT a, MD_SIMD_INT b)
 {
-    return vdupq_n_f32(0.0f);
+    return vaddq_s32(a, b);
 }
 
-static inline MD_SIMD_FLOAT simd_load_h_duplicate(const MD_FLOAT* m)
+static inline MD_SIMD_FLOAT simd_real_gather(
+    MD_SIMD_INT vidx, MD_FLOAT* base, const int scale)
 {
-    return vdupq_n_f32(0.0f);
+#if defined(__ARM_FEATURE_MTE)
+    return vldrwq_gather_offset_f32(base, vreinterpretq_u32_s32(vidx));
+#else
+    MD_SIMD_FLOAT result = vdupq_n_f32(0);
+
+    result = vld1q_lane_f32(&base[vgetq_lane_s32(vidx, 0)], result, 0);
+    result = vld1q_lane_f32(&base[vgetq_lane_s32(vidx, 1)], result, 1);
+    result = vld1q_lane_f32(&base[vgetq_lane_s32(vidx, 2)], result, 2);
+    result = vld1q_lane_f32(&base[vgetq_lane_s32(vidx, 3)], result, 3);
+    return result;
+#endif
 }
 
-// static inline MD_SIMD_FLOAT simd_masked_add(
-//     MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_MASK m)
-// {
-//     return vdupq_n_f32(0.0f);
-// }
+static inline MD_SIMD_FLOAT simd_real_load_h_dual(const MD_FLOAT* m)
+{
+    MD_SIMD_FLOAT ret;
+    fprintf(stderr,
+        "simd_real_load_h_dual(): Not implemented for NEON with single precision!");
+    exit(-1);
+    return ret;
+}
 
-static inline void simd_h_decr3(
+static inline MD_SIMD_FLOAT simd_real_load_h_duplicate(const MD_FLOAT* m)
+{
+    MD_SIMD_FLOAT ret;
+    fprintf(stderr,
+        "simd_real_load_h_duplicate(): Not implemented for NEON with single precision!");
+    exit(-1);
+    return ret;
+}
+
+static inline void simd_real_h_decr3(
     MD_FLOAT* m, MD_SIMD_FLOAT a0, MD_SIMD_FLOAT a1, MD_SIMD_FLOAT a2)
 {
-    return;
+    fprintf(stderr,
+        "simd_real_h_decr3(): Not implemented for NEON with single precision!");
+    exit(-1);
 }
 
-static inline MD_FLOAT simd_h_dual_incr_reduced_sum(
+static inline MD_FLOAT simd_real_h_dual_incr_reduced_sum(
     MD_FLOAT* m, MD_SIMD_FLOAT v0, MD_SIMD_FLOAT v1)
 {
+    fprintf(stderr,
+        "simd_real_h_dual_incr_reduced_sum(): Not implemented for NEON with single "
+        "precision!");
+    exit(-1);
     return 0.0f;
+}
+
+static inline MD_SIMD_INT simd_i32_load_h_duplicate(const int* m)
+{
+    MD_SIMD_INT ret;
+    fprintf(stderr,
+        "simd_i32_load_h_duplicate(): Not implemented for NEON with single precision!");
+    exit(-1);
+    return ret;
+}
+
+static inline MD_SIMD_INT simd_i32_load_h_dual_scaled(const int* m, int scale)
+{
+    MD_SIMD_INT ret;
+    fprintf(stderr,
+        "simd_i32_load_h_dual_scaled(): Not implemented for NEON with single precision!");
+    exit(-1);
+    return ret;
 }

--- a/src/common/simd/neon_float.h
+++ b/src/common/simd/neon_float.h
@@ -107,7 +107,7 @@ static inline MD_SIMD_INT simd_i32_add(MD_SIMD_INT a, MD_SIMD_INT b)
 static inline MD_SIMD_FLOAT simd_real_gather(
     MD_SIMD_INT vidx, MD_FLOAT* base, const int scale)
 {
-#if defined(__ARM_FEATURE_MTE)
+#if defined(__ARM_FEATURE_MVE)
     return vldrwq_gather_offset_f32(base, vreinterpretq_u32_s32(vidx));
 #else
     MD_SIMD_FLOAT result = vdupq_n_f32(0);

--- a/src/common/simd/sve_double.h
+++ b/src/common/simd/sve_double.h
@@ -11,8 +11,8 @@
 #define MD_SIMD_INT   svint64_t
 
 static inline int simd_test_any(MD_SIMD_MASK a) { return svptest_any(svptrue_b64(), a); }
-static inline MD_SIMD_FLOAT simd_real_broadcast(float value) { return svdup_f64(value); }
-static inline MD_SIMD_FLOAT simd_real_zero(void) { return svdup_f64(0.0f); }
+static inline MD_SIMD_FLOAT simd_real_broadcast(MD_FLOAT value) { return svdup_f64(value); }
+static inline MD_SIMD_FLOAT simd_real_zero(void) { return svdup_f64(0.0); }
 static inline MD_SIMD_FLOAT simd_real_sub(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
 {
     return svsub_f64_z(svptrue_b64(), a, b);
@@ -52,9 +52,7 @@ static inline MD_SIMD_FLOAT simd_real_fma(
 
 static inline MD_SIMD_MASK simd_mask_from_u32(uint32_t a)
 {
-    svbool_t predicate = svdupq_n_b64(a & 0x1 ? 1 : 0, a & 0x2 ? 1 : 0);
-
-    return predicate;
+    return svdupq_n_b64(a & 0x1 ? 1 : 0, a & 0x2 ? 1 : 0);
 }
 
 static inline uint32_t simd_mask_to_u32(MD_SIMD_MASK mask)
@@ -136,7 +134,7 @@ static inline MD_SIMD_FLOAT simd_real_masked_add(
 
 static inline MD_SIMD_FLOAT simd_real_select_by_mask(MD_SIMD_FLOAT a, MD_SIMD_MASK mask)
 {
-    return svsel_f64(mask, a, svdup_f64(0.0f));
+    return svsel_f64(mask, a, svdup_f64(0.0));
 }
 
 static inline MD_SIMD_FLOAT simd_real_load_h_dual(const MD_FLOAT* m)
@@ -184,7 +182,8 @@ static inline MD_SIMD_INT simd_i32_add(MD_SIMD_INT a, MD_SIMD_INT b)
 
 static inline MD_SIMD_INT simd_i32_load(const int* m)
 {
-    return svunpklo_s64(svld1_s32(svptrue_b64(), m));
+    svbool_t pg = svwhilelt_b32(0, VECTOR_WIDTH);
+    return svunpklo_s64(svld1_s32(pg, m));
 }
 
 static inline MD_SIMD_INT simd_i32_load_h_duplicate(const int* m)

--- a/src/common/simd/sve_double.h
+++ b/src/common/simd/sve_double.h
@@ -1,0 +1,188 @@
+
+
+#warning SVE_DOUBLE
+typedef svfloat64x2_t MD_SIMD_FLOAT;
+typedef svfloat64x2_t  MD_SIMD_MASK;
+typedef svfloat64_t   MD_SIMD_HALF;
+
+// static inline MD_SIMD_FLOAT simd_padd(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b) {
+//     // Extract vectors from the tuples
+//     svfloat64_t a0 = svget2_f64(a, 0);
+//     svfloat64_t a1 = svget2_f64(a, 1);
+//     svfloat64_t b0 = svget2_f64(b, 0);
+//     svfloat64_t b1 = svget2_f64(b, 1);
+
+//     // Perform pairwise addition
+//     svfloat64_t result0 = svpadd_f64(a0, a1);
+//     svfloat64_t result1 = svpadd_f64(b0, b1);
+
+//     // Construct the result tuple
+//     MD_SIMD_FLOAT result = svcreate2_f64(result0, result1);
+
+//     return result;
+// }
+
+
+// Broadcasting a scalar double value to a SIMD vector tuple
+static inline MD_SIMD_FLOAT simd_broadcast(double value) {
+    MD_SIMD_FLOAT result;
+    result = svcreate2_f64(svdup_f64(value), svdup_f64(value));
+    return result;
+}
+
+static inline MD_SIMD_FLOAT simd_zero() {
+    MD_SIMD_FLOAT result;
+    result = svcreate2_f64(svdup_f64(0), svdup_f64(0));
+    return result;
+}
+
+static inline MD_SIMD_FLOAT simd_sub(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+{
+    MD_SIMD_FLOAT result;
+    result = svcreate2_f64(svsub_f64_z(svptrue_b64(), svget2_f64(a, 0), svget2_f64(b, 0)), svsub_f64_z(svptrue_b64(), svget2_f64(a, 1), svget2_f64(b, 1)));
+    return result;
+}
+
+// Function to load a vector tuple from memory
+static inline MD_SIMD_FLOAT simd_load(const double *ptr) {
+    svfloat64_t v0 = svld1_f64(svptrue_b64(), ptr);
+    svfloat64_t v1 = svld1_f64(svptrue_b64(), ptr + svcntd());
+    MD_SIMD_FLOAT result = svcreate2_f64(v0, v1);
+    return result;
+}
+
+// Function to store a vector tuple to memory
+static inline void simd_store(double* ptr, MD_SIMD_FLOAT vec) {
+    svst1_f64(svptrue_b64(), ptr, svget2_f64(vec, 0));
+    svst1_f64(svptrue_b64(), ptr + svcntd(), svget2_f64(vec, 1));
+}
+
+static inline MD_SIMD_FLOAT simd_add(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+{
+    MD_SIMD_FLOAT result;
+    result = svcreate2_f64(svadd_f64_z(svptrue_b64(), svget2_f64(a, 0), svget2_f64(b, 0)), svadd_f64_z(svptrue_b64(), svget2_f64(a, 1), svget2_f64(b, 1)));
+    return result;
+}
+
+static inline MD_SIMD_FLOAT simd_mul(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+{
+    MD_SIMD_FLOAT result;
+    result = svcreate2_f64(svmul_f64_z(svptrue_b64(), svget2_f64(a, 0), svget2_f64(b, 0)), svmul_f64_z(svptrue_b64(), svget2_f64(a, 1), svget2_f64(b, 1)));
+    return result;
+}
+
+static inline MD_SIMD_FLOAT simd_fma(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_FLOAT c)
+{
+    MD_SIMD_FLOAT result;
+    result = svcreate2_f64(svmad_f64_z(svptrue_b64(), svget2_f64(a, 0), svget2_f64(b, 0), svget2_f64(c, 0)), svmad_f64_z(svptrue_b64(), svget2_f64(a, 1), svget2_f64(b, 1), svget2_f64(c, 1)));
+    return result;
+}
+
+static inline MD_SIMD_FLOAT simd_reciprocal(MD_SIMD_FLOAT a)
+{
+    // Estimate the reciprocal
+    MD_SIMD_FLOAT reciprocal_estimate;
+    reciprocal_estimate = svcreate2_f64(svrecpe_f64(svget2_f64(a, 0)), svrecpe_f64(svget2_f64(a, 1)));
+
+    // Compute the reciprocal correction
+    MD_SIMD_FLOAT reciprocal_correction;
+    reciprocal_correction = svcreate2_f64(svrecps_f64(svget2_f64(reciprocal_estimate, 0), svget2_f64(a, 0)), 
+                                          svrecps_f64(svget2_f64(reciprocal_estimate, 1), svget2_f64(a, 1)));
+
+    // Multiply the estimate by the correction to improve accuracy
+    MD_SIMD_FLOAT reciprocal_result;
+    reciprocal_result = svcreate2_f64(svmul_f64_z(svptrue_b64(), svget2_f64(reciprocal_estimate, 0), svget2_f64(reciprocal_correction, 0)), 
+                                      svmul_f64_z(svptrue_b64(), svget2_f64(reciprocal_estimate, 1), svget2_f64(reciprocal_correction, 1)));
+
+    return reciprocal_result;
+}
+
+static inline MD_SIMD_MASK simd_mask_from_u32(uint32_t a)
+{
+    const uint64_t all = 0xFFFFFFFFFFFFFFFF;
+    const uint64_t none = 0x0;
+    MD_SIMD_HALF zero_mask = svdupq_n_f64(0, 0);
+    MD_SIMD_HALF result1,result2;
+    result1 = svreinterpret_f64_u64(svdup_u64(0xFFFFFFFFFFFFFFFF));
+    result2 = svreinterpret_f64_u64(svdup_u64(0xFFFFFFFFFFFFFFFF));
+    svbool_t predicate1 = svdupq_n_b64 (a & 0x1 ? 1 :0, a & 0x2 ? 1 :0);
+    svbool_t predicate2 = svdupq_n_b64 (a & 0x4 ? 1 :0,a & 0x8 ? 1 :0);
+    
+    result1 = svmul_f64_z(predicate1, result1, zero_mask);
+    result2 = svmul_f64_z(predicate2, result2, zero_mask);
+
+    return svcreate2_f64(result1, result2);
+}
+
+
+static inline MD_SIMD_MASK simd_mask_and(MD_SIMD_MASK a, MD_SIMD_MASK b)
+{
+    MD_SIMD_MASK result;
+    svuint64_t a1i = svreinterpret_u64_f64(svget2_f64(a, 0));
+    svuint64_t b1i = svreinterpret_u64_f64(svget2_f64(b, 0));
+    svuint64_t a2i = svreinterpret_u64_f64(svget2_f64(a, 1));
+    svuint64_t b2i = svreinterpret_u64_f64(svget2_f64(b, 1));
+    
+
+    result = svcreate2_f64(svreinterpret_f64_u64(svand_u64_z(svptrue_b64(), a1i, b1i)), 
+                           svreinterpret_f64_u64(svand_u64_z(svptrue_b64(), a2i, b2i)));
+    return result;
+}
+
+static inline MD_SIMD_MASK simd_mask_cond_lt(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+{
+    // Use an active predicate for all lanes
+    svbool_t pg = svptrue_b32();
+    
+    // Compare elements of a and b, resulting in a predicate
+    svbool_t predicate1 = svcmplt(pg, svget2_f64(a, 0), svget2_f64(b, 0));
+    svbool_t predicate2 = svcmplt(pg, svget2_f64(a, 1), svget2_f64(b, 1));
+
+    MD_SIMD_HALF zero_mask = svdupq_n_f64(0, 0);
+    MD_SIMD_HALF result1 = svreinterpret_f64_u64(svdup_u64(0xFFFFFFFFFFFFFFFF));
+    MD_SIMD_HALF result2 = svreinterpret_f64_u64(svdup_u64(0xFFFFFFFFFFFFFFFF));
+    result1 = svmul_f64_z(predicate1, result1, zero_mask);
+    result2 = svmul_f64_z(predicate2, result2, zero_mask);
+    return svcreate2_f64(result1, result2);
+
+}
+
+// Select elements based on mask
+static inline MD_SIMD_FLOAT select_by_mask(MD_SIMD_FLOAT a, MD_SIMD_MASK mask) {
+    // Convert the float mask to a boolean mask
+    svbool_t pg1 = svcmpne_f64(svptrue_b64(), svget2_f64(mask, 0), svdup_f64(0.0f));
+    svbool_t pg2 = svcmpne_f64(svptrue_b64(), svget2_f64(mask, 1), svdup_f64(0.0f));
+    
+    // Select elements from a where the mask is true, otherwise select 0.0f
+    return svcreate2_f64(svsel_f64(pg1, svget2_f64(a, 0), svdup_f64(0.0f)), svsel_f64(pg2, svget2_f64(a, 1), svdup_f64(0.0f)));
+    // return svsel_f32(pg, a, svdup_f32(0.0f));
+
+}
+
+// Masked add operation
+static inline MD_SIMD_FLOAT simd_masked_add(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_MASK m) {
+    // Convert the float mask to a boolean mask
+    svbool_t pg1 = svcmpne_f64(svptrue_b64(), svget2_f64(m, 0), svdup_f64(0.0f));
+    svbool_t pg2 = svcmpne_f64(svptrue_b64(), svget2_f64(m, 1), svdup_f64(0.0f));
+    
+    // Perform the masked add operation
+    return svcreate2_f64(svadd_f64_m(pg1, svget2_f64(a, 0), svget2_f64(b, 0)), svadd_f64_m(pg2, svget2_f64(a, 1), svget2_f64(b, 1)));
+}
+
+static inline double simd_incr_reduced_sum(double *m, MD_SIMD_FLOAT v0, MD_SIMD_FLOAT v1, MD_SIMD_FLOAT v2, MD_SIMD_FLOAT v3) {
+    MD_SIMD_HALF sum00 = svaddp_f64_m(svptrue_b64(), svget2_f64(v0, 1), svget2_f64(v0, 0));
+    MD_SIMD_HALF sum01 = svaddp_f64_m(svptrue_b64(), svget2_f64(v1, 1), svget2_f64(v1, 0));
+    MD_SIMD_HALF sum10 = svaddp_f64_m(svptrue_b64(), svget2_f64(v2, 1), svget2_f64(v2, 0));
+    MD_SIMD_HALF sum11 = svaddp_f64_m(svptrue_b64(), svget2_f64(v3, 1), svget2_f64(v3, 0));
+    sum00 = svaddp_f64_m(svptrue_b64(),sum00,sum01);
+    sum10 = svaddp_f64_m(svptrue_b64(),sum10,sum11);
+
+    MD_SIMD_FLOAT result_vec = svcreate2_f64(sum00, sum10);
+    result_vec= simd_add(result_vec,simd_load(m));
+    simd_store(m,result_vec);
+
+    double result1 = svaddv_f64(svptrue_b64(), svget2_f64(result_vec,0));
+    double result2 = svaddv_f64(svptrue_b64(), svget2_f64(result_vec,1));
+    return result1 + result2;
+}
+

--- a/src/common/simd/sve_float.h
+++ b/src/common/simd/sve_float.h
@@ -79,7 +79,6 @@ static inline MD_SIMD_MASK simd_mask_and(MD_SIMD_MASK a, MD_SIMD_MASK b)
     return svand_b_z(svptrue_b32(), a, b);
 }
 
-// Conditional mask based on less than comparison
 static inline MD_SIMD_MASK simd_mask_cond_lt(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
 {
     return svcmplt_f32(svptrue_b32(), a, b);
@@ -95,6 +94,21 @@ static inline MD_SIMD_FLOAT simd_real_reciprocal(MD_SIMD_FLOAT a)
 static inline float simd_real_incr_reduced_sum(
     float* m, MD_SIMD_FLOAT v0, MD_SIMD_FLOAT v1, MD_SIMD_FLOAT v2, MD_SIMD_FLOAT v3)
 {
+    /*
+    svbool_t    pg = svptrue_b32();
+    svfloat32_t _m, _s;
+    float32_t   sum[4];
+    sum[0] = svadda_f32(pg, 0.0f, v0);
+    sum[1] = svadda_f32(pg, 0.0f, v1);
+    sum[2] = svadda_f32(pg, 0.0f, v2);
+    sum[3] = svadda_f32(pg, 0.0f, v3);
+    pg     = svptrue_pat_b32(SV_VL4);
+    _m     = svld1_f32(pg, m);
+    _s     = svld1_f32(pg, sum);
+    svst1_f32(pg, m, svadd_f32_x(pg, _m, _s));
+    return svadda_f32(pg, 0.0f, _s);
+    */
+
     MD_SIMD_FLOAT sum0 = svaddp_f32_m(svptrue_b32(), v0, v1);
     MD_SIMD_FLOAT sum1 = svaddp_f32_m(svptrue_b32(), v2, v3);
     MD_SIMD_FLOAT odd  = svuzp2_f32(sum0, sum1);
@@ -114,24 +128,29 @@ static inline MD_SIMD_FLOAT simd_real_masked_add(
     return svadd_f32_m(m, a, b);
 }
 
-// Select elements based on mask
 static inline MD_SIMD_FLOAT simd_real_select_by_mask(MD_SIMD_FLOAT a, MD_SIMD_MASK mask)
 {
     return svsel_f32(mask, a, svdup_f32(0.0f));
 }
 
-// Dummy load functions to match original signatures
 static inline MD_SIMD_FLOAT simd_real_load_h_dual(const MD_FLOAT* m)
 {
-    return svdup_f32(0.0f);
+    MD_SIMD_FLOAT ret;
+    fprintf(stderr,
+        "simd_real_load_h_dual(): Not implemented for SVE with single precision!");
+    exit(-1);
+    return ret;
 }
 
 static inline MD_SIMD_FLOAT simd_real_load_h_duplicate(const MD_FLOAT* m)
 {
-    return svdup_f32(0.0f);
+    MD_SIMD_FLOAT ret;
+    fprintf(stderr,
+        "simd_real_load_h_duplicate(): Not implemented for SVE with single precision!");
+    exit(-1);
+    return ret;
 }
 
-// Dummy function for simd_h_decr3
 static inline void simd_real_h_decr3(
     MD_FLOAT* m, MD_SIMD_FLOAT a0, MD_SIMD_FLOAT a1, MD_SIMD_FLOAT a2)
 {
@@ -140,10 +159,13 @@ static inline void simd_real_h_decr3(
     exit(-1);
 }
 
-// Dummy function for simd_h_dual_incr_reduced_sum
 static inline MD_FLOAT simd_real_h_dual_incr_reduced_sum(
     MD_FLOAT* m, MD_SIMD_FLOAT v0, MD_SIMD_FLOAT v1)
 {
+    fprintf(stderr,
+        "simd_real_h_dual_incr_reduced_sum(): Not implemented for SVE with single "
+        "precision!");
+    exit(-1);
     return 0.0f;
 }
 

--- a/src/common/simd/sve_float.h
+++ b/src/common/simd/sve_float.h
@@ -1,102 +1,121 @@
 #warning SVE FLOAT
 // Typedefs for MD_SIMD_FLOAT and MD_SIMD_MASK
 typedef svfloat32_t MD_SIMD_FLOAT;
-typedef svfloat32_t MD_SIMD_MASK;  // Corrected type for mask
+typedef svfloat32_t MD_SIMD_MASK; // Corrected type for mask
+typedef svint32_t MD_SIMD_INT;
 
 // Broadcasting a scalar value to a SIMD vector
-static inline MD_SIMD_FLOAT simd_broadcast(float value) {
-    return svdup_f32(value);
-}
+static inline MD_SIMD_FLOAT simd_real_broadcast(float value) { return svdup_f32(value); }
 
 // Zeroing a SIMD vector
-static inline MD_SIMD_FLOAT simd_zero(void) {
-    return svdup_f32(0.0f);
-}
+static inline MD_SIMD_FLOAT simd_real_zero(void) { return svdup_f32(0.0f); }
 
 // Helper function to subtract two float64x2x2_t vectors
-static inline MD_SIMD_FLOAT simd_sub(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b) {
+static inline MD_SIMD_FLOAT simd_real_sub(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+{
     return svsub_f32_z(svptrue_b32(), a, b);
 }
 
 // Loading data into a SIMD vector
-static inline MD_SIMD_FLOAT simd_load(const float* ptr) {
+static inline MD_SIMD_FLOAT simd_real_load(const float* ptr)
+{
     return svld1_f32(svptrue_b32(), ptr);
 }
 
+static inline MD_SIMD_FLOAT simd_real_gather(
+    MD_SIMD_INT vidx, MD_FLOAT* base, const int scale)
+{
+    return svld1_gather_s32offset_f32(svptrue_b32(), base, vidx);
+}
+
 // Storing data from a SIMD vector
-static inline void simd_store(MD_FLOAT* ptr, MD_SIMD_FLOAT vec) {
+static inline void simd_real_store(MD_FLOAT* ptr, MD_SIMD_FLOAT vec)
+{
     svst1_f32(svptrue_b32(), ptr, vec);
 }
 
 // Adding two SIMD vectors
-static inline MD_SIMD_FLOAT simd_add(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b) {
+static inline MD_SIMD_FLOAT simd_real_add(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+{
     return svadd_f32_z(svptrue_b32(), a, b);
 }
 
 // Multiplying two SIMD vectors
-static inline MD_SIMD_FLOAT simd_mul(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b) {
+static inline MD_SIMD_FLOAT simd_real_mul(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+{
     return svmul_f32_z(svptrue_b32(), a, b);
 }
 
 // Fused multiply-add operation
-static inline MD_SIMD_FLOAT simd_fma(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_FLOAT c) {
+static inline MD_SIMD_FLOAT simd_real_fma(
+    MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_FLOAT c)
+{
     return svmad_f32_z(svptrue_b32(), a, b, c);
 }
 
-static inline MD_SIMD_FLOAT simd_mask_from_u32(uint32_t a) {
+static inline MD_SIMD_FLOAT simd_mask_from_u32(uint32_t a)
+{
 
-    const uint32_t all = 0xFFFFFFFF;
-    const uint32_t none = 0x0;
+    const uint32_t all     = 0xFFFFFFFF;
+    const uint32_t none    = 0x0;
     MD_SIMD_MASK zero_mask = simd_zero();
-    MD_SIMD_MASK result = svreinterpret_f32_u32(svdup_u32(0xFFFFFFFF));
-    svbool_t predicate = svdupq_n_b32 (a & 0x1 ? 1 :0, a & 0x2 ? 1 :0,a & 0x4 ? 1 :0,a & 0x8 ? 1 :0);
-    return svmul_f32_z(predicate, result, zero_mask);;
+    MD_SIMD_MASK result    = svreinterpret_f32_u32(svdup_u32(0xFFFFFFFF));
+    svbool_t predicate     = svdupq_n_b32(a & 0x1 ? 1 : 0,
+        a & 0x2 ? 1 : 0,
+        a & 0x4 ? 1 : 0,
+        a & 0x8 ? 1 : 0);
+    return svmul_f32_z(predicate, result, zero_mask);
+    ;
 }
 
-static inline MD_SIMD_MASK simd_mask_and(svfloat32_t a, svfloat32_t b) {
+static inline MD_SIMD_MASK simd_mask_and(svfloat32_t a, svfloat32_t b)
+{
     // Reinterpret the float vectors as integer vectors
     svuint32_t ai = svreinterpret_u32_f32(a);
     svuint32_t bi = svreinterpret_u32_f32(b);
-    
+
     // Perform bitwise AND operation
     svuint32_t result = svand_u32_z(svptrue_b32(), ai, bi);
-    
+
     // Reinterpret the result back to float
     return svreinterpret_f32_u32(result);
 }
 
-
 // Conditional mask based on less than comparison
-static inline MD_SIMD_MASK simd_mask_cond_lt(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b) {
+static inline MD_SIMD_MASK simd_mask_cond_lt(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
+{
     // Use an active predicate for all lanes
     svbool_t pg = svptrue_b32();
-    
+
     // Compare elements of a and b, resulting in a predicate
     svbool_t predicate = svcmplt(pg, a, b);
 
     MD_SIMD_MASK zero_mask = simd_zero();
-    MD_SIMD_MASK result = svreinterpret_f32_u32(svdup_u32(0xFFFFFFFF));
-    return svmul_f32_z(predicate, result, zero_mask);;
-
+    MD_SIMD_MASK result    = svreinterpret_f32_u32(svdup_u32(0xFFFFFFFF));
+    return svmul_f32_z(predicate, result, zero_mask);
+    ;
 }
 
 // Reciprocal approximation
-static inline MD_SIMD_FLOAT simd_reciprocal(MD_SIMD_FLOAT a) {
+static inline MD_SIMD_FLOAT simd_real_reciprocal(MD_SIMD_FLOAT a)
+{
     MD_SIMD_FLOAT reciprocal = svrecpe_f32(a);
     reciprocal = svmul_f32_z(svptrue_b32(), reciprocal, svrecps_f32(reciprocal, a));
     return reciprocal;
 }
 
 // Increment reduced sum
-static inline float simd_incr_reduced_sum(float *m, MD_SIMD_FLOAT v0, MD_SIMD_FLOAT v1, MD_SIMD_FLOAT v2, MD_SIMD_FLOAT v3) {
+static inline float simd_incr_reduced_sum(
+    float* m, MD_SIMD_FLOAT v0, MD_SIMD_FLOAT v1, MD_SIMD_FLOAT v2, MD_SIMD_FLOAT v3)
+{
     MD_SIMD_FLOAT sum0 = svaddp_f32_m(svptrue_b32(), v0, v1);
     MD_SIMD_FLOAT sum1 = svaddp_f32_m(svptrue_b32(), v2, v3);
-    MD_SIMD_FLOAT odd  = svuzp2_f32(sum0,sum1);
-    MD_SIMD_FLOAT even = svuzp1_f32(sum0,sum1);
-    MD_SIMD_FLOAT sum  = svaddp_f32_m(svptrue_b32(),even,odd);
+    MD_SIMD_FLOAT odd  = svuzp2_f32(sum0, sum1);
+    MD_SIMD_FLOAT even = svuzp1_f32(sum0, sum1);
+    MD_SIMD_FLOAT sum  = svaddp_f32_m(svptrue_b32(), even, odd);
 
     MD_SIMD_FLOAT mem = svld1_f32(svptrue_b32(), m);
-    sum = svadd_f32_m(svptrue_b32(), sum, mem);
+    sum               = svadd_f32_m(svptrue_b32(), sum, mem);
 
     svst1_f32(svptrue_b32(), m, sum);
 
@@ -105,41 +124,48 @@ static inline float simd_incr_reduced_sum(float *m, MD_SIMD_FLOAT v0, MD_SIMD_FL
 }
 
 // Masked add operation
-static inline MD_SIMD_FLOAT simd_masked_add(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_MASK m) {
+static inline MD_SIMD_FLOAT simd_real_masked_add(
+    MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_MASK m)
+{
     // Convert the float mask to a boolean mask
     svbool_t pg = svcmpne_f32(svptrue_b32(), m, svdup_f32(0.0f));
-    
+
     // Perform the masked add operation
     return svadd_f32_m(pg, a, b);
-
 }
 
 // Select elements based on mask
-static inline MD_SIMD_FLOAT select_by_mask(MD_SIMD_FLOAT a, MD_SIMD_MASK mask) {
+static inline MD_SIMD_FLOAT simd_real_select_by_mask(MD_SIMD_FLOAT a, MD_SIMD_MASK mask)
+{
     // Convert the float mask to a boolean mask
     svbool_t pg = svcmpne_f32(svptrue_b32(), mask, svdup_f32(0.0f));
-    
+
     // Select elements from a where the mask is true, otherwise select 0.0f
     return svsel_f32(pg, a, svdup_f32(0.0f));
-
 }
 
 // Dummy load functions to match original signatures
-static inline MD_SIMD_FLOAT simd_load_h_dual(const MD_FLOAT* m) {
+static inline MD_SIMD_FLOAT simd_real_load_h_dual(const MD_FLOAT* m)
+{
     return svdup_f32(0.0f);
 }
 
-static inline MD_SIMD_FLOAT simd_load_h_duplicate(const MD_FLOAT* m) {
+static inline MD_SIMD_FLOAT simd_real_load_h_duplicate(const MD_FLOAT* m)
+{
     return svdup_f32(0.0f);
 }
 
 // Dummy function for simd_h_decr3
-static inline void simd_h_decr3(MD_FLOAT* m, MD_SIMD_FLOAT a0, MD_SIMD_FLOAT a1, MD_SIMD_FLOAT a2) {
+static inline void simd_h_decr3(
+    MD_FLOAT* m, MD_SIMD_FLOAT a0, MD_SIMD_FLOAT a1, MD_SIMD_FLOAT a2)
+{
     return;
 }
 
 // Dummy function for simd_h_dual_incr_reduced_sum
-static inline MD_FLOAT simd_h_dual_incr_reduced_sum(MD_FLOAT* m, MD_SIMD_FLOAT v0, MD_SIMD_FLOAT v1) {
+static inline MD_FLOAT simd_h_dual_incr_reduced_sum(
+    MD_FLOAT* m, MD_SIMD_FLOAT v0, MD_SIMD_FLOAT v1)
+{
     return 0.0f;
 }
 
@@ -147,7 +173,7 @@ static inline MD_FLOAT simd_h_dual_incr_reduced_sum(MD_FLOAT* m, MD_SIMD_FLOAT v
 // static inline MD_SIMD_FLOAT simd_mask_to_float(MD_SIMD_MASK mask) {
 //     // Convert the float mask to a boolean mask
 //     svbool_t pg = svcmpne_f32(svptrue_b32(), mask, svdup_f32(0.0f));
-    
+
 //     // Create a float vector based on the boolean mask: 1.0f for true, 0.0f for false
 //     return svsel_f32(pg, svdup_f32(1.0f), svdup_f32(0.0f));
 // }

--- a/src/common/simd/sve_float.h
+++ b/src/common/simd/sve_float.h
@@ -1,0 +1,153 @@
+#warning SVE FLOAT
+// Typedefs for MD_SIMD_FLOAT and MD_SIMD_MASK
+typedef svfloat32_t MD_SIMD_FLOAT;
+typedef svfloat32_t MD_SIMD_MASK;  // Corrected type for mask
+
+// Broadcasting a scalar value to a SIMD vector
+static inline MD_SIMD_FLOAT simd_broadcast(float value) {
+    return svdup_f32(value);
+}
+
+// Zeroing a SIMD vector
+static inline MD_SIMD_FLOAT simd_zero(void) {
+    return svdup_f32(0.0f);
+}
+
+// Helper function to subtract two float64x2x2_t vectors
+static inline MD_SIMD_FLOAT simd_sub(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b) {
+    return svsub_f32_z(svptrue_b32(), a, b);
+}
+
+// Loading data into a SIMD vector
+static inline MD_SIMD_FLOAT simd_load(const float* ptr) {
+    return svld1_f32(svptrue_b32(), ptr);
+}
+
+// Storing data from a SIMD vector
+static inline void simd_store(MD_FLOAT* ptr, MD_SIMD_FLOAT vec) {
+    svst1_f32(svptrue_b32(), ptr, vec);
+}
+
+// Adding two SIMD vectors
+static inline MD_SIMD_FLOAT simd_add(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b) {
+    return svadd_f32_z(svptrue_b32(), a, b);
+}
+
+// Multiplying two SIMD vectors
+static inline MD_SIMD_FLOAT simd_mul(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b) {
+    return svmul_f32_z(svptrue_b32(), a, b);
+}
+
+// Fused multiply-add operation
+static inline MD_SIMD_FLOAT simd_fma(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_FLOAT c) {
+    return svmad_f32_z(svptrue_b32(), a, b, c);
+}
+
+static inline MD_SIMD_FLOAT simd_mask_from_u32(uint32_t a) {
+
+    const uint32_t all = 0xFFFFFFFF;
+    const uint32_t none = 0x0;
+    MD_SIMD_MASK zero_mask = simd_zero();
+    MD_SIMD_MASK result = svreinterpret_f32_u32(svdup_u32(0xFFFFFFFF));
+    svbool_t predicate = svdupq_n_b32 (a & 0x1 ? 1 :0, a & 0x2 ? 1 :0,a & 0x4 ? 1 :0,a & 0x8 ? 1 :0);
+    return svmul_f32_z(predicate, result, zero_mask);;
+}
+
+static inline MD_SIMD_MASK simd_mask_and(svfloat32_t a, svfloat32_t b) {
+    // Reinterpret the float vectors as integer vectors
+    svuint32_t ai = svreinterpret_u32_f32(a);
+    svuint32_t bi = svreinterpret_u32_f32(b);
+    
+    // Perform bitwise AND operation
+    svuint32_t result = svand_u32_z(svptrue_b32(), ai, bi);
+    
+    // Reinterpret the result back to float
+    return svreinterpret_f32_u32(result);
+}
+
+
+// Conditional mask based on less than comparison
+static inline MD_SIMD_MASK simd_mask_cond_lt(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b) {
+    // Use an active predicate for all lanes
+    svbool_t pg = svptrue_b32();
+    
+    // Compare elements of a and b, resulting in a predicate
+    svbool_t predicate = svcmplt(pg, a, b);
+
+    MD_SIMD_MASK zero_mask = simd_zero();
+    MD_SIMD_MASK result = svreinterpret_f32_u32(svdup_u32(0xFFFFFFFF));
+    return svmul_f32_z(predicate, result, zero_mask);;
+
+}
+
+// Reciprocal approximation
+static inline MD_SIMD_FLOAT simd_reciprocal(MD_SIMD_FLOAT a) {
+    MD_SIMD_FLOAT reciprocal = svrecpe_f32(a);
+    reciprocal = svmul_f32_z(svptrue_b32(), reciprocal, svrecps_f32(reciprocal, a));
+    return reciprocal;
+}
+
+// Increment reduced sum
+static inline float simd_incr_reduced_sum(float *m, MD_SIMD_FLOAT v0, MD_SIMD_FLOAT v1, MD_SIMD_FLOAT v2, MD_SIMD_FLOAT v3) {
+    MD_SIMD_FLOAT sum0 = svaddp_f32_m(svptrue_b32(), v0, v1);
+    MD_SIMD_FLOAT sum1 = svaddp_f32_m(svptrue_b32(), v2, v3);
+    MD_SIMD_FLOAT odd  = svuzp2_f32(sum0,sum1);
+    MD_SIMD_FLOAT even = svuzp1_f32(sum0,sum1);
+    MD_SIMD_FLOAT sum  = svaddp_f32_m(svptrue_b32(),even,odd);
+
+    MD_SIMD_FLOAT mem = svld1_f32(svptrue_b32(), m);
+    sum = svadd_f32_m(svptrue_b32(), sum, mem);
+
+    svst1_f32(svptrue_b32(), m, sum);
+
+    float result = svaddv_f32(svptrue_b32(), sum);
+    return result;
+}
+
+// Masked add operation
+static inline MD_SIMD_FLOAT simd_masked_add(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b, MD_SIMD_MASK m) {
+    // Convert the float mask to a boolean mask
+    svbool_t pg = svcmpne_f32(svptrue_b32(), m, svdup_f32(0.0f));
+    
+    // Perform the masked add operation
+    return svadd_f32_m(pg, a, b);
+
+}
+
+// Select elements based on mask
+static inline MD_SIMD_FLOAT select_by_mask(MD_SIMD_FLOAT a, MD_SIMD_MASK mask) {
+    // Convert the float mask to a boolean mask
+    svbool_t pg = svcmpne_f32(svptrue_b32(), mask, svdup_f32(0.0f));
+    
+    // Select elements from a where the mask is true, otherwise select 0.0f
+    return svsel_f32(pg, a, svdup_f32(0.0f));
+
+}
+
+// Dummy load functions to match original signatures
+static inline MD_SIMD_FLOAT simd_load_h_dual(const MD_FLOAT* m) {
+    return svdup_f32(0.0f);
+}
+
+static inline MD_SIMD_FLOAT simd_load_h_duplicate(const MD_FLOAT* m) {
+    return svdup_f32(0.0f);
+}
+
+// Dummy function for simd_h_decr3
+static inline void simd_h_decr3(MD_FLOAT* m, MD_SIMD_FLOAT a0, MD_SIMD_FLOAT a1, MD_SIMD_FLOAT a2) {
+    return;
+}
+
+// Dummy function for simd_h_dual_incr_reduced_sum
+static inline MD_FLOAT simd_h_dual_incr_reduced_sum(MD_FLOAT* m, MD_SIMD_FLOAT v0, MD_SIMD_FLOAT v1) {
+    return 0.0f;
+}
+
+// // Helper function to convert MD_SIMD_MASK to MD_SIMD_FLOAT for printing
+// static inline MD_SIMD_FLOAT simd_mask_to_float(MD_SIMD_MASK mask) {
+//     // Convert the float mask to a boolean mask
+//     svbool_t pg = svcmpne_f32(svptrue_b32(), mask, svdup_f32(0.0f));
+    
+//     // Create a float vector based on the boolean mask: 1.0f for true, 0.0f for false
+//     return svsel_f32(pg, svdup_f32(1.0f), svdup_f32(0.0f));
+// }

--- a/src/common/util.c
+++ b/src/common/util.c
@@ -107,7 +107,7 @@ void readline(char* line, FILE* fp)
 void debug_printf(const char* format, ...)
 {
 #ifdef DEBUG
-    __va_list arg;
+    va_list arg;
     int ret;
 
     va_start(arg, format);

--- a/src/verletlist/force.c
+++ b/src/verletlist/force.c
@@ -17,15 +17,15 @@ void initForce(Parameter* param)
         computeForce = computeForceEam;
         break;
     case FF_LJ:
+#ifdef CUDA_TARGET
+        computeForce = computeForceLJCUDA;
+#else
         if (param->half_neigh) {
             computeForce = computeForceLJHalfNeigh;
         } else {
-#ifdef CUDA_TARGET
-            computeForce = computeForceLJFullNeighCUDA;
-#else
             computeForce = computeForceLJFullNeigh;
-#endif
         }
+#endif
         break;
     default:
         fprintf(stderr, "Error: Unknown force field!\n");

--- a/src/verletlist/force.h
+++ b/src/verletlist/force.h
@@ -24,7 +24,7 @@ extern double computeForceLJFullNeigh(Parameter*, Atom*, Neighbor*, Stats*);
 extern double computeForceEam(Parameter*, Atom*, Neighbor*, Stats*);
 
 #ifdef CUDA_TARGET
-extern double computeForceLJFullNeighCUDA(Parameter*, Atom*, Neighbor*, Stats*);
+extern double computeForceLJCUDA(Parameter*, Atom*, Neighbor*, Stats*);
 #define KERNEL_NAME "CUDA"
 #else
 #ifdef USE_SIMD_KERNEL

--- a/src/verletlist/forceCuda.cu
+++ b/src/verletlist/forceCuda.cu
@@ -26,8 +26,7 @@ extern "C" {
 #include <util.h>
 }
 
-// cuda kernel
-__global__ void calc_force(DeviceAtom a,
+__global__ void computeForceLJCudaFullNeigh(DeviceAtom a,
     MD_FLOAT cutforcesq,
     MD_FLOAT sigma6,
     MD_FLOAT epsilon,
@@ -85,6 +84,74 @@ __global__ void calc_force(DeviceAtom a,
     atom_fx(i) = fix;
     atom_fy(i) = fiy;
     atom_fz(i) = fiz;
+}
+
+__global__ void computeForceLJCudaHalfNeigh(DeviceAtom a,
+    MD_FLOAT cutforcesq,
+    MD_FLOAT sigma6,
+    MD_FLOAT epsilon,
+    int Nlocal,
+    int neigh_maxneighs,
+    int* neigh_neighbors,
+    int* neigh_numneigh,
+    int ntypes)
+{
+    const int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= Nlocal) {
+        return;
+    }
+
+    DeviceAtom* atom    = &a;
+    const int numneighs = neigh_numneigh[i];
+
+    MD_FLOAT xtmp = atom_x(i);
+    MD_FLOAT ytmp = atom_y(i);
+    MD_FLOAT ztmp = atom_z(i);
+
+    MD_FLOAT fix = 0;
+    MD_FLOAT fiy = 0;
+    MD_FLOAT fiz = 0;
+
+#ifndef ONE_ATOM_TYPE
+    const int type_i = atom->type[i];
+#endif
+
+    for (int k = 0; k < numneighs; k++) {
+        int j         = neigh_neighbors[Nlocal * k + i];
+        MD_FLOAT delx = xtmp - atom_x(j);
+        MD_FLOAT dely = ytmp - atom_y(j);
+        MD_FLOAT delz = ztmp - atom_z(j);
+        MD_FLOAT rsq  = delx * delx + dely * dely + delz * delz;
+
+#ifndef ONE_ATOM_TYPE
+        const int type_j          = atom->type[j];
+        const int type_ij         = type_i * ntypes + type_j;
+        const MD_FLOAT cutforcesq = atom->cutforcesq[type_ij];
+        const MD_FLOAT sigma6     = atom->sigma6[type_ij];
+        const MD_FLOAT epsilon    = atom->epsilon[type_ij];
+#endif
+
+        if (rsq < cutforcesq) {
+            MD_FLOAT sr2             = 1.0 / rsq;
+            MD_FLOAT sr6             = sr2 * sr2 * sr2 * sigma6;
+            MD_FLOAT force           = 48.0 * sr6 * (sr6 - 0.5) * sr2 * epsilon;
+            MD_FLOAT partial_force_x = delx * force;
+            MD_FLOAT partial_force_y = dely * force;
+            MD_FLOAT partial_force_z = delz * force;
+
+            atomicAdd(&atom_fx(j), -partial_force_x);
+            atomicAdd(&atom_fy(j), -partial_force_y);
+            atomicAdd(&atom_fz(j), -partial_force_z);
+
+            fix += partial_force_x;
+            fiy += partial_force_y;
+            fiz += partial_force_z;
+        }
+    }
+
+    atomicAdd(&atom_fx(i), fix);
+    atomicAdd(&atom_fy(i), fiy);
+    atomicAdd(&atom_fz(i), fiz);
 }
 
 __global__ void kernel_initial_integrate(
@@ -156,8 +223,7 @@ void initialIntegrateCUDA(bool reneigh, Parameter* param, Atom* atom)
     }
 }
 
-double computeForceLJFullNeighCUDA(
-    Parameter* param, Atom* atom, Neighbor* neighbor, Stats* stats)
+double computeForceLJCUDA(Parameter* param, Atom* atom, Neighbor* neighbor, Stats* stats)
 {
     const int num_threads_per_block = get_cuda_num_threads();
     int Nlocal                      = atom->Nlocal;
@@ -186,17 +252,37 @@ double computeForceLJFullNeighCUDA(
     double S             = getTimeStamp();
     LIKWID_MARKER_START("force");
 
-    calc_force<<<num_blocks, num_threads_per_block>>>(atom->d_atom,
-        cutforcesq,
-        sigma6,
-        epsilon,
-        Nlocal,
-        neighbor->maxneighs,
-        neighbor->d_neighbor.neighbors,
-        neighbor->d_neighbor.numneigh,
-        atom->ntypes);
-    cuda_assert("calc_force", cudaPeekAtLastError());
-    cuda_assert("calc_force", cudaDeviceSynchronize());
+    if (neighbor->half_neigh) {
+#ifdef AOS
+        memsetGPU(atom->d_atom.fx, 0, sizeof(MD_FLOAT) * Nlocal * 3);
+#else
+        memsetGPU(atom->d_atom.fx, 0, sizeof(MD_FLOAT) * Nlocal);
+        memsetGPU(atom->d_atom.fy, 0, sizeof(MD_FLOAT) * Nlocal);
+        memsetGPU(atom->d_atom.fz, 0, sizeof(MD_FLOAT) * Nlocal);
+#endif
+        computeForceLJCudaHalfNeigh<<<num_blocks, num_threads_per_block>>>(atom->d_atom,
+            cutforcesq,
+            sigma6,
+            epsilon,
+            Nlocal,
+            neighbor->maxneighs,
+            neighbor->d_neighbor.neighbors,
+            neighbor->d_neighbor.numneigh,
+            atom->ntypes);
+    } else {
+        computeForceLJCudaFullNeigh<<<num_blocks, num_threads_per_block>>>(atom->d_atom,
+            cutforcesq,
+            sigma6,
+            epsilon,
+            Nlocal,
+            neighbor->maxneighs,
+            neighbor->d_neighbor.neighbors,
+            neighbor->d_neighbor.numneigh,
+            atom->ntypes);
+    }
+
+    cuda_assert("computeForceLJCuda", cudaPeekAtLastError());
+    cuda_assert("computeForceLJCuda", cudaDeviceSynchronize());
     cudaProfilerStop();
 
     LIKWID_MARKER_STOP("force");

--- a/src/verletlist/forceCuda.cu
+++ b/src/verletlist/forceCuda.cu
@@ -53,7 +53,7 @@ __global__ void calc_force(DeviceAtom a,
     MD_FLOAT fiy = 0;
     MD_FLOAT fiz = 0;
 
-#ifdef EXPLICIT_TYPES
+#ifndef ONE_ATOM_TYPE
     const int type_i = atom->type[i];
 #endif
 
@@ -64,7 +64,7 @@ __global__ void calc_force(DeviceAtom a,
         MD_FLOAT delz = ztmp - atom_z(j);
         MD_FLOAT rsq  = delx * delx + dely * dely + delz * delz;
 
-#ifdef EXPLICIT_TYPES
+#ifndef ONE_ATOM_TYPE
         const int type_j          = atom->type[j];
         const int type_ij         = type_i * ntypes + type_j;
         const MD_FLOAT cutforcesq = atom->cutforcesq[type_ij];

--- a/src/verletlist/force_eam.c
+++ b/src/verletlist/force_eam.c
@@ -53,7 +53,7 @@ double computeForceEam(Parameter* param, Atom* atom, Neighbor* neighbor, Stats* 
             MD_FLOAT ytmp = atom_y(i);
             MD_FLOAT ztmp = atom_z(i);
             MD_FLOAT rhoi = 0;
-#ifdef EXPLICIT_TYPES
+#ifndef ONE_ATOM_TYPE
             const int type_i = atom->type[i];
 #endif
 #pragma ivdep
@@ -63,7 +63,7 @@ double computeForceEam(Parameter* param, Atom* atom, Neighbor* neighbor, Stats* 
                 MD_FLOAT dely = ytmp - atom_y(j);
                 MD_FLOAT delz = ztmp - atom_z(j);
                 MD_FLOAT rsq  = delx * delx + dely * dely + delz * delz;
-#ifdef EXPLICIT_TYPES
+#ifndef ONE_ATOM_TYPE
                 const int type_j          = atom->type[j];
                 const int type_ij         = type_i * ntypes + type_j;
                 const MD_FLOAT cutforcesq = atom->cutforcesq[type_ij];
@@ -76,7 +76,7 @@ double computeForceEam(Parameter* param, Atom* atom, Neighbor* neighbor, Stats* 
                     m          = m < nr - 1 ? m : nr - 1;
                     p -= m;
                     p = p < 1.0 ? p : 1.0;
-#ifdef EXPLICIT_TYPES
+#ifndef ONE_ATOM_TYPE
                     rhoi += ((rhor_spline[type_ij * nr_tot + m * 7 + 3] * p +
                                  rhor_spline[type_ij * nr_tot + m * 7 + 4]) *
                                     p +
@@ -92,7 +92,7 @@ double computeForceEam(Parameter* param, Atom* atom, Neighbor* neighbor, Stats* 
                 }
             }
 
-#ifdef EXPLICIT_TYPES
+#ifndef ONE_ATOM_TYPE
             const int type_ii = type_i * type_i;
 #endif
             MD_FLOAT p = 1.0 * rhoi * rdrho + 1.0;
@@ -100,7 +100,7 @@ double computeForceEam(Parameter* param, Atom* atom, Neighbor* neighbor, Stats* 
             m          = MAX(1, MIN(m, nrho - 1));
             p -= m;
             p = MIN(p, 1.0);
-#ifdef EXPLICIT_TYPES
+#ifndef ONE_ATOM_TYPE
             fp[i] = (frho_spline[type_ii * nrho_tot + m * 7 + 0] * p +
                         frho_spline[type_ii * nrho_tot + m * 7 + 1]) *
                         p +
@@ -133,7 +133,7 @@ double computeForceEam(Parameter* param, Atom* atom, Neighbor* neighbor, Stats* 
             MD_FLOAT fix  = 0;
             MD_FLOAT fiy  = 0;
             MD_FLOAT fiz  = 0;
-#ifdef EXPLICIT_TYPES
+#ifndef ONE_ATOM_TYPE
             const int type_i = atom->type[i];
 #endif
 
@@ -144,7 +144,7 @@ double computeForceEam(Parameter* param, Atom* atom, Neighbor* neighbor, Stats* 
                 MD_FLOAT dely = ytmp - atom_y(j);
                 MD_FLOAT delz = ztmp - atom_z(j);
                 MD_FLOAT rsq  = delx * delx + dely * dely + delz * delz;
-#ifdef EXPLICIT_TYPES
+#ifndef ONE_ATOM_TYPE
                 const int type_j          = atom->type[j];
                 const int type_ij         = type_i * ntypes + type_j;
                 const MD_FLOAT cutforcesq = atom->cutforcesq[type_ij];
@@ -170,7 +170,7 @@ double computeForceEam(Parameter* param, Atom* atom, Neighbor* neighbor, Stats* 
                     //   terms of embed eng: Fi(sum rho_ij) and Fj(sum rho_ji)
                     //   hence embed' = Fi(sum rho_ij) rhojp + Fj(sum rho_ji) rhoip
 
-#ifdef EXPLICIT_TYPES
+#ifndef ONE_ATOM_TYPE
                     MD_FLOAT rhoip = (rhor_spline[type_ij * nr_tot + m * 7 + 0] * p +
                                          rhor_spline[type_ij * nr_tot + m * 7 + 1]) *
                                          p +

--- a/src/verletlist/force_lj-x86.c
+++ b/src/verletlist/force_lj-x86.c
@@ -67,7 +67,7 @@ double computeForceLJFullNeigh_simd(
                 MD_SIMD_MASK mask_numneighs = simd_mask_int_cond_lt(
                     simd_int_add(simd_int_broadcast(k), simd_int_seq()),
                     numneighs_vec);
-                MD_SIMD_INT j = simd_int_mask_load(&neighs[k], mask_numneighs);
+                MD_SIMD_INT j      = simd_int_mask_load(&neighs[k], mask_numneighs);
 #ifdef AOS
                 MD_SIMD_INT j3     = simd_int_add(simd_int_add(j, j), j); // j * 3
                 MD_SIMD_FLOAT delx = xtmp -

--- a/src/verletlist/force_lj-x86.c
+++ b/src/verletlist/force_lj-x86.c
@@ -53,23 +53,23 @@ double computeForceLJFullNeigh_simd(
         for (int i = 0; i < Nlocal; i++) {
             neighs                    = &neighbor->neighbors[i * neighbor->maxneighs];
             int numneighs             = neighbor->numneigh[i];
-            MD_SIMD_INT numneighs_vec = simd_int_broadcast(numneighs);
-            MD_SIMD_FLOAT xtmp        = simd_broadcast(atom_x(i));
-            MD_SIMD_FLOAT ytmp        = simd_broadcast(atom_y(i));
-            MD_SIMD_FLOAT ztmp        = simd_broadcast(atom_z(i));
-            MD_SIMD_FLOAT fix         = simd_zero();
-            MD_SIMD_FLOAT fiy         = simd_zero();
-            MD_SIMD_FLOAT fiz         = simd_zero();
+            MD_SIMD_INT numneighs_vec = simd_i32_broadcast(numneighs);
+            MD_SIMD_FLOAT xtmp        = simd_real_broadcast(atom_x(i));
+            MD_SIMD_FLOAT ytmp        = simd_real_broadcast(atom_y(i));
+            MD_SIMD_FLOAT ztmp        = simd_real_broadcast(atom_z(i));
+            MD_SIMD_FLOAT fix         = simd_real_zero();
+            MD_SIMD_FLOAT fiy         = simd_real_zero();
+            MD_SIMD_FLOAT fiz         = simd_real_zero();
 
             for (int k = 0; k < numneighs; k += VECTOR_WIDTH) {
                 // If the last iteration of this loop is separated from the rest, this
                 // mask can be set only there
-                MD_SIMD_MASK mask_numneighs = simd_mask_int_cond_lt(
-                    simd_int_add(simd_int_broadcast(k), simd_int_seq()),
+                MD_SIMD_MASK mask_numneighs = simd_mask_i32_cond_lt(
+                    simd_i32_add(simd_i32_broadcast(k), simd_i32_seq()),
                     numneighs_vec);
-                MD_SIMD_INT j      = simd_int_mask_load(&neighs[k], mask_numneighs);
+                MD_SIMD_INT j      = simd_i32_mask_load(&neighs[k], mask_numneighs);
 #ifdef AOS
-                MD_SIMD_INT j3     = simd_int_add(simd_int_add(j, j), j); // j * 3
+                MD_SIMD_INT j3     = simd_i32_add(simd_i32_add(j, j), j); // j * 3
                 MD_SIMD_FLOAT delx = xtmp -
                                      simd_gather(j3, &(atom->x[0]), sizeof(MD_FLOAT));
                 MD_SIMD_FLOAT dely = ytmp -
@@ -77,25 +77,29 @@ double computeForceLJFullNeigh_simd(
                 MD_SIMD_FLOAT delz = ztmp -
                                      simd_gather(j3, &(atom->x[2]), sizeof(MD_FLOAT));
 #else
-                MD_SIMD_FLOAT delx = xtmp - simd_gather(j, atom->x, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT dely = ytmp - simd_gather(j, atom->y, sizeof(MD_FLOAT));
-                MD_SIMD_FLOAT delz = ztmp - simd_gather(j, atom->z, sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT delx = xtmp -
+                                     simd_real_gather(j, atom->x, sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT dely = ytmp -
+                                     simd_real_gather(j, atom->y, sizeof(MD_FLOAT));
+                MD_SIMD_FLOAT delz = ztmp -
+                                     simd_real_gather(j, atom->z, sizeof(MD_FLOAT));
 #endif
-                MD_SIMD_FLOAT rsq        = simd_fma(delx,
+                MD_SIMD_FLOAT rsq        = simd_real_fma(delx,
                     delx,
-                    simd_fma(dely, dely, simd_mul(delz, delz)));
+                    simd_real_fma(dely, dely, simd_real_mul(delz, delz)));
                 MD_SIMD_MASK cutoff_mask = simd_mask_and(mask_numneighs,
                     simd_mask_cond_lt(rsq, cutforcesq_vec));
-                MD_SIMD_FLOAT sr2        = simd_reciprocal(rsq);
-                MD_SIMD_FLOAT sr6        = simd_mul(sr2,
-                    simd_mul(sr2, simd_mul(sr2, sigma6_vec)));
-                MD_SIMD_FLOAT force      = simd_mul(c48_vec,
-                    simd_mul(sr6,
-                        simd_mul(simd_sub(sr6, c05_vec), simd_mul(sr2, eps_vec))));
+                MD_SIMD_FLOAT sr2        = simd_real_reciprocal(rsq);
+                MD_SIMD_FLOAT sr6        = simd_real_mul(sr2,
+                    simd_real_mul(sr2, simd_real_mul(sr2, sigma6_vec)));
+                MD_SIMD_FLOAT force      = simd_real_mul(c48_vec,
+                    simd_real_mul(sr6,
+                        simd_real_mul(simd_real_sub(sr6, c05_vec),
+                            simd_real_mul(sr2, eps_vec))));
 
-                fix = simd_masked_add(fix, simd_mul(delx, force), cutoff_mask);
-                fiy = simd_masked_add(fiy, simd_mul(dely, force), cutoff_mask);
-                fiz = simd_masked_add(fiz, simd_mul(delz, force), cutoff_mask);
+                fix = simd_masked_add(fix, simd_real_mul(delx, force), cutoff_mask);
+                fiy = simd_masked_add(fiy, simd_real_mul(dely, force), cutoff_mask);
+                fiz = simd_masked_add(fiz, simd_real_mul(delz, force), cutoff_mask);
             }
 
             atom_fx(i) += simd_h_reduce_sum(fix);

--- a/src/verletlist/force_lj.c
+++ b/src/verletlist/force_lj.c
@@ -16,7 +16,7 @@ double computeForceLJFullNeigh(
 {
     int nLocal = atom->Nlocal;
     int* neighs;
-#ifndef EXPLICIT_TYPES
+#ifdef ONE_ATOM_TYPE
     MD_FLOAT cutforcesq = param->cutforce * param->cutforce;
     MD_FLOAT sigma6     = param->sigma6;
     MD_FLOAT epsilon    = param->epsilon;
@@ -47,7 +47,7 @@ double computeForceLJFullNeigh(
             MD_FLOAT fiy  = 0;
             MD_FLOAT fiz  = 0;
 
-#ifdef EXPLICIT_TYPES
+#ifndef ONE_ATOM_TYPE
             const int type_i = atom->type[i];
 #endif
 
@@ -58,7 +58,7 @@ double computeForceLJFullNeigh(
                 MD_FLOAT delz = ztmp - atom_z(j);
                 MD_FLOAT rsq  = delx * delx + dely * dely + delz * delz;
 
-#ifdef EXPLICIT_TYPES
+#ifndef ONE_ATOM_TYPE
                 const int type_j          = atom->type[j];
                 const int type_ij         = type_i * atom->ntypes + type_j;
                 const MD_FLOAT cutforcesq = atom->cutforcesq[type_ij];
@@ -109,7 +109,7 @@ double computeForceLJHalfNeigh(
 {
     int nlocal = atom->Nlocal;
     int* neighs;
-#ifndef EXPLICIT_TYPES
+#ifdef ONE_ATOM_TYPE
     MD_FLOAT cutforcesq = param->cutforce * param->cutforce;
     MD_FLOAT sigma6     = param->sigma6;
     MD_FLOAT epsilon    = param->epsilon;
@@ -141,7 +141,7 @@ double computeForceLJHalfNeigh(
             MD_FLOAT fiy  = 0;
             MD_FLOAT fiz  = 0;
 
-#ifdef EXPLICIT_TYPES
+#ifndef ONE_ATOM_TYPE
             const int type_i = atom->type[i];
 #endif
 
@@ -156,7 +156,7 @@ double computeForceLJHalfNeigh(
                 MD_FLOAT delz = ztmp - atom_z(j);
                 MD_FLOAT rsq  = delx * delx + dely * dely + delz * delz;
 
-#ifdef EXPLICIT_TYPES
+#ifndef ONE_ATOM_TYPE
                 const int type_j          = atom->type[j];
                 const int type_ij         = type_i * atom->ntypes + type_j;
                 const MD_FLOAT cutforcesq = atom->cutforcesq[type_ij];

--- a/src/verletlist/main-stub.c
+++ b/src/verletlist/main-stub.c
@@ -227,9 +227,9 @@ int main(int argc, const char* argv[])
         }
 
         atom->type[atom->Nlocal] = rand() % atom->ntypes;
-        atom_x(atom->Nlocal)     = (MD_FLOAT)(i) * 0.00001;
-        atom_y(atom->Nlocal)     = (MD_FLOAT)(i) * 0.00001;
-        atom_z(atom->Nlocal)     = (MD_FLOAT)(i) * 0.00001;
+        atom_x(atom->Nlocal)     = (MD_FLOAT)(i)*0.00001;
+        atom_y(atom->Nlocal)     = (MD_FLOAT)(i)*0.00001;
+        atom_z(atom->Nlocal)     = (MD_FLOAT)(i)*0.00001;
         atom_vx(atom->Nlocal)    = 0.0;
         atom_vy(atom->Nlocal)    = 0.0;
         atom_vz(atom->Nlocal)    = 0.0;

--- a/src/verletlist/neighbor.c
+++ b/src/verletlist/neighbor.c
@@ -212,7 +212,7 @@ void buildNeighborCPU(Atom* atom, Neighbor* neighbor)
             MD_FLOAT ytmp = atom_y(i);
             MD_FLOAT ztmp = atom_z(i);
             int ibin      = coord2bin(xtmp, ytmp, ztmp);
-#ifdef EXPLICIT_TYPES
+#ifndef ONE_ATOM_TYPE
             int type_i = atom->type[i];
 #endif
             for (int k = 0; k < nstencil; k++) {
@@ -230,7 +230,7 @@ void buildNeighborCPU(Atom* atom, Neighbor* neighbor)
                     MD_FLOAT delz = ztmp - atom_z(j);
                     MD_FLOAT rsq  = delx * delx + dely * dely + delz * delz;
 
-#ifdef EXPLICIT_TYPES
+#ifndef ONE_ATOM_TYPE
                     int type_j = atom->type[j];
                     const MD_FLOAT cutoff =
                         atom->cutneighsq[type_i * atom->ntypes + type_j];

--- a/src/verletlist/neighborCuda.cu
+++ b/src/verletlist/neighborCuda.cu
@@ -130,6 +130,7 @@ __global__ void compute_neighborhood(DeviceAtom a,
     Neighbor_params np,
     int nlocal,
     int maxneighs,
+    int halfneigh,
     int nstencil,
     int* stencil,
     int* bins,
@@ -163,8 +164,7 @@ __global__ void compute_neighborhood(DeviceAtom a,
 
         for (int m = 0; m < bincount[jbin]; m++) {
             int j = loc_bin[m];
-
-            if (j == i) {
+            if (j == i || (halfneigh && (j < i))) {
                 continue;
             }
 
@@ -305,6 +305,7 @@ void buildNeighborCUDA(Atom* atom, Neighbor* neighbor)
             np,
             atom->Nlocal,
             neighbor->maxneighs,
+            neighbor->half_neigh,
             nstencil,
             c_stencil,
             c_binning.bins,

--- a/src/verletlist/neighborCuda.cu
+++ b/src/verletlist/neighborCuda.cu
@@ -259,23 +259,21 @@ void buildNeighborCUDA(Atom* atom, Neighbor* neighbor)
             c_binning.mbins * c_binning.atoms_per_bin * sizeof(int));
     }
 
-    Neighbor_params np {
-        .xprd    = xprd,
-        .yprd    = yprd,
-        .zprd    = zprd,
-        .bininvx = bininvx,
-        .bininvy = bininvy,
-        .bininvz = bininvz,
-        .mbinxlo = mbinxlo,
-        .mbinylo = mbinylo,
-        .mbinzlo = mbinzlo,
-        .nbinx   = nbinx,
-        .nbiny   = nbiny,
-        .nbinz   = nbinz,
-        .mbinx   = mbinx,
-        .mbiny   = mbiny,
-        .mbinz   = mbinz
-    };
+    Neighbor_params np { .xprd = xprd,
+        .yprd                  = yprd,
+        .zprd                  = zprd,
+        .bininvx               = bininvx,
+        .bininvy               = bininvy,
+        .bininvz               = bininvz,
+        .mbinxlo               = mbinxlo,
+        .mbinylo               = mbinylo,
+        .mbinzlo               = mbinzlo,
+        .nbinx                 = nbinx,
+        .nbiny                 = nbiny,
+        .nbinz                 = nbinz,
+        .mbinx                 = mbinx,
+        .mbiny                 = mbiny,
+        .mbinz                 = mbinz };
 
     if (c_resize_needed == NULL) {
         c_resize_needed = (int*)allocateGPU(sizeof(int));

--- a/src/verletlist/neighborCuda.cu
+++ b/src/verletlist/neighborCuda.cu
@@ -154,7 +154,7 @@ __global__ void compute_neighborhood(DeviceAtom a,
     MD_FLOAT ytmp = atom_y(i);
     MD_FLOAT ztmp = atom_z(i);
     int ibin      = coord2bin_device(xtmp, ytmp, ztmp, np);
-#ifdef EXPLICIT_TYPES
+#ifndef ONE_ATOM_TYPE
     int type_i = atom->type[i];
 #endif
     for (int k = 0; k < nstencil; k++) {
@@ -173,7 +173,7 @@ __global__ void compute_neighborhood(DeviceAtom a,
             MD_FLOAT delz = ztmp - atom_z(j);
             MD_FLOAT rsq  = delx * delx + dely * dely + delz * delz;
 
-#ifdef EXPLICIT_TYPES
+#ifndef ONE_ATOM_TYPE
             int type_j            = atom->type[j];
             const MD_FLOAT cutoff = atom->cutneighsq[type_i * ntypes + type_j];
 #else

--- a/src/verletlist/neighborCuda.cu
+++ b/src/verletlist/neighborCuda.cu
@@ -259,21 +259,23 @@ void buildNeighborCUDA(Atom* atom, Neighbor* neighbor)
             c_binning.mbins * c_binning.atoms_per_bin * sizeof(int));
     }
 
-    Neighbor_params np { .xprd = xprd,
-        .yprd                  = yprd,
-        .zprd                  = zprd,
-        .bininvx               = bininvx,
-        .bininvy               = bininvy,
-        .bininvz               = bininvz,
-        .mbinxlo               = mbinxlo,
-        .mbinylo               = mbinylo,
-        .mbinzlo               = mbinzlo,
-        .nbinx                 = nbinx,
-        .nbiny                 = nbiny,
-        .nbinz                 = nbinz,
-        .mbinx                 = mbinx,
-        .mbiny                 = mbiny,
-        .mbinz                 = mbinz };
+    Neighbor_params np {
+        .xprd    = xprd,
+        .yprd    = yprd,
+        .zprd    = zprd,
+        .bininvx = bininvx,
+        .bininvy = bininvy,
+        .bininvz = bininvz,
+        .mbinxlo = mbinxlo,
+        .mbinylo = mbinylo,
+        .mbinzlo = mbinzlo,
+        .nbinx   = nbinx,
+        .nbiny   = nbiny,
+        .nbinz   = nbinz,
+        .mbinx   = mbinx,
+        .mbiny   = mbiny,
+        .mbinz   = mbinz
+    };
 
     if (c_resize_needed == NULL) {
         c_resize_needed = (int*)allocateGPU(sizeof(int));

--- a/src/verletlist/stats.c
+++ b/src/verletlist/stats.c
@@ -32,7 +32,7 @@ void displayStatistics(Atom* atom, Parameter* param, Stats* stats, double* timer
     double avg_simd = stats->total_force_iters /
                       (double)(atom->Nlocal * (param->ntimes + 1));
 
-#ifdef EXPLICIT_TYPES
+#ifndef ONE_ATOM_TYPE
     force_useful_volume += 1e-9 *
                            (double)((atom->Nlocal * (param->ntimes + 1)) +
                                     stats->total_force_neighs) *

--- a/src/verletlist/tracing.c
+++ b/src/verletlist/tracing.c
@@ -25,7 +25,7 @@ void traceAddresses(Parameter* param, Atom* atom, Neighbor* neighbor, int timest
         MEM_TRACE(atom_z(i), 'R');
         INDEX_TRACE_ATOM(i);
 
-#ifdef EXPLICIT_TYPES
+#ifndef ONE_ATOM_TYPE
         MEM_TRACE(atom->type[i], 'R');
 #endif
 
@@ -39,7 +39,7 @@ void traceAddresses(Parameter* param, Atom* atom, Neighbor* neighbor, int timest
             MEM_TRACE(atom_y(j), 'R');
             MEM_TRACE(atom_z(j), 'R');
 
-#ifdef EXPLICIT_TYPES
+#ifndef ONE_ATOM_TYPE
             MEM_TRACE(atom->type[j], 'R');
 #endif
         }

--- a/src/verletlist/tracing.h
+++ b/src/verletlist/tracing.h
@@ -71,7 +71,7 @@
 #define INDEX_TRACE(l, e)                                                                \
     if (TRACER_CONDITION) {                                                              \
         for (int __i = 0; __i < (e); __i += VECTOR_WIDTH) {                              \
-            int __e = (((e) - __i) < VECTOR_WIDTH) ? ((e) - __i) : VECTOR_WIDTH;         \
+            int __e = (((e)-__i) < VECTOR_WIDTH) ? ((e)-__i) : VECTOR_WIDTH;             \
             fprintf(index_tracer_fp, "I: ");                                             \
             for (int __j = 0; __j < __e; ++__j) {                                        \
                 fprintf(index_tracer_fp, "%d ", l[__i + __j]);                           \
@@ -83,7 +83,7 @@
 #define DIST_TRACE_SORT(l, e)                                                            \
     if (TRACER_CONDITION) {                                                              \
         for (int __i = 0; __i < (e); __i += VECTOR_WIDTH) {                              \
-            int __e = (((e) - __i) < VECTOR_WIDTH) ? ((e) - __i) : VECTOR_WIDTH;         \
+            int __e = (((e)-__i) < VECTOR_WIDTH) ? ((e)-__i) : VECTOR_WIDTH;             \
             if (__e > 1) {                                                               \
                 for (int __j = __i; __j < __i + __e - 1; ++__j) {                        \
                     for (int __k = __i; __k < __i + __e - (__j - __i) - 1; ++__k) {      \
@@ -101,7 +101,7 @@
 #define DIST_TRACE(l, e)                                                                 \
     if (TRACER_CONDITION) {                                                              \
         for (int __i = 0; __i < (e); __i += VECTOR_WIDTH) {                              \
-            int __e = (((e) - __i) < VECTOR_WIDTH) ? ((e) - __i) : VECTOR_WIDTH;         \
+            int __e = (((e)-__i) < VECTOR_WIDTH) ? ((e)-__i) : VECTOR_WIDTH;             \
             if (__e > 1) {                                                               \
                 fprintf(index_tracer_fp, "D: ");                                         \
                 for (int __j = 0; __j < __e - 1; ++__j) {                                \


### PR DESCRIPTION
- Distance calculation when building the neighbor lists now uses SIMD intrinsics in the Cluster Pair case
- Support for multiple atom types added and EXPLICIT_TYPES option switched to ONE_ATOM_TYPE (inverse case), where default is false (use parameter lookup based on atom types)
- Fix AVX and AVX2 intrinsics (tested on Ivy Bridge and Broadwell)
- Fix and optimize CUDA kernels