### PR TITLE
Bugfix for typo in intrisic, which broke compiling with intel icx

### DIFF
--- a/src/common/simd/avx_double.h
+++ b/src/common/simd/avx_double.h
@@ -91,7 +91,7 @@ static inline MD_FLOAT simd_real_h_dual_incr_reduced_sum(
     t0 = _mm256_add_pd(v0, _mm256_permute_pd(v0, 0x5));
     t1 = _mm256_add_pd(v1, _mm256_permute_pd(v1, 0x5));
     t2 = _mm256_add_pd(t0, t1);
-    t0 = _mm256_add_pd(t1, _mm256_permute_pd(t1, 0x55));
+    t0 = _mm256_add_pd(t1, _mm256_permute_pd(t1, 0x5));
 
     acc = _mm256_load_pd(m);
     acc = _mm256_add_pd(acc, t2);


### PR DESCRIPTION
When compiling MD-Bench with ICX, it did not compile, The GCC seems to cast
the parameter for the intrinsic internally and accepts value sizes greater than 8bit.

Error with ICX:
MD-Bench/src/common/simd/avx_double.h:94:28: error: argument value 85 is outside 
the valid range [0, 15] [-Wargument-outside-range]
   94 |     t0 = _mm256_add_pd(t1, _mm256_permute_pd(t1, 0x55));
        |                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~

Fix:
0x55 was a typo and is changed to 0x5.