### PR TITLE
[ADD] --suf [name] as parameter

### DIFF
--- a/src/clusterpair/atom.c
+++ b/src/clusterpair/atom.c
@@ -25,7 +25,7 @@ inline int get_ncj_from_nci(int nci)
 #endif
 }
 
-int write_atoms_to_file(Atom* atom)
+int write_atoms_to_file(Atom* atom, char* name)
 {
     // file system variable
     char *file_system = getenv("FASTTMP");
@@ -37,7 +37,7 @@ int write_atoms_to_file(Atom* atom)
     }
 
     char file_path[256]; 
-    snprintf(file_path, sizeof(file_path), "%s/tmp_atoms.txt", file_system);
+    snprintf(file_path, sizeof(file_path), "%s/%s", file_system, name);
 
     FILE *fp = fopen(file_path, "wb");
     if (fp == NULL) {
@@ -218,7 +218,7 @@ if(me == 0 && param->setup) {
             oz++;
         }
     }
-        write_atoms_to_file(atom);
+        write_atoms_to_file(atom, param->atom_file_name);
     }
 }
 

--- a/src/clusterpair/main.c
+++ b/src/clusterpair/main.c
@@ -254,6 +254,11 @@ int main(int argc, char** argv)
             continue;
         }
 
+        if ((strcmp(argv[i], "--suf") == 0)) {
+            param.atom_file_name = strdup(argv[++i]);
+            continue;
+        }
+
         if ((strcmp(argv[i], "-h") == 0) || (strcmp(argv[i], "--help") == 0)) {
             printf("MD Bench: A minimalistic re-implementation of miniMD\n");
             printf(HLINE);

--- a/src/common/grid.c
+++ b/src/common/grid.c
@@ -523,8 +523,6 @@ int read_atoms_from_file(Atom* atom, char* file){
                 atom_vy(i)=vy;
                 atom_vz(i)=vz;
                 atom->type[i]=type;
-		if(type >= 4)
-			printf("Type error.\n");
                 i++;
             }
     }

--- a/src/common/grid.c
+++ b/src/common/grid.c
@@ -469,7 +469,7 @@ void initGrid(Grid* grid, int nprocs)
     grid->Timer = 0.;
 }
 
-int read_atoms_from_file(Atom* atom){
+int read_atoms_from_file(Atom* atom, char* file){
     
     // file system variable
     char *file_system = getenv("FASTTMP");
@@ -481,7 +481,7 @@ int read_atoms_from_file(Atom* atom){
     }
 
     char file_path[256]; 
-    snprintf(file_path, sizeof(file_path), "%s/tmp_atoms.txt", file_system);
+    snprintf(file_path, sizeof(file_path), "%s/%s", file_system, file);
 
     FILE *fp = fopen(file_path, "r");
     if (fp == NULL) {
@@ -523,6 +523,8 @@ int read_atoms_from_file(Atom* atom){
                 atom_vy(i)=vy;
                 atom_vz(i)=vz;
                 atom->type[i]=type;
+		if(type >= 4)
+			printf("Type error.\n");
                 i++;
             }
     }
@@ -559,7 +561,7 @@ void setupGrid(Grid* grid, Atom* atom, Parameter* param)
     }
 
     MPI_Barrier(world);
-    read_atoms_from_file(atom);
+    read_atoms_from_file(atom, param->atom_file_name);
 
 
      //printGrid(grid);

--- a/src/common/parameter.c
+++ b/src/common/parameter.c
@@ -20,6 +20,7 @@ void initParameter(Parameter* param)
     param->xtc_file        = NULL;
     param->eam_file        = NULL;
     param->write_atom_file = NULL;
+    param->atom_file_name  = strdup("atoms_tmp.txt");
     param->force_field     = FF_LJ;
     param->epsilon         = 1.0;
     param->sigma           = 1.0;
@@ -91,6 +92,7 @@ void readParameter(Parameter* param, const char* filename)
         if (tok != NULL && val != NULL) {
             PARSE_PARAM(force_field, str2ff);
             PARSE_STRING(input_file);
+            PARSE_STRING(atom_file_name);
             PARSE_STRING(eam_file);
             PARSE_STRING(vtk_file);
             PARSE_STRING(xtc_file);

--- a/src/common/parameter.h
+++ b/src/common/parameter.h
@@ -35,6 +35,7 @@ typedef struct {
     char* vtk_file;
     char* xtc_file;
     char* write_atom_file;
+    char* atom_file_name;
     MD_FLOAT epsilon;
     MD_FLOAT sigma;
     MD_FLOAT sigma6;

--- a/src/verletlist/atom.c
+++ b/src/verletlist/atom.c
@@ -24,7 +24,7 @@
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 #endif
 
-int write_atoms_to_file(Atom* atom)
+int write_atoms_to_file(Atom* atom, char* name)
 {
     // file system variable
     char *file_system = getenv("FASTTMP");
@@ -36,7 +36,7 @@ int write_atoms_to_file(Atom* atom)
     }
 
     char file_path[256]; 
-    snprintf(file_path, sizeof(file_path), "%s/tmp_atoms.txt", file_system);
+    snprintf(file_path, sizeof(file_path), "%s/%s", file_system, name);
 
     FILE *fp = fopen(file_path, "wb");
     if (fp == NULL) {
@@ -222,7 +222,7 @@ if(me == 0 && param->setup) {
             oz++;
         }
     }
-        write_atoms_to_file(atom);
+        write_atoms_to_file(atom, param->atom_file_name);
     }
 }
 

--- a/src/verletlist/main.c
+++ b/src/verletlist/main.c
@@ -262,6 +262,12 @@ int main(int argc, char** argv)
             param.setup = atoi(argv[++i]);
             continue;
         }
+
+        if ((strcmp(argv[i], "--suf") == 0)) {
+            param.atom_file_name = strdup(argv[++i]);
+            continue;
+        }
+
         if ((strcmp(argv[i], "-h") == 0) || (strcmp(argv[i], "--help") == 0)) {
             if (comm.myproc == 0) {
                 printf("MD Bench: A performance-oriented prototyping harness for MD "


### PR DESCRIPTION
--suf [file_name] can be used to specify the name of the atomfile that will be stored on $FASTTMP. This allows for running multiple versions with different sizes independently and easier store atom files.