### PR TITLE
Port Kernels to AMD GPUs and include double cutoff/skin strategy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,8 @@ test: $(TEST_BIN) $(TARGET)
 	@bash tests/test_data_layout.sh
 	@echo "===>  RUNNING  test_mpi"
 	@bash tests/test_mpi.sh
+	@echo "===>  RUNNING  test_double_cutoff"
+	@bash tests/test_double_cutoff.sh ./$(TARGET)
 
 TEST_COMMON_SRCS := $(COMMON_DIR)/parameter.c $(COMMON_DIR)/box.c $(COMMON_DIR)/thermo.c $(COMMON_DIR)/allocate.c $(COMMON_DIR)/util.c
 TEST_CP_SRCS     := $(SRC_ROOT)/clusterpair/atom.c $(SRC_ROOT)/clusterpair/neighbor.c $(SRC_ROOT)/clusterpair/pbc.c $(SRC_ROOT)/clusterpair/integrate.c

--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,8 @@ test: $(TEST_BIN) $(TARGET)
 	@bash tests/sim_copper_fcc_regression.sh ./$(TARGET)
 	@echo "===>  RUNNING  regression_energy_lj on $(TARGET)"
 	@bash tests/regression_energy_lj.sh ./$(TARGET)
+	@echo "===>  RUNNING  test_double_cutoff on $(TARGET)"
+	@bash tests/test_double_cutoff.sh ./$(TARGET)
 	@echo "===>  RUNNING  regression_scheme_equiv (geometric)"
 	@bash tests/regression_scheme_equiv.sh
 	@echo "===>  RUNNING  regression_scheme_equiv (single)"
@@ -133,8 +135,6 @@ test: $(TEST_BIN) $(TARGET)
 	@bash tests/test_data_layout.sh
 	@echo "===>  RUNNING  test_mpi"
 	@bash tests/test_mpi.sh
-	@echo "===>  RUNNING  test_double_cutoff"
-	@bash tests/test_double_cutoff.sh ./$(TARGET)
 
 TEST_COMMON_SRCS := $(COMMON_DIR)/parameter.c $(COMMON_DIR)/box.c $(COMMON_DIR)/thermo.c $(COMMON_DIR)/allocate.c $(COMMON_DIR)/util.c
 TEST_CP_SRCS     := $(SRC_ROOT)/clusterpair/atom.c $(SRC_ROOT)/clusterpair/neighbor.c $(SRC_ROOT)/clusterpair/pbc.c $(SRC_ROOT)/clusterpair/integrate.c

--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,8 @@
-* Apply Lennard-Jones Geometric Combination Rule
-* Define frequency to sort atoms (independent neighboring frequency)
+* Evaluate LJ mixing rules on GPUs and other cases
+* Evaluate CP for AMD GPUs
 * Use a single capacity for the neighbor-lists and evaluate CPU vs GPU performance
 * Evaluate Lennard-Jones (and Coloumb) force components to be integrated into short-range kernels
 * Double cut-off method with pruning (inner, outer)
-* Implement compression of atoms that need to be computed, only execute
-arithmetic when register is full
+* Implement compression of atoms that need to be computed, only execute arithmetic when register is full
 * Implement LJ case from https://ieeexplore.ieee.org/document/11370954 for ARM and x86
 * Implement stubbed case and gather benchmark for GPUs

--- a/config.mk
+++ b/config.mk
@@ -1,5 +1,5 @@
 # Compiler tool chain (GCC/CLANG/ICC/ICX/ONEAPI/NVCC/HIPCC)
-TOOLCHAIN ?= ICX
+TOOLCHAIN ?= GCC
 # ISA of instruction code (X86/ARM)
 ISA ?= X86
 # Instruction set for instrinsic kernels (NONE/<X86-SIMD>/<ARM-SIMD>)
@@ -15,7 +15,7 @@ ENABLE_OPENMP ?= true
 # Enable MPI parallelization
 ENABLE_MPI ?= false
 # SP or DP
-DATA_TYPE ?= DP
+DATA_TYPE ?= SP
 # AOS or SOA
 ATOM_DATA_LAYOUT ?= AOS
 # Neighbor-lists data layout (auto/AOS/SOA)
@@ -52,7 +52,7 @@ USE_SCALAR_KERNEL ?= false
 # Use reference version (for correction and metrics purposes)
 USE_REFERENCE_KERNEL ?= false
 # Use SIMD intrinsic kernels for force computation (true or false)
-USE_SIMD_KERNEL ?= true
+USE_SIMD_KERNEL ?= false
 # Enable XTC output (a GROMACS file format for trajectories)
 XTC_OUTPUT ?= false
 

--- a/make/include_HIPCC.mk
+++ b/make/include_HIPCC.mk
@@ -24,14 +24,14 @@ ANSI_CFLAGS += -std=c99
 ANSI_CFLAGS += -pedantic
 ANSI_CFLAGS += -Wextra
 
-#
-# Mi2XXX + Native
-#CFLAGS   = -O3 --offload-arch=gfx90a -march=native -ffast-math -funroll-loops # -fopenmp
-# Mi300A + Native
-CFLAGS   = -O3 -march=native -ffast-math -funroll-loops # -fopenmp
-#
+# Target GPU architecture (override on command line, e.g.: make GPU_ARCH=gfx90a)
+# gfx90a = MI250X, gfx940 = MI300A (APU), gfx942 = MI300X
+GPU_ARCH ?= gfx942
+
+CFLAGS   = -O3 --offload-arch=$(GPU_ARCH) -march=native -ffast-math -funroll-loops # -fopenmp
+
 ASFLAGS  =  -masm=intel
 LFLAGS   =
-DEFINES  += -D_GNU_SOURCE -DCUDA_TARGET=1 -DNO_ZMM_INTRIN #-DLIKWID_PERFMON
 INCLUDES = $(LIKWID_INC) $(MPI_HOME) -I/opt/rocm/include
-LIBS     = -lm $(LIKWID_LIB) $(MPI_LIB) -lamdhip64 #-llikwid
+DEFINES  += -D_GNU_SOURCE -DCUDA_TARGET=1 -DNO_ZMM_INTRIN #-DLIKWID_PERFMON
+LIBS     = -lm $(LIKWID_LIB) $(MPI_LIB) -lamdhip64 -lroctx64 #-llikwid

--- a/make/include_HIPCC.mk
+++ b/make/include_HIPCC.mk
@@ -24,9 +24,12 @@ ANSI_CFLAGS += -std=c99
 ANSI_CFLAGS += -pedantic
 ANSI_CFLAGS += -Wextra
 
-# Target GPU architecture (override on command line, e.g.: make GPU_ARCH=gfx90a)
-# gfx90a = MI250X, gfx940 = MI300A (APU), gfx942 = MI300X
-GPU_ARCH ?= gfx942
+# Target GPU architecture must be provided explicitly on the command line or in the
+# environment, e.g.: make GPU_ARCH=gfx90a
+# Common values: gfx90a = MI250X, gfx940 = MI300A (APU), gfx942 = MI300X
+ifeq ($(strip $(GPU_ARCH)),)
+$(error GPU_ARCH is not set. Please specify a supported AMD GPU target, e.g. 'make GPU_ARCH=gfx90a')
+endif
 
 CFLAGS   = -O3 --offload-arch=$(GPU_ARCH) -march=native -ffast-math -funroll-loops # -fopenmp
 

--- a/src/clusterpair/atom.c
+++ b/src/clusterpair/atom.c
@@ -966,9 +966,9 @@ void growPbc(Atom* atom)
             atom->NmaxGhost * sizeof(int),
             nold * sizeof(int));
     } else {
-        atom->PBCx = (int*)malloc(atom->NmaxGhost * sizeof(int));
-        atom->PBCy = (int*)malloc(atom->NmaxGhost * sizeof(int));
-        atom->PBCz = (int*)malloc(atom->NmaxGhost * sizeof(int));
+        atom->PBCx = (int*)allocate(ALIGNMENT, atom->NmaxGhost * sizeof(int));
+        atom->PBCy = (int*)allocate(ALIGNMENT, atom->NmaxGhost * sizeof(int));
+        atom->PBCz = (int*)allocate(ALIGNMENT, atom->NmaxGhost * sizeof(int));
     }
 }
 

--- a/src/clusterpair/force_lj.c
+++ b/src/clusterpair/force_lj.c
@@ -66,7 +66,7 @@ double computeForceLJRef(Parameter* param, Atom* atom, Neighbor* neighbor, Stats
             int ci_vec_base = CI_VECTOR3_BASE_INDEX(ci);
             MD_FLOAT* ci_x  = &atom->cl_x[ci_vec_base];
             MD_FLOAT* ci_f  = &atom->cl_f[ci_vec_base];
-            int numneighs   = neighbor->numneigh[ci];
+            int numneighs   = neighbor->numneigh_inner[ci];
 
 #if LJ_COMB_RULE == LJ_COMB_GEOM
             int ci_sca_base       = CI_SCALAR_BASE_INDEX(ci);
@@ -242,8 +242,11 @@ double computeForceLJ2xnnHalfNeigh(
             int ci_vec_base      = CI_VECTOR3_BASE_INDEX(ci);
             MD_FLOAT* ci_x       = &atom->cl_x[ci_vec_base];
             MD_FLOAT* ci_f       = &atom->cl_f[ci_vec_base];
-            int numneighs        = neighbor->numneigh[ci];
-            int numneighs_masked = neighbor->numneigh_masked[ci];
+            int numneighs              = neighbor->numneigh_inner[ci];
+            int numneighs_masked       = neighbor->numneigh_masked[ci];
+            int numneighs_inner_masked = neighbor->numneigh_inner_masked[ci];
+            int unmasked_inner_end     = numneighs_masked +
+                                         (numneighs - numneighs_inner_masked);
 
             MD_SIMD_FLOAT xi0_tmp = simd_real_load_h_dual(&ci_x[CL_X_INDEX_3D(0)]);
             MD_SIMD_FLOAT xi2_tmp = simd_real_load_h_dual(&ci_x[CL_X_INDEX_3D(2)]);
@@ -275,7 +278,7 @@ double computeForceLJ2xnnHalfNeigh(
             MD_SIMD_INT tbase2 = simd_i32_load_h_dual_scaled(&ci_t[2], atom->ntypes);
 #endif
 
-            for (int k = 0; k < numneighs_masked; k++) {
+            for (int k = 0; k < numneighs_inner_masked; k++) {
                 const int cj    = neighs(neighbor->neighbors, ci, k, nbM, nbN);
                 int cj_vec_base = CJ_VECTOR3_BASE_INDEX(cj);
                 // int imask = neighs_imask[k];
@@ -426,7 +429,7 @@ double computeForceLJ2xnnHalfNeigh(
                 }
             }
 
-            for (int k = numneighs_masked; k < numneighs; k++) {
+            for (int k = numneighs_masked; k < unmasked_inner_end; k++) {
                 const int cj    = neighs(neighbor->neighbors, ci, k, nbM, nbN);
                 int cj_vec_base = CJ_VECTOR3_BASE_INDEX(cj);
                 MD_FLOAT* cj_x  = &atom->cl_x[cj_vec_base];
@@ -614,8 +617,11 @@ double computeForceLJ2xnnFullNeigh(
             int ci_vec_base            = CI_VECTOR3_BASE_INDEX(ci);
             MD_FLOAT* ci_x             = &atom->cl_x[ci_vec_base];
             MD_FLOAT* ci_f             = &atom->cl_f[ci_vec_base];
-            const int numneighs        = neighbor->numneigh[ci];
-            const int numneighs_masked = neighbor->numneigh_masked[ci];
+            const int numneighs              = neighbor->numneigh_inner[ci];
+            const int numneighs_masked       = neighbor->numneigh_masked[ci];
+            const int numneighs_inner_masked = neighbor->numneigh_inner_masked[ci];
+            const int unmasked_inner_end     = numneighs_masked +
+                                               (numneighs - numneighs_inner_masked);
 
             MD_SIMD_FLOAT xi0_tmp = simd_real_load_h_dual(&ci_x[CL_X_INDEX_3D(0)]);
             MD_SIMD_FLOAT xi2_tmp = simd_real_load_h_dual(&ci_x[CL_X_INDEX_3D(2)]);
@@ -646,7 +652,7 @@ double computeForceLJ2xnnFullNeigh(
             MD_SIMD_INT tbase2 = simd_i32_load_h_dual_scaled(&ci_t[2], atom->ntypes);
 #endif
 
-            for (int k = 0; k < numneighs_masked; k++) {
+            for (int k = 0; k < numneighs_inner_masked; k++) {
                 const int cj    = neighs(neighbor->neighbors, ci, k, nbM, nbN);
                 int cj_vec_base = CJ_VECTOR3_BASE_INDEX(cj);
                 MD_FLOAT* cj_x  = &atom->cl_x[cj_vec_base];
@@ -783,7 +789,7 @@ double computeForceLJ2xnnFullNeigh(
                     cutoff_mask2);
             }
 
-            for (int k = numneighs_masked; k < numneighs; k++) {
+            for (int k = numneighs_masked; k < unmasked_inner_end; k++) {
                 const int cj    = neighs(neighbor->neighbors, ci, k, nbM, nbN);
                 int cj_vec_base = CJ_VECTOR3_BASE_INDEX(cj);
                 MD_FLOAT* cj_x  = &atom->cl_x[cj_vec_base];
@@ -971,8 +977,11 @@ double computeForceLJ4xnHalfNeigh(
             int ci_vec_base      = CI_VECTOR3_BASE_INDEX(ci);
             MD_FLOAT* ci_x       = &atom->cl_x[ci_vec_base];
             MD_FLOAT* ci_f       = &atom->cl_f[ci_vec_base];
-            int numneighs        = neighbor->numneigh[ci];
-            int numneighs_masked = neighbor->numneigh_masked[ci];
+            int numneighs              = neighbor->numneigh_inner[ci];
+            int numneighs_masked       = neighbor->numneigh_masked[ci];
+            int numneighs_inner_masked = neighbor->numneigh_inner_masked[ci];
+            int unmasked_inner_end     = numneighs_masked +
+                                         (numneighs - numneighs_inner_masked);
 
             MD_SIMD_FLOAT xi0_tmp = simd_real_broadcast(ci_x[CL_X_INDEX_3D(0)]);
             MD_SIMD_FLOAT xi1_tmp = simd_real_broadcast(ci_x[CL_X_INDEX_3D(1)]);
@@ -1026,7 +1035,7 @@ double computeForceLJ4xnHalfNeigh(
             MD_SIMD_INT tbase3 = simd_i32_broadcast(ci_t[3] * atom->ntypes);
 #endif
 
-            for (int k = 0; k < numneighs_masked; k++) {
+            for (int k = 0; k < numneighs_inner_masked; k++) {
                 const int cj    = neighs(neighbor->neighbors, ci, k, nbM, nbN);
                 int cj_vec_base = CJ_VECTOR3_BASE_INDEX(cj);
                 MD_FLOAT* cj_x  = &atom->cl_x[cj_vec_base];
@@ -1269,7 +1278,7 @@ double computeForceLJ4xnHalfNeigh(
                 }
             }
 
-            for (int k = numneighs_masked; k < numneighs; k++) {
+            for (int k = numneighs_masked; k < unmasked_inner_end; k++) {
                 const int cj    = neighs(neighbor->neighbors, ci, k, nbM, nbN);
                 int cj_vec_base = CJ_VECTOR3_BASE_INDEX(cj);
                 MD_FLOAT* cj_x  = &atom->cl_x[cj_vec_base];
@@ -1543,8 +1552,11 @@ double computeForceLJ4xnFullNeigh(
             int ci_vec_base      = CI_VECTOR3_BASE_INDEX(ci);
             MD_FLOAT* ci_x       = &atom->cl_x[ci_vec_base];
             MD_FLOAT* ci_f       = &atom->cl_f[ci_vec_base];
-            int numneighs        = neighbor->numneigh[ci];
-            int numneighs_masked = neighbor->numneigh_masked[ci];
+            int numneighs              = neighbor->numneigh_inner[ci];
+            int numneighs_masked       = neighbor->numneigh_masked[ci];
+            int numneighs_inner_masked = neighbor->numneigh_inner_masked[ci];
+            int unmasked_inner_end     = numneighs_masked +
+                                         (numneighs - numneighs_inner_masked);
 
             MD_SIMD_FLOAT xi0_tmp = simd_real_broadcast(ci_x[CL_X_INDEX_3D(0)]);
             MD_SIMD_FLOAT xi1_tmp = simd_real_broadcast(ci_x[CL_X_INDEX_3D(1)]);
@@ -1598,7 +1610,7 @@ double computeForceLJ4xnFullNeigh(
             MD_SIMD_INT tbase3 = simd_i32_broadcast(ci_t[3] * atom->ntypes);
 #endif
 
-            for (int k = 0; k < numneighs_masked; k++) {
+            for (int k = 0; k < numneighs_inner_masked; k++) {
                 const int cj    = neighs(neighbor->neighbors, ci, k, nbM, nbN);
                 int cj_vec_base = CJ_VECTOR3_BASE_INDEX(cj);
                 MD_FLOAT* cj_x  = &atom->cl_x[cj_vec_base];
@@ -1826,7 +1838,7 @@ double computeForceLJ4xnFullNeigh(
                     cutoff_mask3);
             }
 
-            for (int k = numneighs_masked; k < numneighs; k++) {
+            for (int k = numneighs_masked; k < unmasked_inner_end; k++) {
                 const int cj    = neighs(neighbor->neighbors, ci, k, nbM, nbN);
                 int cj_vec_base = CJ_VECTOR3_BASE_INDEX(cj);
                 MD_FLOAT* cj_x  = &atom->cl_x[cj_vec_base];

--- a/src/clusterpair/force_lj_cuda.cu
+++ b/src/clusterpair/force_lj_cuda.cu
@@ -626,6 +626,103 @@ extern "C" void updatePbcCUDA(Atom* atom, Parameter* param)
     cuda_assert("cudaUpdatePbc", cudaDeviceSynchronize());
 }
 
+__global__ void cudaPruneNeighbor(MD_FLOAT* cuda_cl_x,
+    int* cuda_numneigh,
+    int* cuda_numneigh_inner,
+    int* cuda_neighbors,
+    int Nclusters_local,
+    int maxneighs,
+    MD_FLOAT cutsq)
+{
+    unsigned int ci = blockDim.x * blockIdx.x + threadIdx.x;
+    if (ci >= Nclusters_local) {
+        return;
+    }
+
+    const int numneighs = cuda_numneigh[ci];
+    MD_FLOAT* ci_x      = &cuda_cl_x[CI_VECTOR_BASE_INDEX(ci)];
+    int lo              = 0;
+
+    for (int hi = 0; hi < numneighs; hi++) {
+        int cj         = neighs(cuda_neighbors, ci, hi, Nclusters_local, maxneighs);
+        MD_FLOAT* cj_x = &cuda_cl_x[CJ_VECTOR_BASE_INDEX(cj)];
+        int is_inner   = 0;
+
+        for (int cii = 0; cii < CLUSTER_M && !is_inner; cii++) {
+            MD_FLOAT xtmp = ci_x[CL_X_INDEX(cii)];
+            MD_FLOAT ytmp = ci_x[CL_Y_INDEX(cii)];
+            MD_FLOAT ztmp = ci_x[CL_Z_INDEX(cii)];
+            for (int cjj = 0; cjj < CLUSTER_N; cjj++) {
+                MD_FLOAT delx = xtmp - cj_x[CL_X_INDEX(cjj)];
+                MD_FLOAT dely = ytmp - cj_x[CL_Y_INDEX(cjj)];
+                MD_FLOAT delz = ztmp - cj_x[CL_Z_INDEX(cjj)];
+                if (delx * delx + dely * dely + delz * delz < cutsq) {
+                    is_inner = 1;
+                    break;
+                }
+            }
+        }
+
+        if (is_inner) {
+            if (hi != lo) {
+                int t_cj = neighs(cuda_neighbors, ci, lo, Nclusters_local, maxneighs);
+                neighs(cuda_neighbors,
+                    ci,
+                    lo,
+                    Nclusters_local,
+                    maxneighs) = cj;
+                neighs(cuda_neighbors,
+                    ci,
+                    hi,
+                    Nclusters_local,
+                    maxneighs) = t_cj;
+            }
+            lo++;
+        }
+    }
+
+    cuda_numneigh_inner[ci] = lo;
+}
+
+extern "C" void pruneNeighborCUDASup(Parameter*, Atom*, Neighbor*);
+
+extern "C" void pruneNeighborCUDA(Parameter* param, Atom* atom, Neighbor* neighbor)
+{
+    DEBUG_MESSAGE("pruneNeighborCUDA start\n");
+
+    if (param->super_clustering) {
+        pruneNeighborCUDASup(param, atom, neighbor);
+        return;
+    }
+
+    if (param->outer_skin <= 0.0) {
+        // Defensive: caller already guards on this, but mirror outer counts in case it does not.
+        memcpyOnGPU(cuda_numneigh_inner,
+            cuda_numneigh,
+            atom->Nclusters_local * sizeof(int));
+        return;
+    }
+
+    const MD_FLOAT cut_inner = param->cutforce + param->skin;
+    const MD_FLOAT cutsq     = cut_inner * cut_inner;
+    const int threads_num    = 64;
+    const int N              = atom->Nclusters_local;
+    dim3 block_size          = dim3(threads_num, 1, 1);
+    dim3 grid_size           = dim3((N + threads_num - 1) / threads_num, 1, 1);
+
+    cudaPruneNeighbor<<<grid_size, block_size>>>(cuda_cl_x,
+        cuda_numneigh,
+        cuda_numneigh_inner,
+        cuda_neighbors,
+        atom->Nclusters_local,
+        neighbor->maxneighs,
+        cutsq);
+
+    cuda_assert("cudaPruneNeighbor", cudaPeekAtLastError());
+    cuda_assert("cudaPruneNeighbor", cudaDeviceSynchronize());
+    DEBUG_MESSAGE("pruneNeighborCUDA end\n");
+}
+
 extern "C" double computeForceLJCuda(
     Parameter* param, Atom* atom, Neighbor* neighbor, Stats* stats)
 {

--- a/src/clusterpair/force_lj_cuda.cu
+++ b/src/clusterpair/force_lj_cuda.cu
@@ -10,9 +10,6 @@
 extern "C" {
 #include <stdio.h>
 //---
-#include <cuda.h>
-#include <driver_types.h>
-//---
 #include <likwid-marker.h>
 //---
 #include <allocate.h>

--- a/src/clusterpair/force_lj_cuda.cu
+++ b/src/clusterpair/force_lj_cuda.cu
@@ -56,6 +56,7 @@ MD_FLOAT* cuda_cl_v;
 MD_FLOAT* cuda_cl_f;
 int* cuda_neighbors;
 int* cuda_numneigh;
+int* cuda_numneigh_inner;
 int* cuda_natoms;
 int* natoms;
 int* ngatoms;
@@ -108,8 +109,9 @@ extern "C" void initDevice(Parameter* param, Atom* atom, Neighbor* neighbor)
     cuda_PBCx      = (int*)allocateGPU(atom->Nclusters_max * SCLUSTER_SIZE * sizeof(int));
     cuda_PBCy      = (int*)allocateGPU(atom->Nclusters_max * SCLUSTER_SIZE * sizeof(int));
     cuda_PBCz      = (int*)allocateGPU(atom->Nclusters_max * SCLUSTER_SIZE * sizeof(int));
-    cuda_numneigh  = (int*)allocateGPU(atom->Nclusters_max * sizeof(int));
-    cuda_neighbors = (int*)allocateGPU(
+    cuda_numneigh       = (int*)allocateGPU(atom->Nclusters_max * sizeof(int));
+    cuda_numneigh_inner = (int*)allocateGPU(atom->Nclusters_max * sizeof(int));
+    cuda_neighbors      = (int*)allocateGPU(
         atom->Nclusters_max * neighbor->maxneighs * sizeof(int));
     natoms  = (int*)malloc(atom->Nclusters_max * SCLUSTER_SIZE * sizeof(int));
     ngatoms = (int*)malloc(atom->Nclusters_max * SCLUSTER_SIZE * sizeof(int));
@@ -155,6 +157,9 @@ extern "C" void copyDataToCUDADevice(Parameter* param, Atom* atom, Neighbor* nei
 #endif
 
     memcpyToGPU(cuda_numneigh, neighbor->numneigh, atom->Nclusters_local * sizeof(int));
+    memcpyToGPU(cuda_numneigh_inner,
+        neighbor->numneigh_inner,
+        atom->Nclusters_local * sizeof(int));
     memcpyToGPU(cuda_neighbors,
         neighbor->neighbors,
         atom->Nclusters_local * neighbor->maxneighs * sizeof(int));
@@ -180,6 +185,7 @@ extern "C" void cudaDeviceFree(Parameter* param)
     cuda_assert("cudaDeviceFree", cudaFree(cuda_cl_t));
 #endif
     cuda_assert("cudaDeviceFree", cudaFree(cuda_numneigh));
+    cuda_assert("cudaDeviceFree", cudaFree(cuda_numneigh_inner));
     cuda_assert("cudaDeviceFree", cudaFree(cuda_neighbors));
     cuda_assert("cudaDeviceFree", cudaFree(cuda_natoms));
     cuda_assert("cudaDeviceFree", cudaFree(cuda_border_map));
@@ -658,7 +664,7 @@ extern "C" double computeForceLJCuda(
             cuda_cl_f,
             atom->Nclusters_local,
             atom->Nclusters_max,
-            cuda_numneigh,
+            cuda_numneigh_inner,
             cuda_neighbors,
             neighbor->maxneighs);
     } else {
@@ -678,7 +684,7 @@ extern "C" double computeForceLJCuda(
             cuda_cl_f,
             atom->Nclusters_local,
             atom->Nclusters_max,
-            cuda_numneigh,
+            cuda_numneigh_inner,
             cuda_neighbors,
             neighbor->maxneighs);
     }
@@ -736,6 +742,8 @@ extern "C" void growClustersCUDA(Atom* atom)
         cuda_jclusters_natoms = (int*)reallocateGPU(cuda_jclusters_natoms,
             atom->Nclusters_max * sizeof(int));
         cuda_numneigh         = (int*)reallocateGPU(cuda_numneigh,
+            atom->Nclusters_max * sizeof(int));
+        cuda_numneigh_inner   = (int*)reallocateGPU(cuda_numneigh_inner,
             atom->Nclusters_max * sizeof(int));
 
         free(natoms);

--- a/src/clusterpair/force_lj_cuda.cu
+++ b/src/clusterpair/force_lj_cuda.cu
@@ -178,21 +178,21 @@ extern "C" void copyDataFromCUDADevice(Parameter* param, Atom* atom)
 
 extern "C" void cudaDeviceFree(Parameter* param)
 {
-    cuda_assert("cudaDeviceFree", cudaFree(cuda_cl_x));
-    cuda_assert("cudaDeviceFree", cudaFree(cuda_cl_v));
-    cuda_assert("cudaDeviceFree", cudaFree(cuda_cl_f));
+    GPUfree(cuda_cl_x);
+    GPUfree(cuda_cl_v);
+    GPUfree(cuda_cl_f);
 #if LJ_COMB_RULE != LJ_COMB_SINGLE
-    cuda_assert("cudaDeviceFree", cudaFree(cuda_cl_t));
+    GPUfree(cuda_cl_t);
 #endif
-    cuda_assert("cudaDeviceFree", cudaFree(cuda_numneigh));
-    cuda_assert("cudaDeviceFree", cudaFree(cuda_numneigh_inner));
-    cuda_assert("cudaDeviceFree", cudaFree(cuda_neighbors));
-    cuda_assert("cudaDeviceFree", cudaFree(cuda_natoms));
-    cuda_assert("cudaDeviceFree", cudaFree(cuda_border_map));
-    cuda_assert("cudaDeviceFree", cudaFree(cuda_jclusters_natoms));
-    cuda_assert("cudaDeviceFree", cudaFree(cuda_PBCx));
-    cuda_assert("cudaDeviceFree", cudaFree(cuda_PBCy));
-    cuda_assert("cudaDeviceFree", cudaFree(cuda_PBCz));
+    GPUfree(cuda_numneigh);
+    GPUfree(cuda_numneigh_inner);
+    GPUfree(cuda_neighbors);
+    GPUfree(cuda_natoms);
+    GPUfree(cuda_border_map);
+    GPUfree(cuda_jclusters_natoms);
+    GPUfree(cuda_PBCx);
+    GPUfree(cuda_PBCy);
+    GPUfree(cuda_PBCz);
 
     free(natoms);
     free(ngatoms);
@@ -948,9 +948,9 @@ be in the device comm->atom_recv[ineigh],            //int comm->firstrecv[iswap
 offset,    //int &buf[offset * size]);               //MD_FLOAT* --> need to be in the
 devic
     }
-    cuda_assert("cudaDeviceFree", cudaFree(cuda_sendlist));
-    cuda_assert("cudaDeviceFree", cudaFree(cuda_buf_recv));
-    cuda_assert("cudaDeviceFree", cudaFree(cuda_buf_send));
+    GPUfree(cuda_sendlist);
+    GPUfree(cuda_buf_recv);
+    GPUfree(cuda_buf_send);
 }
 
 __global__ void packForwardCuda(MD_FLOAT* cuda_cl_x, int* cuda_jclusters_natoms, int nc,

--- a/src/clusterpair/force_lj_cuda.cu
+++ b/src/clusterpair/force_lj_cuda.cu
@@ -7,6 +7,12 @@
 
 #include <device.h>
 
+#ifdef __HIP_PLATFORM_AMD__
+#define FULL_WARP_MASK 0xffffffffffffffffULL
+#else
+#define FULL_WARP_MASK 0xffffffffU
+#endif
+
 extern "C" {
 #include <stdio.h>
 //---
@@ -275,7 +281,7 @@ __global__ void computeForceLJCudaFullNeigh(
     // It is very unlikely that M > 32, but we keep this check here to
     // avoid any issues in such situations
 #if CLUSTER_M <= 32
-    unsigned mask = 0xffffffff;
+    auto mask = FULL_WARP_MASK;
 #ifdef SUPERCLUSTER_INVERSE_THREAD_MAPPING
     for (int offset = CLUSTER_M / 2; offset > 0; offset /= 2) {
 #ifdef CUDA_TARGET
@@ -422,7 +428,7 @@ __global__ void computeForceLJCudaHalfNeigh(
     atomicAdd(&ci_f[CL_Y_INDEX_3D(cii)], fiy);
     atomicAdd(&ci_f[CL_Z_INDEX_3D(cii)], fiz);
 #else
-    unsigned mask = 0xffffffff;
+    auto mask = FULL_WARP_MASK;
     fix += __shfl_down_sync(mask, fix, CLUSTER_M);
     fiy += __shfl_up_sync(mask, fiy, CLUSTER_M);
     fiz += __shfl_down_sync(mask, fiz, CLUSTER_M);

--- a/src/clusterpair/force_lj_cuda_sup.cu
+++ b/src/clusterpair/force_lj_cuda_sup.cu
@@ -1,3 +1,9 @@
+#ifdef __HIP_PLATFORM_AMD__
+#define FULL_WARP_MASK 0xffffffffffffffffULL
+#else
+#define FULL_WARP_MASK 0xffffffffU
+#endif
+
 extern "C" {
 
 #include <stdio.h>
@@ -238,7 +244,7 @@ __global__ void computeForceLJCudaSup_halfwarp(MD_FLOAT* cuda_cl_x,
 
 #ifndef SUPERCLUSTER_INVERSE_THREAD_MAPPING
         int aj        = cj * CLUSTER_N + cjj;
-        unsigned mask = 0xffffffff;
+        auto mask = FULL_WARP_MASK;
 
         fcj_buf.x += __shfl_down_sync(mask, fcj_buf.x, 1);
         fcj_buf.y += __shfl_up_sync(mask, fcj_buf.y, 1);
@@ -280,7 +286,7 @@ __global__ void computeForceLJCudaSup_halfwarp(MD_FLOAT* cuda_cl_x,
         MD_FLOAT fix  = fbuf[sci_ci].x;
         MD_FLOAT fiy  = fbuf[sci_ci].y;
         MD_FLOAT fiz  = fbuf[sci_ci].z;
-        unsigned mask = 0xffffffff;
+        auto mask = FULL_WARP_MASK;
         fix += __shfl_down_sync(mask, fix, CLUSTER_M);
         fiy += __shfl_up_sync(mask, fiy, CLUSTER_M);
         fiz += __shfl_down_sync(mask, fiz, CLUSTER_M);
@@ -418,7 +424,7 @@ __global__ void computeForceLJCudaSup_fullwarp(MD_FLOAT* cuda_cl_x,
         MD_FLOAT fix  = fbuf[sci_ci].x;
         MD_FLOAT fiy  = fbuf[sci_ci].y;
         MD_FLOAT fiz  = fbuf[sci_ci].z;
-        unsigned mask = 0xffffffff;
+        auto mask = FULL_WARP_MASK;
 
 #ifdef SUPERCLUSTER_INVERSE_THREAD_MAPPING
 

--- a/src/clusterpair/force_lj_cuda_sup.cu
+++ b/src/clusterpair/force_lj_cuda_sup.cu
@@ -2,9 +2,6 @@ extern "C" {
 
 #include <stdio.h>
 //---
-#include <cuda.h>
-#include <driver_types.h>
-//---
 #include <likwid-marker.h>
 //---
 #include <atom.h>

--- a/src/clusterpair/force_lj_cuda_sup.cu
+++ b/src/clusterpair/force_lj_cuda_sup.cu
@@ -26,6 +26,7 @@ extern MD_FLOAT* cuda_cl_v;
 extern MD_FLOAT* cuda_cl_f;
 extern int* cuda_neighbors;
 extern int* cuda_numneigh;
+extern int* cuda_numneigh_inner;
 extern int* cuda_natoms;
 extern int* natoms;
 extern int* ngatoms;
@@ -524,7 +525,7 @@ extern "C" double computeForceLJCudaSup(
         computeForceLJCudaSup_halfwarp<<<grid_size, block_size>>>(cuda_cl_x,
             cuda_cl_f,
             atom->Nclusters_local,
-            cuda_numneigh,
+            cuda_numneigh_inner,
             cuda_neighbors,
             neighbor->maxneighs,
 #if LJ_COMB_RULE == LJ_COMB_SINGLE
@@ -543,7 +544,7 @@ extern "C" double computeForceLJCudaSup(
         computeForceLJCudaSup_fullwarp<<<grid_size, block_size>>>(cuda_cl_x,
             cuda_cl_f,
             atom->Nclusters_local,
-            cuda_numneigh,
+            cuda_numneigh_inner,
             cuda_neighbors,
             neighbor->maxneighs,
 #if LJ_COMB_RULE == LJ_COMB_SINGLE

--- a/src/clusterpair/force_lj_cuda_sup.cu
+++ b/src/clusterpair/force_lj_cuda_sup.cu
@@ -569,3 +569,96 @@ extern "C" double computeForceLJCudaSup(
     DEBUG_MESSAGE("computeForceLJCudaSup stop\r\n");
     return E - S;
 }
+
+__global__ void cudaPruneNeighborSup(MD_FLOAT* cuda_cl_x,
+    int* cuda_numneigh,
+    int* cuda_numneigh_inner,
+    int* cuda_neighbors,
+    int Nclusters_local,
+    int maxneighs,
+    MD_FLOAT cutsq)
+{
+    unsigned int sci = blockDim.x * blockIdx.x + threadIdx.x;
+    if (sci >= Nclusters_local) {
+        return;
+    }
+
+    const int numneighs = cuda_numneigh[sci];
+    MD_FLOAT* sci_x     = &cuda_cl_x[SCI_VECTOR_BASE_INDEX(sci)];
+    int lo              = 0;
+
+    for (int hi = 0; hi < numneighs; hi++) {
+        int cj         = neighs(cuda_neighbors, sci, hi, Nclusters_local, maxneighs);
+        MD_FLOAT* cj_x = &cuda_cl_x[CJ_VECTOR_BASE_INDEX(cj)];
+        int is_inner   = 0;
+
+        for (int sci_ci = 0; sci_ci < SCLUSTER_SIZE && !is_inner; sci_ci++) {
+            for (int cii = 0; cii < CLUSTER_M && !is_inner; cii++) {
+                int ai        = sci_ci * CLUSTER_M + cii;
+                MD_FLOAT xtmp = sci_x[CL_X_INDEX(ai)];
+                MD_FLOAT ytmp = sci_x[CL_Y_INDEX(ai)];
+                MD_FLOAT ztmp = sci_x[CL_Z_INDEX(ai)];
+                for (int cjj = 0; cjj < CLUSTER_N; cjj++) {
+                    MD_FLOAT delx = xtmp - cj_x[CL_X_INDEX(cjj)];
+                    MD_FLOAT dely = ytmp - cj_x[CL_Y_INDEX(cjj)];
+                    MD_FLOAT delz = ztmp - cj_x[CL_Z_INDEX(cjj)];
+                    if (delx * delx + dely * dely + delz * delz < cutsq) {
+                        is_inner = 1;
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (is_inner) {
+            if (hi != lo) {
+                int t_cj = neighs(cuda_neighbors, sci, lo, Nclusters_local, maxneighs);
+                neighs(cuda_neighbors,
+                    sci,
+                    lo,
+                    Nclusters_local,
+                    maxneighs) = cj;
+                neighs(cuda_neighbors,
+                    sci,
+                    hi,
+                    Nclusters_local,
+                    maxneighs) = t_cj;
+            }
+            lo++;
+        }
+    }
+
+    cuda_numneigh_inner[sci] = lo;
+}
+
+extern "C" void pruneNeighborCUDASup(Parameter* param, Atom* atom, Neighbor* neighbor)
+{
+    DEBUG_MESSAGE("pruneNeighborCUDASup start\n");
+
+    if (param->outer_skin <= 0.0) {
+        // Defensive: caller already guards on this, but mirror outer counts in case it does not.
+        memcpyOnGPU(cuda_numneigh_inner,
+            cuda_numneigh,
+            atom->Nclusters_local * sizeof(int));
+        return;
+    }
+
+    const MD_FLOAT cut_inner = param->cutforce + param->skin;
+    const MD_FLOAT cutsq     = cut_inner * cut_inner;
+    const int threads_num    = 64;
+    const int N              = atom->Nclusters_local;
+    dim3 block_size          = dim3(threads_num, 1, 1);
+    dim3 grid_size           = dim3((N + threads_num - 1) / threads_num, 1, 1);
+
+    cudaPruneNeighborSup<<<grid_size, block_size>>>(cuda_cl_x,
+        cuda_numneigh,
+        cuda_numneigh_inner,
+        cuda_neighbors,
+        atom->Nclusters_local,
+        neighbor->maxneighs,
+        cutsq);
+
+    cuda_assert("cudaPruneNeighborSup", cudaPeekAtLastError());
+    cuda_assert("cudaPruneNeighborSup", cudaDeviceSynchronize());
+    DEBUG_MESSAGE("pruneNeighborCUDASup end\n");
+}

--- a/src/clusterpair/main-stub.c
+++ b/src/clusterpair/main-stub.c
@@ -64,8 +64,10 @@ void createNeighbors(
     const int maxneighs       = nneighs * nreps;
     const int ncj             = get_ncj_from_nci(atom->Nclusters_local);
     const unsigned int imask  = NBNXN_INTERACTION_MASK_ALL;
-    neighbor->numneigh        = (int*)malloc(atom->Nclusters_max * sizeof(int));
-    neighbor->numneigh_masked = (int*)malloc(atom->Nclusters_max * sizeof(int));
+    neighbor->numneigh              = (int*)malloc(atom->Nclusters_max * sizeof(int));
+    neighbor->numneigh_masked       = (int*)malloc(atom->Nclusters_max * sizeof(int));
+    neighbor->numneigh_inner        = (int*)malloc(atom->Nclusters_max * sizeof(int));
+    neighbor->numneigh_inner_masked = (int*)malloc(atom->Nclusters_max * sizeof(int));
     neighbor->neighbors = (int*)malloc(atom->Nclusters_max * maxneighs * sizeof(int));
     neighbor->neighbors_imask = (unsigned int*)malloc(
         atom->Nclusters_max * maxneighs * sizeof(unsigned int));
@@ -120,8 +122,10 @@ void createNeighbors(
             }
         }
 
-        neighbor->numneigh[ci]        = nneighs * nreps;
-        neighbor->numneigh_masked[ci] = (masked == 1) ? (nneighs * nreps) : 0;
+        neighbor->numneigh[ci]              = nneighs * nreps;
+        neighbor->numneigh_masked[ci]       = (masked == 1) ? (nneighs * nreps) : 0;
+        neighbor->numneigh_inner[ci]        = nneighs * nreps;
+        neighbor->numneigh_inner_masked[ci] = (masked == 1) ? (nneighs * nreps) : 0;
     }
 }
 

--- a/src/clusterpair/main.c
+++ b/src/clusterpair/main.c
@@ -37,6 +37,7 @@
 extern void copyDataToCUDADevice(Parameter*, Atom*, Neighbor*);
 extern void copyDataFromCUDADevice(Parameter*, Atom*);
 extern void cudaDeviceFree(Parameter*);
+extern void pruneNeighborCUDA(Parameter*, Atom*, Neighbor*);
 
 #define HLINE                                                                            \
     "----------------------------------------------------------------------------\n"
@@ -223,8 +224,8 @@ int main(int argc, char** argv)
             param.skin = atof(argv[++i]);
             continue;
         }
-        if ((strcmp(argv[i], "--skin-inner") == 0)) {
-            param.skin_inner = atof(argv[++i]);
+        if ((strcmp(argv[i], "--outer-skin") == 0)) {
+            param.outer_skin = atof(argv[++i]);
             continue;
         }
         if ((strcmp(argv[i], "--prune-every") == 0)) {
@@ -233,10 +234,6 @@ int main(int argc, char** argv)
         }
         if ((strcmp(argv[i], "--reneigh-every") == 0)) {
             param.reneigh_every = atoi(argv[++i]);
-            continue;
-        }
-        if ((strcmp(argv[i], "--double-cutoff") == 0)) {
-            param.enable_double_cutoff = atoi(argv[++i]);
             continue;
         }
         if ((strcmp(argv[i], "--freq") == 0)) {
@@ -276,11 +273,10 @@ int main(int argc, char** argv)
             printf("-nx/-ny/-nz <int>:    set linear dimension of systembox in x/y/z "
                    "direction\n");
             printf("-r / --radius <real>: set cutoff radius\n");
-            printf("-s / --skin <real>:   set skin (outer Verlet buffer)\n");
-            printf("--skin-inner <real>:  inner skin (cutforce + skin_inner = inner cutoff)\n");
+            printf("-s / --skin <real>:   set skin (Verlet buffer for the force-evaluation list)\n");
+            printf("--outer-skin <real>:  additive outer skin (outer cutoff = cutforce + skin + outer_skin; >0 enables double-cutoff)\n");
             printf("--prune-every <int>:  pruning frequency (steps between inner-list refresh)\n");
             printf("--reneigh-every <int>: neighbor-list rebuild frequency (steps)\n");
-            printf("--double-cutoff <0|1>: enable (1, default) or disable (0) double-cutoff scheme\n");
             printf("--freq <real>:        processor frequency (GHz)\n");
             printf("--vtk <string>:       VTK file for visualization\n");
             printf("--xtc <string>:       XTC file for visualization\n");
@@ -297,7 +293,8 @@ int main(int argc, char** argv)
         exit(0);
     }
 
-    param.cutneigh = param.cutforce + param.skin;
+    param.outer_skin = MAX(param.outer_skin, 0.0);
+    param.cutneigh = param.cutforce + param.skin + param.outer_skin;
     timer[SETUP]   = setup(&param, &eam, &atom, &neighbor, &stats, &comm, &grid);
 
     if (comm.myproc == 0) {
@@ -347,14 +344,14 @@ int main(int argc, char** argv)
         initialIntegrate(&param, &atom);
 
         if ((n + 1) % param.reneigh_every) {
-            if (param.enable_double_cutoff && !((n + 1) % param.prune_every)) {
+            if (param.outer_skin > 0.0 && !((n + 1) % param.prune_every)) {
+                double prune_start = getTimeStamp();
 #ifdef CUDA_TARGET
-                copyDataFromCUDADevice(&param, &atom);
-#endif
+                pruneNeighborCUDA(&param, &atom, &neighbor);
+#else
                 pruneNeighbor(&param, &atom, &neighbor);
-#ifdef CUDA_TARGET
-                copyDataToCUDADevice(&param, &atom, &neighbor);
 #endif
+                timer[NEIGH] += getTimeStamp() - prune_start;
             }
 
             timer[FORWARD] += forward(&comm, &atom, &param);

--- a/src/clusterpair/main.c
+++ b/src/clusterpair/main.c
@@ -223,6 +223,22 @@ int main(int argc, char** argv)
             param.skin = atof(argv[++i]);
             continue;
         }
+        if ((strcmp(argv[i], "--skin-inner") == 0)) {
+            param.skin_inner = atof(argv[++i]);
+            continue;
+        }
+        if ((strcmp(argv[i], "--prune-every") == 0)) {
+            param.prune_every = atoi(argv[++i]);
+            continue;
+        }
+        if ((strcmp(argv[i], "--reneigh-every") == 0)) {
+            param.reneigh_every = atoi(argv[++i]);
+            continue;
+        }
+        if ((strcmp(argv[i], "--double-cutoff") == 0)) {
+            param.enable_double_cutoff = atoi(argv[++i]);
+            continue;
+        }
         if ((strcmp(argv[i], "--freq") == 0)) {
             param.proc_freq = atof(argv[++i]);
             continue;
@@ -260,7 +276,11 @@ int main(int argc, char** argv)
             printf("-nx/-ny/-nz <int>:    set linear dimension of systembox in x/y/z "
                    "direction\n");
             printf("-r / --radius <real>: set cutoff radius\n");
-            printf("-s / --skin <real>:   set skin (verlet buffer)\n");
+            printf("-s / --skin <real>:   set skin (outer Verlet buffer)\n");
+            printf("--skin-inner <real>:  inner skin (cutforce + skin_inner = inner cutoff)\n");
+            printf("--prune-every <int>:  pruning frequency (steps between inner-list refresh)\n");
+            printf("--reneigh-every <int>: neighbor-list rebuild frequency (steps)\n");
+            printf("--double-cutoff <0|1>: enable (1, default) or disable (0) double-cutoff scheme\n");
             printf("--freq <real>:        processor frequency (GHz)\n");
             printf("--vtk <string>:       VTK file for visualization\n");
             printf("--xtc <string>:       XTC file for visualization\n");
@@ -327,8 +347,14 @@ int main(int argc, char** argv)
         initialIntegrate(&param, &atom);
 
         if ((n + 1) % param.reneigh_every) {
-            if (!((n + 1) % param.prune_every)) {
+            if (param.enable_double_cutoff && !((n + 1) % param.prune_every)) {
+#ifdef CUDA_TARGET
+                copyDataFromCUDADevice(&param, &atom);
+#endif
                 pruneNeighbor(&param, &atom, &neighbor);
+#ifdef CUDA_TARGET
+                copyDataToCUDADevice(&param, &atom, &neighbor);
+#endif
             }
 
             timer[FORWARD] += forward(&comm, &atom, &param);

--- a/src/clusterpair/neighbor.c
+++ b/src/clusterpair/neighbor.c
@@ -146,12 +146,10 @@ void setupNeighbor(Parameter* param, Atom* atom)
     binsizey   = (yhi - ylo) / nbiny;
     bininvx    = 1.0 / binsizex;
     bininvy    = 1.0 / binsizey;
-    cutneighsq = cutneigh * cutneigh;
-    {
-        const MD_FLOAT cut_inner = param->cutforce + param->skin_inner;
-        cutneigh_inner_sq        = cut_inner * cut_inner;
-    }
-    dcut_enabled = param->enable_double_cutoff;
+    cutneighsq               = cutneigh * cutneigh;
+    const MD_FLOAT cut_inner = param->cutforce + param->skin;
+    cutneigh_inner_sq        = cut_inner * cut_inner;
+    dcut_enabled             = (cutneigh_inner_sq < cutneighsq);
 
     coord   = xlo - cutneigh - SMALL * xprd;
     mbinxlo = (int)(coord * bininvx);

--- a/src/clusterpair/neighbor.c
+++ b/src/clusterpair/neighbor.c
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include <allocate.h>
 #include <atom.h>
 #include <force.h>
 #include <neighbor.h>
@@ -183,7 +184,7 @@ void setupNeighbor(Parameter* param, Atom* atom)
     if (stencil) {
         free(stencil);
     }
-    stencil  = (int*)malloc((2 * nexty + 1) * (2 * nextx + 1) * sizeof(int));
+    stencil  = (int*)allocate(ALIGNMENT, (2 * nexty + 1) * (2 * nextx + 1) * sizeof(int));
     nstencil = 0;
 
     for (int j = -nexty; j <= nexty; j++) {
@@ -207,10 +208,10 @@ void setupNeighbor(Parameter* param, Atom* atom)
         free(bin_clusters);
     }
     mbins         = mbinx * mbiny;
-    bincount      = (int*)malloc(mbins * sizeof(int));
-    bins          = (int*)malloc(mbins * atoms_per_bin * sizeof(int));
-    bin_nclusters = (int*)malloc(mbins * sizeof(int));
-    bin_clusters  = (int*)malloc(mbins * clusters_per_bin * sizeof(int));
+    bincount      = (int*)allocate(ALIGNMENT, mbins * sizeof(int));
+    bins          = (int*)allocate(ALIGNMENT, mbins * atoms_per_bin * sizeof(int));
+    bin_nclusters = (int*)allocate(ALIGNMENT, mbins * sizeof(int));
+    bin_clusters  = (int*)allocate(ALIGNMENT, mbins * clusters_per_bin * sizeof(int));
 
     /*
     DEBUG_MESSAGE("lo, hi = (%e, %e, %e), (%e, %e, %e)\n", xlo, ylo, zlo, xhi, yhi, zhi);
@@ -299,12 +300,12 @@ void buildNeighborCPU(Atom* atom, Neighbor* neighbor)
         if (neighbor->numneigh_inner_masked) free(neighbor->numneigh_inner_masked);
         if (neighbor->neighbors) free(neighbor->neighbors);
         if (neighbor->neighbors_imask) free(neighbor->neighbors_imask);
-        neighbor->numneigh              = (int*)malloc(nmax * sizeof(int));
-        neighbor->numneigh_masked       = (int*)malloc(nmax * sizeof(int));
-        neighbor->numneigh_inner        = (int*)malloc(nmax * sizeof(int));
-        neighbor->numneigh_inner_masked = (int*)malloc(nmax * sizeof(int));
-        neighbor->neighbors = (int*)malloc(nmax * neighbor->maxneighs * sizeof(int));
-        neighbor->neighbors_imask = (unsigned int*)malloc(
+        neighbor->numneigh              = (int*)allocate(ALIGNMENT, nmax * sizeof(int));
+        neighbor->numneigh_masked       = (int*)allocate(ALIGNMENT, nmax * sizeof(int));
+        neighbor->numneigh_inner        = (int*)allocate(ALIGNMENT, nmax * sizeof(int));
+        neighbor->numneigh_inner_masked = (int*)allocate(ALIGNMENT, nmax * sizeof(int));
+        neighbor->neighbors = (int*)allocate(ALIGNMENT, nmax * neighbor->maxneighs * sizeof(int));
+        neighbor->neighbors_imask = (unsigned int*)allocate(ALIGNMENT,
             nmax * neighbor->maxneighs * sizeof(unsigned int));
     }
 
@@ -708,8 +709,8 @@ void buildNeighborCPU(Atom* atom, Neighbor* neighbor)
             fflush(stdout);
             free(neighbor->neighbors);
             free(neighbor->neighbors_imask);
-            neighbor->neighbors = (int*)malloc(nmax * neighbor->maxneighs * sizeof(int));
-            neighbor->neighbors_imask = (unsigned int*)malloc(
+            neighbor->neighbors = (int*)allocate(ALIGNMENT, nmax * neighbor->maxneighs * sizeof(int));
+            neighbor->neighbors_imask = (unsigned int*)allocate(ALIGNMENT,
                 nmax * neighbor->maxneighs * sizeof(unsigned int));
 #ifdef CUDA_TARGET
             growNeighborCUDA(atom, neighbor);
@@ -788,9 +789,9 @@ void buildNeighborSuperclusters(Atom* atom, Neighbor* neighbor)
         if (neighbor->numneigh) free(neighbor->numneigh);
         if (neighbor->numneigh_inner) free(neighbor->numneigh_inner);
         if (neighbor->neighbors) free(neighbor->neighbors);
-        neighbor->numneigh       = (int*)malloc(nmax * sizeof(int));
-        neighbor->numneigh_inner = (int*)malloc(nmax * sizeof(int));
-        neighbor->neighbors = (int*)malloc(nmax * neighbor->maxneighs * sizeof(int));
+        neighbor->numneigh       = (int*)allocate(ALIGNMENT, nmax * sizeof(int));
+        neighbor->numneigh_inner = (int*)allocate(ALIGNMENT, nmax * sizeof(int));
+        neighbor->neighbors = (int*)allocate(ALIGNMENT, nmax * neighbor->maxneighs * sizeof(int));
     }
 
     MD_FLOAT bbx    = 0.5 * (binsizex + binsizex);
@@ -958,7 +959,7 @@ void buildNeighborSuperclusters(Atom* atom, Neighbor* neighbor)
             neighbor->maxneighs = new_maxneighs * 1.2;
             fprintf(stdout, "RESIZE %d\n", neighbor->maxneighs);
             free(neighbor->neighbors);
-            neighbor->neighbors = (int*)malloc(
+            neighbor->neighbors = (int*)allocate(ALIGNMENT,
                 atom->Nmax * neighbor->maxneighs * sizeof(int));
         }
     }
@@ -1490,7 +1491,7 @@ void binAtoms(Atom* atom)
         if (resize) {
             free(bins);
             atoms_per_bin *= 2;
-            bins = (int*)malloc(mbins * atoms_per_bin * sizeof(int));
+            bins = (int*)allocate(ALIGNMENT, mbins * atoms_per_bin * sizeof(int));
         }
     }
 
@@ -2129,7 +2130,7 @@ void binJClusters(Parameter* param, Atom* atom)
         if (resize) {
             free(bin_clusters);
             clusters_per_bin *= 2;
-            bin_clusters = (int*)malloc(mbins * clusters_per_bin * sizeof(int));
+            bin_clusters = (int*)allocate(ALIGNMENT, mbins * clusters_per_bin * sizeof(int));
         }
     }
 
@@ -2287,8 +2288,8 @@ static void neighborGhost(Atom* atom, Neighbor* neighbor)
     int Ncluster_local = atom->Nclusters_local;
     int Nclusterghost  = atom->Nclusters_ghost;
     if (neighbor->listshell) free(neighbor->listshell);
-    neighbor->listshell = (int*)malloc(Nclusterghost * sizeof(int));
-    int* listzone       = (int*)malloc(8 * Nclusterghost * sizeof(int));
+    neighbor->listshell = (int*)allocate(ALIGNMENT, Nclusterghost * sizeof(int));
+    int* listzone       = (int*)allocate(ALIGNMENT, 8 * Nclusterghost * sizeof(int));
     int countCluster[8] = { 0, 0, 0, 0, 0, 0, 0, 0 };
 
     // Selecting ghost atoms for interaction and putting them into regions
@@ -2312,8 +2313,8 @@ static void neighborGhost(Atom* atom, Neighbor* neighbor)
     neighbor->Nshell = Nshell;
     if (neighbor->numNeighShell) free(neighbor->numNeighShell);
     if (neighbor->neighshell) free(neighbor->neighshell);
-    neighbor->neighshell    = (int*)malloc(Nshell * neighbor->maxneighs * sizeof(int));
-    neighbor->numNeighShell = (int*)malloc(Nshell * sizeof(int));
+    neighbor->neighshell    = (int*)allocate(ALIGNMENT, Nshell * neighbor->maxneighs * sizeof(int));
+    neighbor->numNeighShell = (int*)allocate(ALIGNMENT, Nshell * sizeof(int));
 
     int resize = 1;
 
@@ -2359,7 +2360,7 @@ static void neighborGhost(Atom* atom, Neighbor* neighbor)
 
         if (resize) {
             free(neighbor->neighshell);
-            neighbor->neighshell = (int*)malloc(
+            neighbor->neighshell = (int*)allocate(ALIGNMENT,
                 Nshell * neighbor->maxneighs * sizeof(int));
         }
     }

--- a/src/clusterpair/neighbor.c
+++ b/src/clusterpair/neighbor.c
@@ -36,7 +36,9 @@ static int mbins;            // total number of bins
 static int atoms_per_bin;    // max atoms per bin
 static int clusters_per_bin; // max clusters per bin
 static MD_FLOAT cutneigh;
-static MD_FLOAT cutneighsq; // neighbor cutoff squared
+static MD_FLOAT cutneighsq;
+static MD_FLOAT cutneigh_inner_sq;
+static int dcut_enabled;
 static int nmax;
 static int nstencil; // # of bins in stencil
 static int* stencil; // stencil list of bin offsets
@@ -75,10 +77,12 @@ void initNeighbor(Neighbor* neighbor, Parameter* param)
     } else {
         neighbor->maxneighs = 200;
     }
-    neighbor->numneigh        = NULL;
-    neighbor->numneigh_masked = NULL;
-    neighbor->neighbors       = NULL;
-    neighbor->neighbors_imask = NULL;
+    neighbor->numneigh              = NULL;
+    neighbor->numneigh_masked       = NULL;
+    neighbor->numneigh_inner        = NULL;
+    neighbor->numneigh_inner_masked = NULL;
+    neighbor->neighbors             = NULL;
+    neighbor->neighbors_imask       = NULL;
     // MPI Implementation
     method      = param->method;
     shellMethod = method ? 1 : 0;
@@ -143,6 +147,11 @@ void setupNeighbor(Parameter* param, Atom* atom)
     bininvx    = 1.0 / binsizex;
     bininvy    = 1.0 / binsizey;
     cutneighsq = cutneigh * cutneigh;
+    {
+        const MD_FLOAT cut_inner = param->cutforce + param->skin_inner;
+        cutneigh_inner_sq        = cut_inner * cut_inner;
+    }
+    dcut_enabled = param->enable_double_cutoff;
 
     coord   = xlo - cutneigh - SMALL * xprd;
     mbinxlo = (int)(coord * bininvx);
@@ -288,10 +297,14 @@ void buildNeighborCPU(Atom* atom, Neighbor* neighbor)
         nmax = atom->Nclusters_local;
         if (neighbor->numneigh) free(neighbor->numneigh);
         if (neighbor->numneigh_masked) free(neighbor->numneigh_masked);
+        if (neighbor->numneigh_inner) free(neighbor->numneigh_inner);
+        if (neighbor->numneigh_inner_masked) free(neighbor->numneigh_inner_masked);
         if (neighbor->neighbors) free(neighbor->neighbors);
         if (neighbor->neighbors_imask) free(neighbor->neighbors_imask);
-        neighbor->numneigh        = (int*)malloc(nmax * sizeof(int));
-        neighbor->numneigh_masked = (int*)malloc(nmax * sizeof(int));
+        neighbor->numneigh              = (int*)malloc(nmax * sizeof(int));
+        neighbor->numneigh_masked       = (int*)malloc(nmax * sizeof(int));
+        neighbor->numneigh_inner        = (int*)malloc(nmax * sizeof(int));
+        neighbor->numneigh_inner_masked = (int*)malloc(nmax * sizeof(int));
         neighbor->neighbors = (int*)malloc(nmax * neighbor->maxneighs * sizeof(int));
         neighbor->neighbors_imask = (unsigned int*)malloc(
             nmax * neighbor->maxneighs * sizeof(unsigned int));
@@ -761,6 +774,8 @@ void buildNeighborCPU(Atom* atom, Neighbor* neighbor)
     }
     */
 
+    pruneNeighborCPU(NULL, atom, neighbor);
+
     DEBUG_MESSAGE("buildNeighbor end\n");
 }
 
@@ -773,8 +788,10 @@ void buildNeighborSuperclusters(Atom* atom, Neighbor* neighbor)
     if (atom->Nclusters_local > nmax) {
         nmax = atom->Nclusters_local;
         if (neighbor->numneigh) free(neighbor->numneigh);
+        if (neighbor->numneigh_inner) free(neighbor->numneigh_inner);
         if (neighbor->neighbors) free(neighbor->neighbors);
-        neighbor->numneigh  = (int*)malloc(nmax * sizeof(int));
+        neighbor->numneigh       = (int*)malloc(nmax * sizeof(int));
+        neighbor->numneigh_inner = (int*)malloc(nmax * sizeof(int));
         neighbor->neighbors = (int*)malloc(nmax * neighbor->maxneighs * sizeof(int));
     }
 
@@ -1093,23 +1110,32 @@ void buildNeighborSuperclusters(Atom* atom, Neighbor* neighbor)
     }
     */
 
+    pruneNeighborSuperclusters(NULL, atom, neighbor);
+
     DEBUG_MESSAGE("buildNeighborSuperclusters end\n");
 }
 
 void pruneNeighborCPU(Parameter* param, Atom* atom, Neighbor* neighbor)
 {
     DEBUG_MESSAGE("pruneNeighbor start\n");
-    // MD_FLOAT cutsq = param->cutforce * param->cutforce;
-    MD_FLOAT cutsq = cutneighsq;
-    const int nbM  = atom->Nclusters_local;
-    const int nbN  = neighbor->maxneighs;
+    if (!dcut_enabled) {
+        // Disabled: mirror outer counts so the force kernel reads the full list.
+        for (int ci = 0; ci < atom->Nclusters_local; ci++) {
+            neighbor->numneigh_inner[ci]        = neighbor->numneigh[ci];
+            neighbor->numneigh_inner_masked[ci] = neighbor->numneigh_masked[ci];
+        }
+        return;
+    }
+
+    const MD_FLOAT cutsq = cutneigh_inner_sq;
+    const int nbM        = atom->Nclusters_local;
+    const int nbN        = neighbor->maxneighs;
 
     for (int ci = 0; ci < atom->Nclusters_local; ci++) {
-        int numneighs        = neighbor->numneigh[ci];
-        int numneighs_masked = neighbor->numneigh_masked[ci];
-        int k                = 0;
-        int ci_vec_base      = CI_VECTOR3_BASE_INDEX(ci);
-        MD_FLOAT* ci_x       = &atom->cl_x[ci_vec_base];
+        const int numneighs        = neighbor->numneigh[ci];
+        const int numneighs_masked = neighbor->numneigh_masked[ci];
+        int ci_vec_base            = CI_VECTOR3_BASE_INDEX(ci);
+        MD_FLOAT* ci_x             = &atom->cl_x[ci_vec_base];
 
 #if defined(CLUSTERPAIR_KERNEL_2XNN)
         MD_SIMD_FLOAT cutneighsq_vec = simd_real_broadcast(cutsq);
@@ -1135,22 +1161,14 @@ void pruneNeighborCPU(Parameter* param, Atom* atom, Neighbor* neighbor)
         MD_SIMD_FLOAT zi3_tmp        = simd_real_broadcast(ci_x[CL_Z_INDEX_3D(3)]);
 #endif
 
-        // Remove dummy clusters if necessary
-        if (CLUSTER_N < VECTOR_WIDTH) {
-            while (neighs(neighbor->neighbors, ci, numneighs - 1, nbM, nbN) ==
-                   atom->dummy_cj) {
-                numneighs--;
-            }
-        }
-
-        while (k < numneighs) {
+        int is_inner[numneighs > 0 ? numneighs : 1];
+        for (int k = 0; k < numneighs; k++) {
             int cj                 = neighs(neighbor->neighbors, ci, k, nbM, nbN);
             int cj_vec_base        = CJ_VECTOR3_BASE_INDEX(cj);
             MD_FLOAT* cj_x         = &atom->cl_x[cj_vec_base];
             int atom_dist_in_range = 0;
 
 #if defined(CLUSTERPAIR_KERNEL_2XNN)
-
             MD_SIMD_FLOAT xj_tmp = simd_real_load_h_duplicate(&cj_x[CL_X_INDEX_3D(0)]);
             MD_SIMD_FLOAT yj_tmp = simd_real_load_h_duplicate(&cj_x[CL_Y_INDEX_3D(0)]);
             MD_SIMD_FLOAT zj_tmp = simd_real_load_h_duplicate(&cj_x[CL_Z_INDEX_3D(0)]);
@@ -1166,16 +1184,12 @@ void pruneNeighborCPU(Parameter* param, Atom* atom, Neighbor* neighbor)
             MD_SIMD_FLOAT rsq2   = simd_real_fma(delx2,
                 delx2,
                 simd_real_fma(dely2, dely2, simd_real_mul(delz2, delz2)));
-
             MD_SIMD_MASK cutoff_mask0 = simd_mask_cond_lt(rsq0, cutneighsq_vec);
             MD_SIMD_MASK cutoff_mask2 = simd_mask_cond_lt(rsq2, cutneighsq_vec);
-
             if (simd_test_any(cutoff_mask0) || simd_test_any(cutoff_mask2)) {
                 atom_dist_in_range = 1;
             }
-
 #elif defined(CLUSTERPAIR_KERNEL_4XN)
-
             MD_SIMD_FLOAT xj_tmp = simd_real_load(&cj_x[CL_X_INDEX_3D(0)]);
             MD_SIMD_FLOAT yj_tmp = simd_real_load(&cj_x[CL_Y_INDEX_3D(0)]);
             MD_SIMD_FLOAT zj_tmp = simd_real_load(&cj_x[CL_Z_INDEX_3D(0)]);
@@ -1191,7 +1205,6 @@ void pruneNeighborCPU(Parameter* param, Atom* atom, Neighbor* neighbor)
             MD_SIMD_FLOAT delx3  = simd_real_sub(xi3_tmp, xj_tmp);
             MD_SIMD_FLOAT dely3  = simd_real_sub(yi3_tmp, yj_tmp);
             MD_SIMD_FLOAT delz3  = simd_real_sub(zi3_tmp, zj_tmp);
-
             MD_SIMD_FLOAT rsq0 = simd_real_fma(delx0,
                 delx0,
                 simd_real_fma(dely0, dely0, simd_real_mul(delz0, delz0)));
@@ -1204,12 +1217,10 @@ void pruneNeighborCPU(Parameter* param, Atom* atom, Neighbor* neighbor)
             MD_SIMD_FLOAT rsq3 = simd_real_fma(delx3,
                 delx3,
                 simd_real_fma(dely3, dely3, simd_real_mul(delz3, delz3)));
-
             MD_SIMD_MASK cutoff_mask0 = simd_mask_cond_lt(rsq0, cutneighsq_vec);
             MD_SIMD_MASK cutoff_mask1 = simd_mask_cond_lt(rsq1, cutneighsq_vec);
             MD_SIMD_MASK cutoff_mask2 = simd_mask_cond_lt(rsq2, cutneighsq_vec);
             MD_SIMD_MASK cutoff_mask3 = simd_mask_cond_lt(rsq3, cutneighsq_vec);
-
             if (simd_test_any(cutoff_mask0) || simd_test_any(cutoff_mask1) ||
                 simd_test_any(cutoff_mask2) || simd_test_any(cutoff_mask3)) {
                 atom_dist_in_range = 1;
@@ -1225,39 +1236,85 @@ void pruneNeighborCPU(Parameter* param, Atom* atom, Neighbor* neighbor)
                         break;
                     }
                 }
+                if (atom_dist_in_range) break;
             }
 #endif
 
-            if (atom_dist_in_range) {
-                k++;
-            } else {
-                numneighs--;
-                if (k < numneighs_masked) {
-                    numneighs_masked--;
+            is_inner[k] = atom_dist_in_range;
+        }
+
+        // Partition each section (masked / unmasked) in place: inner first.
+        int lo = 0;
+        for (int hi = 0; hi < numneighs_masked; hi++) {
+            if (is_inner[hi]) {
+                if (hi != lo) {
+                    int t_cj          = neighs(neighbor->neighbors, ci, lo, nbM, nbN);
+                    unsigned int t_im = neighs(neighbor->neighbors_imask,
+                        ci,
+                        lo,
+                        nbM,
+                        nbN);
+                    int t_in          = is_inner[lo];
+                    neighs(neighbor->neighbors,
+                        ci,
+                        lo,
+                        nbM,
+                        nbN) = neighs(neighbor->neighbors, ci, hi, nbM, nbN);
+                    neighs(neighbor->neighbors_imask,
+                        ci,
+                        lo,
+                        nbM,
+                        nbN) = neighs(neighbor->neighbors_imask, ci, hi, nbM, nbN);
+                    is_inner[lo]                                  = is_inner[hi];
+                    neighs(neighbor->neighbors, ci, hi, nbM, nbN) = t_cj;
+                    neighs(neighbor->neighbors_imask,
+                        ci,
+                        hi,
+                        nbM,
+                        nbN) = t_im;
+                    is_inner[hi] = t_in;
                 }
-                neighs(neighbor->neighbors, ci, k, nbM, nbN) = neighs(neighbor->neighbors,
-                    ci,
-                    numneighs,
-                    nbM,
-                    nbN);
+                lo++;
+            }
+        }
+        const int n_inner_masked = lo;
+
+        lo = numneighs_masked;
+        for (int hi = numneighs_masked; hi < numneighs; hi++) {
+            if (is_inner[hi]) {
+                if (hi != lo) {
+                    int t_cj          = neighs(neighbor->neighbors, ci, lo, nbM, nbN);
+                    unsigned int t_im = neighs(neighbor->neighbors_imask,
+                        ci,
+                        lo,
+                        nbM,
+                        nbN);
+                    int t_in          = is_inner[lo];
+                    neighs(neighbor->neighbors,
+                        ci,
+                        lo,
+                        nbM,
+                        nbN) = neighs(neighbor->neighbors, ci, hi, nbM, nbN);
+                    neighs(neighbor->neighbors_imask,
+                        ci,
+                        lo,
+                        nbM,
+                        nbN) = neighs(neighbor->neighbors_imask, ci, hi, nbM, nbN);
+                    is_inner[lo]                                  = is_inner[hi];
+                    neighs(neighbor->neighbors, ci, hi, nbM, nbN) = t_cj;
+                    neighs(neighbor->neighbors_imask,
+                        ci,
+                        hi,
+                        nbM,
+                        nbN) = t_im;
+                    is_inner[hi] = t_in;
+                }
+                lo++;
             }
         }
 
-        // Readd dummy clusters if necessary
-        if (CLUSTER_N < VECTOR_WIDTH) {
-            while (numneighs % (VECTOR_WIDTH / CLUSTER_N)) {
-                neighs(neighbor->neighbors,
-                    ci,
-                    numneighs,
-                    nbM,
-                    nbN) = atom->dummy_cj; // Last cluster is always a dummy cluster
-                neighs(neighbor->neighbors_imask, ci, numneighs, nbM, nbN) = 0;
-                numneighs++;
-            }
-        }
-
-        neighbor->numneigh[ci]        = numneighs;
-        neighbor->numneigh_masked[ci] = numneighs_masked;
+        neighbor->numneigh_inner_masked[ci] = n_inner_masked;
+        neighbor->numneigh_inner[ci]        = n_inner_masked + (lo - numneighs_masked);
     }
 
     DEBUG_MESSAGE("pruneNeighbor end\n");
@@ -1266,75 +1323,69 @@ void pruneNeighborCPU(Parameter* param, Atom* atom, Neighbor* neighbor)
 void pruneNeighborSuperclusters(Parameter* param, Atom* atom, Neighbor* neighbor)
 {
     DEBUG_MESSAGE("pruneNeighbor start\n");
-    // MD_FLOAT cutsq = param->cutforce * param->cutforce;
-    MD_FLOAT cutsq = cutneighsq;
-    const int nbM  = atom->Nclusters_local;
-    const int nbN  = neighbor->maxneighs;
+    if (!dcut_enabled) {
+        for (int sci = 0; sci < atom->Nclusters_local; sci++) {
+            neighbor->numneigh_inner[sci] = neighbor->numneigh[sci];
+        }
+        return;
+    }
+
+    const MD_FLOAT cutsq = cutneigh_inner_sq;
+    const int nbM        = atom->Nclusters_local;
+    const int nbN        = neighbor->maxneighs;
 
     for (int sci = 0; sci < atom->Nclusters_local; sci++) {
-        for (int scii = 0; scii < atom->siclusters[sci].nclusters; scii++) {
-            int numneighs = neighbor->numneigh[sci];
-            int k         = 0;
+        const int numneighs = neighbor->numneigh[sci];
+        int is_inner[numneighs > 0 ? numneighs : 1];
 
-            // Remove dummy clusters if necessary
-            if (CLUSTER_N < VECTOR_WIDTH) {
-                while (neighs(neighbor->neighbors, sci, numneighs - 1, nbM, nbN) ==
-                       atom->dummy_cj) {
-                    numneighs--;
-                }
-            }
+        for (int k = 0; k < numneighs; k++) {
+            int cj          = neighs(neighbor->neighbors, sci, k, nbM, nbN);
+            int is_neighbor = 0;
 
-            while (k < numneighs) {
-                int is_neighbor = 0;
-                int cj          = neighs(neighbor->neighbors, sci, k, nbM, nbN);
+            for (int sci_ci = 0; sci_ci < atom->siclusters[sci].nclusters; sci_ci++) {
+                const int ci    = sci * SCLUSTER_SIZE + sci_ci;
+                int ci_vec_base = SCI_VECTOR_BASE_INDEX(sci) + sci_ci * CLUSTER_M;
+                int cj_vec_base = CJ_VECTOR3_BASE_INDEX(cj);
+                MD_FLOAT* ci_x  = &atom->cl_x[ci_vec_base];
+                MD_FLOAT* cj_x  = &atom->cl_x[cj_vec_base];
 
-                for (int sci_ci = 0; sci_ci < atom->siclusters[sci].nclusters; sci_ci++) {
-                    const int ci    = sci * SCLUSTER_SIZE + sci_ci;
-                    int ci_vec_base = SCI_VECTOR_BASE_INDEX(sci) + sci_ci * CLUSTER_M;
-                    int cj_vec_base = CJ_VECTOR3_BASE_INDEX(cj);
-                    MD_FLOAT* ci_x  = &atom->cl_x[ci_vec_base];
-                    MD_FLOAT* cj_x  = &atom->cl_x[cj_vec_base];
-
-                    for (int cii = 0; cii < atom->iclusters[ci].natoms; cii++) {
-                        for (int cjj = 0; cjj < atom->jclusters[cj].natoms; cjj++) {
-                            MD_FLOAT delx = ci_x[CL_X_INDEX(cii)] - cj_x[CL_X_INDEX(cjj)];
-                            MD_FLOAT dely = ci_x[CL_Y_INDEX(cii)] - cj_x[CL_Y_INDEX(cjj)];
-                            MD_FLOAT delz = ci_x[CL_Z_INDEX(cii)] - cj_x[CL_Z_INDEX(cjj)];
-                            if (delx * delx + dely * dely + delz * delz < cutsq) {
-                                is_neighbor = 1;
-                                break;
-                            }
+                for (int cii = 0; cii < atom->iclusters[ci].natoms; cii++) {
+                    for (int cjj = 0; cjj < atom->jclusters[cj].natoms; cjj++) {
+                        MD_FLOAT delx = ci_x[CL_X_INDEX(cii)] - cj_x[CL_X_INDEX(cjj)];
+                        MD_FLOAT dely = ci_x[CL_Y_INDEX(cii)] - cj_x[CL_Y_INDEX(cjj)];
+                        MD_FLOAT delz = ci_x[CL_Z_INDEX(cii)] - cj_x[CL_Z_INDEX(cjj)];
+                        if (delx * delx + dely * dely + delz * delz < cutsq) {
+                            is_neighbor = 1;
+                            break;
                         }
                     }
+                    if (is_neighbor) break;
                 }
-
-                if (is_neighbor) {
-                    k++;
-                } else {
-                    numneighs--;
-                    neighs(neighbor->neighbors,
-                        sci,
-                        k,
-                        nbM,
-                        nbN) = neighs(neighbor->neighbors, sci, numneighs, nbM, nbN);
-                }
+                if (is_neighbor) break;
             }
-
-            // Readd dummy clusters if necessary
-            if (CLUSTER_N < VECTOR_WIDTH) {
-                while (numneighs % (VECTOR_WIDTH / CLUSTER_N)) {
-                    neighs(neighbor->neighbors,
-                        sci,
-                        numneighs,
-                        nbM,
-                        nbN) = atom->dummy_cj; // Last cluster is always a dummy cluster
-                    neighs(neighbor->neighbors_imask, sci, numneighs, nbM, nbN) = 0;
-                    numneighs++;
-                }
-            }
-
-            neighbor->numneigh[sci] = numneighs;
+            is_inner[k] = is_neighbor;
         }
+
+        int lo = 0;
+        for (int hi = 0; hi < numneighs; hi++) {
+            if (is_inner[hi]) {
+                if (hi != lo) {
+                    int t_cj = neighs(neighbor->neighbors, sci, lo, nbM, nbN);
+                    int t_in = is_inner[lo];
+                    neighs(neighbor->neighbors,
+                        sci,
+                        lo,
+                        nbM,
+                        nbN) = neighs(neighbor->neighbors, sci, hi, nbM, nbN);
+                    is_inner[lo]                                   = is_inner[hi];
+                    neighs(neighbor->neighbors, sci, hi, nbM, nbN) = t_cj;
+                    is_inner[hi]                                   = t_in;
+                }
+                lo++;
+            }
+        }
+
+        neighbor->numneigh_inner[sci] = lo;
     }
 
     DEBUG_MESSAGE("pruneNeighbor end\n");

--- a/src/clusterpair/neighbor.c
+++ b/src/clusterpair/neighbor.c
@@ -44,6 +44,7 @@ static int nmax;
 static int nstencil; // # of bins in stencil
 static int* stencil; // stencil list of bin offsets
 static MD_FLOAT binsizex, binsizey;
+static int* is_inner_buf;  // reusable scratch for pruneNeighbor*, sized by maxneighs
 
 static int coord2bin(MD_FLOAT, MD_FLOAT);
 static MD_FLOAT bindist(int, int);
@@ -78,6 +79,7 @@ void initNeighbor(Neighbor* neighbor, Parameter* param)
     } else {
         neighbor->maxneighs = 200;
     }
+    is_inner_buf = (int*)allocate(ALIGNMENT, neighbor->maxneighs * sizeof(int));
     neighbor->numneigh              = NULL;
     neighbor->numneigh_masked       = NULL;
     neighbor->numneigh_inner        = NULL;
@@ -709,9 +711,12 @@ void buildNeighborCPU(Atom* atom, Neighbor* neighbor)
             fflush(stdout);
             free(neighbor->neighbors);
             free(neighbor->neighbors_imask);
+            free(is_inner_buf);
             neighbor->neighbors = (int*)allocate(ALIGNMENT, nmax * neighbor->maxneighs * sizeof(int));
             neighbor->neighbors_imask = (unsigned int*)allocate(ALIGNMENT,
                 nmax * neighbor->maxneighs * sizeof(unsigned int));
+            is_inner_buf = (int*)allocate(ALIGNMENT,
+                neighbor->maxneighs * sizeof(int));
 #ifdef CUDA_TARGET
             growNeighborCUDA(atom, neighbor);
 #endif
@@ -959,8 +964,11 @@ void buildNeighborSuperclusters(Atom* atom, Neighbor* neighbor)
             neighbor->maxneighs = new_maxneighs * 1.2;
             fprintf(stdout, "RESIZE %d\n", neighbor->maxneighs);
             free(neighbor->neighbors);
+            free(is_inner_buf);
             neighbor->neighbors = (int*)allocate(ALIGNMENT,
                 atom->Nmax * neighbor->maxneighs * sizeof(int));
+            is_inner_buf = (int*)allocate(ALIGNMENT,
+                neighbor->maxneighs * sizeof(int));
         }
     }
     // if (atom->Nclusters_local > 0) debug_check_supercluster_neighbors(atom, neighbor,
@@ -1130,6 +1138,8 @@ void pruneNeighborCPU(Parameter* param, Atom* atom, Neighbor* neighbor)
     const int nbM        = atom->Nclusters_local;
     const int nbN        = neighbor->maxneighs;
 
+    int* is_inner = is_inner_buf;
+
     for (int ci = 0; ci < atom->Nclusters_local; ci++) {
         const int numneighs        = neighbor->numneigh[ci];
         const int numneighs_masked = neighbor->numneigh_masked[ci];
@@ -1160,7 +1170,6 @@ void pruneNeighborCPU(Parameter* param, Atom* atom, Neighbor* neighbor)
         MD_SIMD_FLOAT zi3_tmp        = simd_real_broadcast(ci_x[CL_Z_INDEX_3D(3)]);
 #endif
 
-        int is_inner[numneighs > 0 ? numneighs : 1];
         for (int k = 0; k < numneighs; k++) {
             int cj                 = neighs(neighbor->neighbors, ci, k, nbM, nbN);
             int cj_vec_base        = CJ_VECTOR3_BASE_INDEX(cj);
@@ -1333,9 +1342,10 @@ void pruneNeighborSuperclusters(Parameter* param, Atom* atom, Neighbor* neighbor
     const int nbM        = atom->Nclusters_local;
     const int nbN        = neighbor->maxneighs;
 
+    int* is_inner = is_inner_buf;
+
     for (int sci = 0; sci < atom->Nclusters_local; sci++) {
         const int numneighs = neighbor->numneigh[sci];
-        int is_inner[numneighs > 0 ? numneighs : 1];
 
         for (int k = 0; k < numneighs; k++) {
             int cj          = neighs(neighbor->neighbors, sci, k, nbM, nbN);

--- a/src/clusterpair/neighbor.h
+++ b/src/clusterpair/neighbor.h
@@ -42,6 +42,10 @@ typedef struct {
     int maxneighs;
     int* numneigh;
     int* numneigh_masked;
+    // Inner sub-list counts: force kernels iterate only [0, numneigh_inner).
+    // When the double-cutoff toggle is off these mirror numneigh*.
+    int* numneigh_inner;
+    int* numneigh_inner_masked;
     int half_neigh;
     int* neighbors;
     unsigned int* neighbors_imask;

--- a/src/clusterpair/neighbor.h
+++ b/src/clusterpair/neighbor.h
@@ -42,19 +42,16 @@ typedef struct {
     int maxneighs;
     int* numneigh;
     int* numneigh_masked;
-    // Inner sub-list counts: force kernels iterate only [0, numneigh_inner).
-    // When the double-cutoff toggle is off these mirror numneigh*.
     int* numneigh_inner;
     int* numneigh_inner_masked;
     int half_neigh;
     int* neighbors;
     unsigned int* neighbors_imask;
     // MPI
-    int Nshell;         // # of cluster in listShell(Cluster here cover all possible ghost
-                        // interactions)
-    int* numNeighShell; // # of neighs for each atom in listShell
-    int* neighshell;    // list of neighs for each atom in listShell
-    int* listshell;     // Atoms to compute the force
+    int Nshell;
+    int* numNeighShell;
+    int* neighshell;
+    int* listshell;
 } Neighbor;
 
 typedef void (*BuildNeighborFunction)(Atom*, Neighbor*);

--- a/src/common/device.c
+++ b/src/common/device.c
@@ -16,5 +16,6 @@ void* allocateGPU(size_t bytesize) { return NULL; }
 void* reallocateGPU(void* ptr, size_t new_bytesize) { return NULL; }
 void memcpyToGPU(void* d_ptr, void* h_ptr, size_t bytesize) {}
 void memcpyFromGPU(void* h_ptr, void* d_ptr, size_t bytesize) {}
+void memcpyOnGPU(void* d_dst, void* d_src, size_t bytesize) {}
 void memsetGPU(void* d_ptr, int value, size_t bytesize) {}
 #endif

--- a/src/common/device.h
+++ b/src/common/device.h
@@ -15,11 +15,31 @@
 #ifdef CUDA_TARGET
 #if CUDA_TARGET == 0
 #include <cuda_runtime.h>
-#define error_t cudaError_t
+#define error_t             cudaError_t
+#define GPU_SUCCESS         cudaSuccess
+#define GPU_ERROR_STR       cudaGetErrorString
+#define GPU_MALLOC(p, s)    cudaMalloc(p, s)
+#define GPU_MALLOC_HOST(p, s) cudaMallocHost(p, s)
+#define GPU_FREE            cudaFree
+#define GPU_FREE_HOST       cudaFreeHost
+#define GPU_MEMCPY(d, s, n, k) cudaMemcpy(d, s, n, k)
+#define GPU_MEMSET(d, v, n) cudaMemset(d, v, n)
+#define GPU_H2D             cudaMemcpyHostToDevice
+#define GPU_D2H             cudaMemcpyDeviceToHost
 #elif CUDA_TARGET == 1
 #define __HIP_PLATFORM_AMD__
 #include <hip/hip_runtime.h>
-#define error_t hipError_t
+#define error_t             hipError_t
+#define GPU_SUCCESS         hipSuccess
+#define GPU_ERROR_STR       hipGetErrorString
+#define GPU_MALLOC(p, s)    hipMalloc(p, s)
+#define GPU_MALLOC_HOST(p, s) hipHostMalloc(p, s, 0)
+#define GPU_FREE            hipFree
+#define GPU_FREE_HOST       hipHostFree
+#define GPU_MEMCPY(d, s, n, k) hipMemcpy(d, s, n, k)
+#define GPU_MEMSET(d, v, n) hipMemset(d, v, n)
+#define GPU_H2D             hipMemcpyHostToDevice
+#define GPU_D2H             hipMemcpyDeviceToHost
 #endif
 #ifdef __cplusplus
 extern "C" {

--- a/src/common/device.h
+++ b/src/common/device.h
@@ -26,6 +26,7 @@
 #define GPU_MEMSET(d, v, n) cudaMemset(d, v, n)
 #define GPU_H2D             cudaMemcpyHostToDevice
 #define GPU_D2H             cudaMemcpyDeviceToHost
+#define GPU_D2D             cudaMemcpyDeviceToDevice
 #elif CUDA_TARGET == 1
 #define __HIP_PLATFORM_AMD__
 #include <hip/hip_runtime.h>
@@ -40,6 +41,7 @@
 #define GPU_MEMSET(d, v, n) hipMemset(d, v, n)
 #define GPU_H2D             hipMemcpyHostToDevice
 #define GPU_D2H             hipMemcpyDeviceToHost
+#define GPU_D2D             hipMemcpyDeviceToDevice
 #endif
 #ifdef __cplusplus
 extern "C" {
@@ -53,6 +55,7 @@ extern void* allocateGPU(size_t bytesize);
 extern void* reallocateGPU(void* ptr, size_t new_bytesize);
 extern void memcpyToGPU(void* d_ptr, void* h_ptr, size_t bytesize);
 extern void memcpyFromGPU(void* h_ptr, void* d_ptr, size_t bytesize);
+extern void memcpyOnGPU(void* d_dst, void* d_src, size_t bytesize);
 extern void memsetGPU(void* d_ptr, int value, size_t bytesize);
 #ifdef __cplusplus
 }

--- a/src/common/deviceGPU.cu
+++ b/src/common/deviceGPU.cu
@@ -56,6 +56,11 @@ void memcpyFromGPU(void* h_ptr, void* d_ptr, size_t bytesize)
 #endif
 }
 
+void memcpyOnGPU(void* d_dst, void* d_src, size_t bytesize)
+{
+    cuda_assert("memcpyOnGPU", GPU_MEMCPY(d_dst, d_src, bytesize, GPU_D2D));
+}
+
 void memsetGPU(void* d_ptr, int value, size_t bytesize)
 {
     cuda_assert("memsetGPU", GPU_MEMSET(d_ptr, value, bytesize));

--- a/src/common/deviceGPU.cu
+++ b/src/common/deviceGPU.cu
@@ -7,39 +7,36 @@
 #include <stdio.h>
 #include <stdlib.h>
 //---
-#include <cuda_runtime.h>
-
 #include <device.h>
 
-void cuda_assert(const char* label, cudaError_t err)
+void cuda_assert(const char* label, error_t err)
 {
-    if (err != cudaSuccess) {
-        printf("[CUDA Error]: %s: %s\r\n", label, cudaGetErrorString(err));
+    if (err != GPU_SUCCESS) {
+        printf("[GPU Error]: %s: %s\r\n", label, GPU_ERROR_STR(err));
         exit(-1);
     }
 }
 
-void GPUfree(void* any) { cuda_assert("GPUfree", cudaFree(any)); }
+void GPUfree(void* any) { cuda_assert("GPUfree", GPU_FREE(any)); }
 
 void* allocateGPU(size_t bytesize)
 {
     void* ptr;
 #ifdef CUDA_HOST_MEMORY
-    cuda_assert("allocateGPU", cudaMallocHost((void**)&ptr, bytesize));
+    cuda_assert("allocateGPU", GPU_MALLOC_HOST((void**)&ptr, bytesize));
 #else
-    cuda_assert("allocateGPU", cudaMalloc((void**)&ptr, bytesize));
+    cuda_assert("allocateGPU", GPU_MALLOC((void**)&ptr, bytesize));
 #endif
     return ptr;
 }
 
-// Data is not preserved
 void* reallocateGPU(void* ptr, size_t new_bytesize)
 {
     if (ptr != NULL) {
 #ifdef CUDA_HOST_MEMORY
-        cudaFreeHost(ptr);
+        (void)GPU_FREE_HOST(ptr);
 #else
-        cudaFree(ptr);
+        (void)GPU_FREE(ptr);
 #endif
     }
     return allocateGPU(new_bytesize);
@@ -48,20 +45,18 @@ void* reallocateGPU(void* ptr, size_t new_bytesize)
 void memcpyToGPU(void* d_ptr, void* h_ptr, size_t bytesize)
 {
 #ifndef CUDA_HOST_MEMORY
-    cuda_assert("memcpyToGPU",
-        cudaMemcpy(d_ptr, h_ptr, bytesize, cudaMemcpyHostToDevice));
+    cuda_assert("memcpyToGPU", GPU_MEMCPY(d_ptr, h_ptr, bytesize, GPU_H2D));
 #endif
 }
 
 void memcpyFromGPU(void* h_ptr, void* d_ptr, size_t bytesize)
 {
 #ifndef CUDA_HOST_MEMORY
-    cuda_assert("memcpyFromGPU",
-        cudaMemcpy(h_ptr, d_ptr, bytesize, cudaMemcpyDeviceToHost));
+    cuda_assert("memcpyFromGPU", GPU_MEMCPY(h_ptr, d_ptr, bytesize, GPU_D2H));
 #endif
 }
 
 void memsetGPU(void* d_ptr, int value, size_t bytesize)
 {
-    cuda_assert("memsetGPU", cudaMemset(d_ptr, value, bytesize));
+    cuda_assert("memsetGPU", GPU_MEMSET(d_ptr, value, bytesize));
 }

--- a/src/common/gpu_profiler.h
+++ b/src/common/gpu_profiler.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C)  NHR@FAU, University Erlangen-Nuremberg.
+ * All rights reserved. This file is part of MD-Bench.
+ * Use of this source code is governed by a LGPL-3.0
+ * license that can be found in the LICENSE file.
+ */
+#ifndef __GPU_PROFILER_H_
+#define __GPU_PROFILER_H_
+
+#ifdef CUDA_TARGET
+#if CUDA_TARGET == 0
+#include <cuda_profiler_api.h>
+#define GPU_PROFILE_START(name) cudaProfilerStart()
+#define GPU_PROFILE_STOP()      cudaProfilerStop()
+#elif CUDA_TARGET == 1
+#include <roctracer/roctx.h>
+#define GPU_PROFILE_START(name) roctxRangePush(name)
+#define GPU_PROFILE_STOP()      roctxRangePop()
+#endif
+#else
+#define GPU_PROFILE_START(name)
+#define GPU_PROFILE_STOP()
+#endif
+
+#endif

--- a/src/common/parameter.c
+++ b/src/common/parameter.c
@@ -99,9 +99,8 @@ void initParameter(Parameter* param)
     param->pbc_z            = 1;
     param->cutforce            = 2.5;
     param->skin                = 0.3;
-    param->skin_inner          = 0.0;
-    param->cutneigh            = param->cutforce + param->skin;
-    param->enable_double_cutoff = 0;
+    param->outer_skin          = 0.0;
+    param->cutneigh            = param->cutforce + param->skin + param->outer_skin;
     param->temp             = 1.44;
     param->nstat            = 100;
     param->mass             = 1.0;
@@ -213,7 +212,7 @@ void readParameter(Parameter* param, const char* filename)
         char* val = strtok(NULL, " \t\n\r");
 
 // Exact-match: strncmp with the name length was a prefix match, so e.g.
-// "skin_inner" matched both `skin` and `skin_inner` and clobbered the first.
+// "outer_skin" matched both `skin` and `outer_skin` and clobbered the first.
 #define PARSE_PARAM(p, f)                                                                \
     if (strcmp(tok, #p) == 0) {                                                          \
         param->p = f(val);                                                               \
@@ -240,8 +239,7 @@ void readParameter(Parameter* param, const char* filename)
             PARSE_REAL(dt);
             PARSE_REAL(cutforce);
             PARSE_REAL(skin);
-            PARSE_REAL(skin_inner);
-            PARSE_INT(enable_double_cutoff);
+            PARSE_REAL(outer_skin);
             PARSE_REAL(temp);
             PARSE_REAL(mass);
             PARSE_REAL(proc_freq);
@@ -289,13 +287,13 @@ void readParameter(Parameter* param, const char* filename)
     // Update balance parameter, 10 could be change
     param->balance_every *= param->reneigh_every;
 
-    if (param->skin_inner > param->skin) {
+    if (param->outer_skin < 0.0) {
         fprintf(stderr,
-            "WARN: skin_inner (%.6e) > skin (%.6e); clamping.\n",
-            (double)param->skin_inner,
-            (double)param->skin);
-        param->skin_inner = param->skin;
+            "WARN: outer_skin (%.6e) < 0; clamping to 0.\n",
+            (double)param->outer_skin);
+        param->outer_skin = 0.0;
     }
+    param->cutneigh = param->cutforce + param->skin + param->outer_skin;
     fclose(fp);
 }
 
@@ -400,10 +398,9 @@ void printParameter(Parameter* param)
     fprintf(stdout, "    Timestep (dt):                     %.6e\n", param->dt);
     fprintf(stdout, "    Cutoff radius:                     %.6e\n", param->cutforce);
     fprintf(stdout, "    Skin distance:                     %.6e\n", param->skin);
-    fprintf(stdout, "    Skin distance (inner):             %.6e\n", param->skin_inner);
     fprintf(stdout,
-        "    Double cutoff:                     %s\n",
-        param->enable_double_cutoff ? "yes" : "no");
+        "    Outer skin (additive):             %.6e\n",
+        param->outer_skin);
     fprintf(stdout,
         "    Half neighbor-lists:               %s\n",
         param->half_neigh ? "yes" : "no");

--- a/src/common/parameter.c
+++ b/src/common/parameter.c
@@ -97,16 +97,18 @@ void initParameter(Parameter* param)
     param->pbc_x            = 1;
     param->pbc_y            = 1;
     param->pbc_z            = 1;
-    param->cutforce         = 2.5;
-    param->skin             = 0.3;
-    param->cutneigh         = param->cutforce + param->skin;
+    param->cutforce            = 2.5;
+    param->skin                = 0.3;
+    param->skin_inner          = 0.0;
+    param->cutneigh            = param->cutforce + param->skin;
+    param->enable_double_cutoff = 1;
     param->temp             = 1.44;
     param->nstat            = 100;
     param->mass             = 1.0;
     param->dtforce          = 0.5 * param->dt;
     param->reneigh_every    = 20;
     param->resort_every     = 400;
-    param->prune_every      = 1000;
+    param->prune_every      = 5;
     param->x_out_every      = 20;
     param->v_out_every      = 5;
     param->half_neigh       = 0;
@@ -121,6 +123,13 @@ void initParameter(Parameter* param)
     param->method        = 0;
     param->balance_every = param->reneigh_every;
     param->setup         = 1;
+
+#ifdef _OPENMP
+    // Use static scheduling as default
+    if (getenv("OMP_SCHEDULE") == NULL) {
+        omp_set_schedule(omp_sched_static, 0);
+    }
+#endif
 }
 
 void readTypesFile(Parameter* param)
@@ -203,12 +212,14 @@ void readParameter(Parameter* param, const char* filename)
         char* tok = strtok(line, " \t\n\r");
         char* val = strtok(NULL, " \t\n\r");
 
+// Exact-match: strncmp with the name length was a prefix match, so e.g.
+// "skin_inner" matched both `skin` and `skin_inner` and clobbered the first.
 #define PARSE_PARAM(p, f)                                                                \
-    if (strncmp(tok, #p, sizeof(#p) / sizeof(#p[0]) - 1) == 0) {                         \
+    if (strcmp(tok, #p) == 0) {                                                          \
         param->p = f(val);                                                               \
     }
 #define PARSE_PARAM_FLAG(p, f, flag)                                                     \
-    if (strncmp(tok, #p, sizeof(#p) / sizeof(#p[0]) - 1) == 0) {                         \
+    if (strcmp(tok, #p) == 0) {                                                          \
         param->p = f(val);                                                               \
         flag     = 1;                                                                    \
     }
@@ -229,6 +240,8 @@ void readParameter(Parameter* param, const char* filename)
             PARSE_REAL(dt);
             PARSE_REAL(cutforce);
             PARSE_REAL(skin);
+            PARSE_REAL(skin_inner);
+            PARSE_INT(enable_double_cutoff);
             PARSE_REAL(temp);
             PARSE_REAL(mass);
             PARSE_REAL(proc_freq);
@@ -275,6 +288,14 @@ void readParameter(Parameter* param, const char* filename)
 
     // Update balance parameter, 10 could be change
     param->balance_every *= param->reneigh_every;
+
+    if (param->skin_inner > param->skin) {
+        fprintf(stderr,
+            "WARN: skin_inner (%.6e) > skin (%.6e); clamping.\n",
+            (double)param->skin_inner,
+            (double)param->skin);
+        param->skin_inner = param->skin;
+    }
     fclose(fp);
 }
 
@@ -379,6 +400,10 @@ void printParameter(Parameter* param)
     fprintf(stdout, "    Timestep (dt):                     %.6e\n", param->dt);
     fprintf(stdout, "    Cutoff radius:                     %.6e\n", param->cutforce);
     fprintf(stdout, "    Skin distance:                     %.6e\n", param->skin);
+    fprintf(stdout, "    Skin distance (inner):             %.6e\n", param->skin_inner);
+    fprintf(stdout,
+        "    Double cutoff:                     %s\n",
+        param->enable_double_cutoff ? "yes" : "no");
     fprintf(stdout,
         "    Half neighbor-lists:               %s\n",
         param->half_neigh ? "yes" : "no");

--- a/src/common/parameter.c
+++ b/src/common/parameter.c
@@ -211,14 +211,14 @@ void readParameter(Parameter* param, const char* filename)
         char* tok = strtok(line, " \t\n\r");
         char* val = strtok(NULL, " \t\n\r");
 
-// Exact-match: strncmp with the name length was a prefix match, so e.g.
-// "outer_skin" matched both `skin` and `outer_skin` and clobbered the first.
+#define PARAM_NAME_LEN(p)   (sizeof(#p) / sizeof(#p[0]) - 1)
+#define PARAM_MATCH(tok, p) (strlen(tok) == PARAM_NAME_LEN(p) && strncmp(tok, #p, PARAM_NAME_LEN(p)) == 0)
 #define PARSE_PARAM(p, f)                                                                \
-    if (strcmp(tok, #p) == 0) {                                                          \
+    if (PARAM_MATCH(tok, p)) {                                                           \
         param->p = f(val);                                                               \
     }
 #define PARSE_PARAM_FLAG(p, f, flag)                                                     \
-    if (strcmp(tok, #p) == 0) {                                                          \
+    if (PARAM_MATCH(tok, p)) {                                                           \
         param->p = f(val);                                                               \
         flag     = 1;                                                                    \
     }
@@ -287,12 +287,9 @@ void readParameter(Parameter* param, const char* filename)
     // Update balance parameter, 10 could be change
     param->balance_every *= param->reneigh_every;
 
-    if (param->outer_skin < 0.0) {
-        fprintf(stderr,
-            "WARN: outer_skin (%.6e) < 0; clamping to 0.\n",
-            (double)param->outer_skin);
-        param->outer_skin = 0.0;
-    }
+    // Clamp outer skin parameter to 0.0 if required
+    param->outer_skin = MAX(param->outer_skin, 0.0);
+
     param->cutneigh = param->cutforce + param->skin + param->outer_skin;
     fclose(fp);
 }

--- a/src/common/parameter.c
+++ b/src/common/parameter.c
@@ -101,7 +101,7 @@ void initParameter(Parameter* param)
     param->skin                = 0.3;
     param->skin_inner          = 0.0;
     param->cutneigh            = param->cutforce + param->skin;
-    param->enable_double_cutoff = 1;
+    param->enable_double_cutoff = 0;
     param->temp             = 1.44;
     param->nstat            = 100;
     param->mass             = 1.0;

--- a/src/common/parameter.h
+++ b/src/common/parameter.h
@@ -101,10 +101,9 @@ typedef struct {
     MD_FLOAT dt;
     MD_FLOAT dtforce;
     MD_FLOAT skin;
-    MD_FLOAT skin_inner;
+    MD_FLOAT outer_skin;
     MD_FLOAT cutforce;
     MD_FLOAT cutneigh;
-    int enable_double_cutoff;
     int nx, ny, nz;
     int pbc_x, pbc_y, pbc_z;
     MD_FLOAT lattice;

--- a/src/common/parameter.h
+++ b/src/common/parameter.h
@@ -101,8 +101,10 @@ typedef struct {
     MD_FLOAT dt;
     MD_FLOAT dtforce;
     MD_FLOAT skin;
+    MD_FLOAT skin_inner;
     MD_FLOAT cutforce;
     MD_FLOAT cutneigh;
+    int enable_double_cutoff;
     int nx, ny, nz;
     int pbc_x, pbc_y, pbc_z;
     MD_FLOAT lattice;

--- a/src/common/simd/avx2_double.h
+++ b/src/common/simd/avx2_double.h
@@ -117,7 +117,9 @@ static inline MD_SIMD_MASK simd_mask_cond_lt(MD_SIMD_FLOAT a, MD_SIMD_FLOAT b)
 }
 static inline MD_SIMD_MASK simd_mask_i32_cond_lt(MD_SIMD_INT a, MD_SIMD_INT b)
 {
-    return _mm256_cvtepi32_pd(_mm_cmplt_epi32(a, b));
+    // Sign-extend 4x32-bit comparison result to 4x64-bit, then cast to double mask.
+    // _mm256_cvtepi32_pd would convert -1 to -1.0 (0xBFF0...) rather than all-ones.
+    return _mm256_castsi256_pd(_mm256_cvtepi32_epi64(_mm_cmplt_epi32(a, b)));
 }
 static inline MD_SIMD_MASK simd_mask_and(MD_SIMD_MASK a, MD_SIMD_MASK b)
 {

--- a/src/verletlist/forceCuda.cu
+++ b/src/verletlist/forceCuda.cu
@@ -9,12 +9,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 //---
-#include <cuda_profiler_api.h>
-#include <cuda_runtime.h>
-//---
 #include <likwid-marker.h>
 
 #include <device.h>
+#include <gpu_profiler.h>
 
 extern "C" {
 #include <allocate.h>
@@ -261,7 +259,7 @@ double computeForceLJCUDA(Parameter* param, Atom* atom, Neighbor* neighbor, Stat
     // HINT: Run with cuda-memcheck ./MDBench-NVCC in case of error
     // memsetGPU(atom->d_atom.fx, 0, sizeof(MD_FLOAT) * Nlocal * 3);
 
-    cudaProfilerStart();
+    GPU_PROFILE_START("force_lj");
     const int num_blocks = ceil((float)Nlocal / (float)num_threads_per_block);
     double S             = getTimeStamp();
     LIKWID_MARKER_START("force");
@@ -297,7 +295,7 @@ double computeForceLJCUDA(Parameter* param, Atom* atom, Neighbor* neighbor, Stat
 
     cuda_assert("computeForceLJCuda", cudaPeekAtLastError());
     cuda_assert("computeForceLJCuda", cudaDeviceSynchronize());
-    cudaProfilerStop();
+    GPU_PROFILE_STOP();
 
     LIKWID_MARKER_STOP("force");
     double E = getTimeStamp();

--- a/src/verletlist/main.c
+++ b/src/verletlist/main.c
@@ -395,7 +395,9 @@ int main(int argc, char** argv)
             timer[NEIGH] += reneighbour(n, &param, &atom, &neighbor, &comm);
         } else {
             timer[FORWARD] += forward(&comm, &atom, &param);
+#ifndef _MPI
             updatePbc(&atom, &param, false);
+#endif
         }
 
 #if defined(MEM_TRACER) || defined(INDEX_TRACER)

--- a/src/verletlist/main.c
+++ b/src/verletlist/main.c
@@ -395,6 +395,7 @@ int main(int argc, char** argv)
             timer[NEIGH] += reneighbour(n, &param, &atom, &neighbor, &comm);
         } else {
             timer[FORWARD] += forward(&comm, &atom, &param);
+            updatePbc(&atom, &param, false);
         }
 
 #if defined(MEM_TRACER) || defined(INDEX_TRACER)

--- a/src/verletlist/neighbor.c
+++ b/src/verletlist/neighbor.c
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include <allocate.h>
 #include <atom.h>
 #include <neighbor.h>
 #include <parameter.h>
@@ -228,7 +229,7 @@ void setupNeighbor(Parameter* param)
     if (stencil) {
         free(stencil);
     }
-    stencil = (int*)malloc(
+    stencil = (int*)allocate(ALIGNMENT,
         (2 * nextz + 1) * (2 * nexty + 1) * (2 * nextx + 1) * sizeof(int));
     nstencil   = 0;
     int kstart = -nextz;
@@ -250,11 +251,11 @@ void setupNeighbor(Parameter* param)
     if (bincount) {
         free(bincount);
     }
-    bincount = (int*)malloc(mbins * sizeof(int));
+    bincount = (int*)allocate(ALIGNMENT, mbins * sizeof(int));
     if (bins) {
         free(bins);
     }
-    bins = (int*)malloc(mbins * atoms_per_bin * sizeof(int));
+    bins = (int*)allocate(ALIGNMENT, mbins * atoms_per_bin * sizeof(int));
 }
 
 void buildNeighborCPU(Atom* atom, Neighbor* neighbor)
@@ -267,8 +268,8 @@ void buildNeighborCPU(Atom* atom, Neighbor* neighbor)
         nmax = nall;
         if (neighbor->numneigh) free(neighbor->numneigh);
         if (neighbor->neighbors) free(neighbor->neighbors);
-        neighbor->numneigh  = (int*)malloc(nmax * sizeof(int));
-        neighbor->neighbors = (int*)malloc(nmax * neighbor->maxneighs * sizeof(int));
+        neighbor->numneigh  = (int*)allocate(ALIGNMENT, nmax * sizeof(int));
+        neighbor->neighbors = (int*)allocate(ALIGNMENT, nmax * neighbor->maxneighs * sizeof(int));
     }
 
     /* bin local & ghost atoms */
@@ -339,7 +340,7 @@ void buildNeighborCPU(Atom* atom, Neighbor* neighbor)
             printf("RESIZE %d, PROC %d\n", neighbor->maxneighs, me);
             neighbor->maxneighs = new_maxneighs * 1.2;
             free(neighbor->neighbors);
-            neighbor->neighbors = (int*)malloc(
+            neighbor->neighbors = (int*)allocate(ALIGNMENT,
                 atom->Nmax * neighbor->maxneighs * sizeof(int));
         }
     }
@@ -456,7 +457,7 @@ void binatoms(Atom* atom)
         if (resize) {
             free(bins);
             atoms_per_bin *= 2;
-            bins = (int*)malloc(mbins * atoms_per_bin * sizeof(int));
+            bins = (int*)allocate(ALIGNMENT, mbins * atoms_per_bin * sizeof(int));
         }
     }
 
@@ -476,15 +477,15 @@ void sortAtom(Atom* atom)
     }
 
 #ifdef ATOM_POSITION_AOS
-    MD_FLOAT* new_x  = (MD_FLOAT*)malloc(Nmax * sizeof(MD_FLOAT) * 3);
-    MD_FLOAT* new_vx = (MD_FLOAT*)malloc(Nmax * sizeof(MD_FLOAT) * 3);
+    MD_FLOAT* new_x  = (MD_FLOAT*)allocate(ALIGNMENT, Nmax * sizeof(MD_FLOAT) * 3);
+    MD_FLOAT* new_vx = (MD_FLOAT*)allocate(ALIGNMENT, Nmax * sizeof(MD_FLOAT) * 3);
 #else
-    MD_FLOAT* new_x  = (MD_FLOAT*)malloc(Nmax * sizeof(MD_FLOAT));
-    MD_FLOAT* new_y  = (MD_FLOAT*)malloc(Nmax * sizeof(MD_FLOAT));
-    MD_FLOAT* new_z  = (MD_FLOAT*)malloc(Nmax * sizeof(MD_FLOAT));
-    MD_FLOAT* new_vx = (MD_FLOAT*)malloc(Nmax * sizeof(MD_FLOAT));
-    MD_FLOAT* new_vy = (MD_FLOAT*)malloc(Nmax * sizeof(MD_FLOAT));
-    MD_FLOAT* new_vz = (MD_FLOAT*)malloc(Nmax * sizeof(MD_FLOAT));
+    MD_FLOAT* new_x  = (MD_FLOAT*)allocate(ALIGNMENT, Nmax * sizeof(MD_FLOAT));
+    MD_FLOAT* new_y  = (MD_FLOAT*)allocate(ALIGNMENT, Nmax * sizeof(MD_FLOAT));
+    MD_FLOAT* new_z  = (MD_FLOAT*)allocate(ALIGNMENT, Nmax * sizeof(MD_FLOAT));
+    MD_FLOAT* new_vx = (MD_FLOAT*)allocate(ALIGNMENT, Nmax * sizeof(MD_FLOAT));
+    MD_FLOAT* new_vy = (MD_FLOAT*)allocate(ALIGNMENT, Nmax * sizeof(MD_FLOAT));
+    MD_FLOAT* new_vz = (MD_FLOAT*)allocate(ALIGNMENT, Nmax * sizeof(MD_FLOAT));
 #endif
     MD_FLOAT* old_x  = atom->x;
     MD_FLOAT* old_y  = atom->y;
@@ -595,8 +596,8 @@ static void neighborGhost(Atom* atom, Neighbor* neighbor)
     int Nlocal = atom->Nlocal;
     int Nghost = atom->Nghost;
     if (neighbor->listshell) free(neighbor->listshell);
-    neighbor->listshell = (int*)malloc(Nghost * sizeof(int));
-    int* listzone       = (int*)malloc(8 * Nghost * sizeof(int));
+    neighbor->listshell = (int*)allocate(ALIGNMENT, Nghost * sizeof(int));
+    int* listzone       = (int*)allocate(ALIGNMENT, 8 * Nghost * sizeof(int));
     int countAtoms[8]   = { 0, 0, 0, 0, 0, 0, 0, 0 };
 
     // Selecting ghost atoms for interaction
@@ -617,8 +618,8 @@ static void neighborGhost(Atom* atom, Neighbor* neighbor)
     neighbor->Nshell = Nshell;
     if (neighbor->numNeighShell) free(neighbor->numNeighShell);
     if (neighbor->neighshell) free(neighbor->neighshell);
-    neighbor->neighshell    = (int*)malloc(Nshell * neighbor->maxneighs * sizeof(int));
-    neighbor->numNeighShell = (int*)malloc(Nshell * sizeof(int));
+    neighbor->neighshell    = (int*)allocate(ALIGNMENT, Nshell * neighbor->maxneighs * sizeof(int));
+    neighbor->numNeighShell = (int*)allocate(ALIGNMENT, Nshell * sizeof(int));
     int resize              = 1;
 
     while (resize) {
@@ -682,7 +683,7 @@ static void neighborGhost(Atom* atom, Neighbor* neighbor)
 
         if (resize) {
             free(neighbor->neighshell);
-            neighbor->neighshell = (int*)malloc(
+            neighbor->neighshell = (int*)allocate(ALIGNMENT,
                 Nshell * neighbor->maxneighs * sizeof(int));
         }
     }

--- a/src/verletlist/neighborCuda.cu
+++ b/src/verletlist/neighborCuda.cu
@@ -4,14 +4,13 @@
  * Use of this source code is governed by a LGPL-3.0
  * license that can be found in the LICENSE file.
  */
-#include <cuda_profiler_api.h>
-#include <cuda_runtime.h>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 //---
 
 #include <device.h>
+#include <gpu_profiler.h>
 
 extern "C" {
 #include <atom.h>
@@ -261,7 +260,7 @@ void buildNeighborCUDA(Atom* atom, Neighbor* neighbor)
     DEBUG_MESSAGE("buildNeighborCUDA begin\n");
     DeviceNeighbor* d_neighbor      = &(neighbor->d_neighbor);
     const int num_threads_per_block = get_cuda_num_threads();
-    cudaProfilerStart();
+    GPU_PROFILE_START("build_neighbor");
 
     int nall = atom->Nlocal + atom->Nghost;
     if (nall > nmax) {
@@ -359,6 +358,6 @@ void buildNeighborCUDA(Atom* atom, Neighbor* neighbor)
         }
     }
 
-    cudaProfilerStop();
+    GPU_PROFILE_STOP();
     DEBUG_MESSAGE("buildNeighborCUDA end\n");
 }

--- a/tests/test_double_cutoff.sh
+++ b/tests/test_double_cutoff.sh
@@ -78,18 +78,31 @@ echo "Baseline  : T=${base_T}  P=${base_P}"
 echo "Config A  : T=${a_T}     P=${a_P}"
 echo "Config B  : T=${b_T}     P=${b_P}"
 
-# --- Compare two values against a tolerance (relative error) -----------------
+# --- Compare two values against a tolerance ----------------------------------
 # Usage: check_rel <label> <got> <ref> <tol>
+# Relative error when |ref| >= EPS; otherwise falls back to absolute error
+# (tol interpreted as an absolute tolerance) to avoid division by zero / blow-up
+# on near-zero references such as baseline pressure in some configurations.
+EPS="1e-12"
 check_rel() {
     local label="$1" got="$2" ref="$3" tol="$4"
     local ok
-    ok=$(awk -v a="${got}" -v b="${ref}" -v t="${tol}" \
-        'BEGIN { d = a - b; if (d < 0) d = -d; print (d / (b < 0 ? -b : b) <= t) ? "1" : "0" }')
+    ok=$(awk -v a="${got}" -v b="${ref}" -v t="${tol}" -v eps="${EPS}" \
+        'BEGIN {
+            d = a - b; if (d < 0) d = -d;
+            ab = (b < 0 ? -b : b);
+            err = (ab < eps) ? d : d / ab;
+            print (err <= t) ? "1" : "0";
+         }')
     if [[ "${ok}" != "1" ]]; then
         local diff
-        diff=$(awk -v a="${got}" -v b="${ref}" \
-            'BEGIN { d = a - b; if (d < 0) d = -d; print d / (b < 0 ? -b : b) }')
-        echo "FAIL: ${label}: got ${got}, ref ${ref}, rel_err=${diff} > tol=${tol}" >&2
+        diff=$(awk -v a="${got}" -v b="${ref}" -v eps="${EPS}" \
+            'BEGIN {
+                d = a - b; if (d < 0) d = -d;
+                ab = (b < 0 ? -b : b);
+                print (ab < eps) ? d : d / ab;
+             }')
+        echo "FAIL: ${label}: got ${got}, ref ${ref}, err=${diff} > tol=${tol}" >&2
         return 1
     fi
 }

--- a/tests/test_double_cutoff.sh
+++ b/tests/test_double_cutoff.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Regression test for the double-cutoff scheme (--outer-skin).
+#
+# Runs three configurations of the FCC lattice testcase and verifies that
+# temperature and pressure remain physically consistent:
+#
+#   Baseline   : single-cutoff, skin=0.3, reneigh-every 20
+#   Config A   : double-cutoff, same outer cutoff (0.1+0.2=0.3), same rebuild schedule
+#                → near-identical dynamics, tight tolerance
+#   Config B   : double-cutoff, extended outer cutoff (0.3+0.4=0.7), fewer rebuilds
+#                → slight divergence from different rebuild times, loose tolerance
+#
+# Usage:
+#   ./tests/test_double_cutoff.sh /path/to/MDBench-<TAG>
+# or set MDBENCH_BIN in the environment.
+
+BIN="${1:-${MDBENCH_BIN:-}}"
+
+if [[ -z "${BIN}" ]]; then
+    echo "Usage: $0 /path/to/MDBench-<TAG>  (or set MDBENCH_BIN)" >&2
+    exit 1
+fi
+
+if [[ ! -x "${BIN}" ]]; then
+    echo "Binary '${BIN}' is not executable" >&2
+    exit 1
+fi
+
+# Skip gracefully when the binary was not built with double-cutoff support
+# (i.e. it is not a clusterpair build).
+if ! "${BIN}" --help 2>&1 | grep -q "outer-skin"; then
+    echo "Binary does not support --outer-skin (not a clusterpair build), skipping."
+    exit 0
+fi
+
+COMMON_ARGS="-n 200 -r 2.5"
+
+LOG_BASE="$(mktemp "${TMPDIR:-/tmp}/mdbench_dcut_base.XXXXXX")"
+LOG_A="$(mktemp    "${TMPDIR:-/tmp}/mdbench_dcut_A.XXXXXX")"
+LOG_B="$(mktemp    "${TMPDIR:-/tmp}/mdbench_dcut_B.XXXXXX")"
+
+cleanup() { rm -f "${LOG_BASE}" "${LOG_A}" "${LOG_B}"; }
+
+extract_tp() {
+    local file="$1"
+    grep -E '^[[:space:]]*[0-9]+[[:space:]]+[0-9.eE+-]+' "${file}" | tail -n 1 || true
+}
+
+echo "Running baseline (skin=0.3, reneigh-every 20)..."
+"${BIN}" ${COMMON_ARGS} -s 0.3 --reneigh-every 20 >"${LOG_BASE}"
+
+echo "Running Config A (skin=0.1, outer-skin=0.2, prune-every 4, reneigh-every 20)..."
+"${BIN}" ${COMMON_ARGS} -s 0.1 --outer-skin 0.2 --prune-every 4 --reneigh-every 20 >"${LOG_A}"
+
+echo "Running Config B (skin=0.3, outer-skin=0.4, prune-every 10, reneigh-every 40)..."
+"${BIN}" ${COMMON_ARGS} -s 0.3 --outer-skin 0.4 --prune-every 10 --reneigh-every 40 >"${LOG_B}"
+
+base_line="$(extract_tp "${LOG_BASE}")"
+a_line="$(extract_tp    "${LOG_A}")"
+b_line="$(extract_tp    "${LOG_B}")"
+
+if [[ -z "${base_line}" || -z "${a_line}" || -z "${b_line}" ]]; then
+    echo "Could not extract thermo lines from one or more outputs." >&2
+    echo "Logs: ${LOG_BASE}  ${LOG_A}  ${LOG_B}" >&2
+    exit 1
+fi
+
+base_T=$(echo "${base_line}" | awk '{print $2}')
+base_P=$(echo "${base_line}" | awk '{print $3}')
+a_T=$(echo    "${a_line}"    | awk '{print $2}')
+a_P=$(echo    "${a_line}"    | awk '{print $3}')
+b_T=$(echo    "${b_line}"    | awk '{print $2}')
+b_P=$(echo    "${b_line}"    | awk '{print $3}')
+
+echo "Baseline  : T=${base_T}  P=${base_P}"
+echo "Config A  : T=${a_T}     P=${a_P}"
+echo "Config B  : T=${b_T}     P=${b_P}"
+
+# --- Compare two values against a tolerance (relative error) -----------------
+# Usage: check_rel <label> <got> <ref> <tol>
+check_rel() {
+    local label="$1" got="$2" ref="$3" tol="$4"
+    local ok
+    ok=$(awk -v a="${got}" -v b="${ref}" -v t="${tol}" \
+        'BEGIN { d = a - b; if (d < 0) d = -d; print (d / (b < 0 ? -b : b) <= t) ? "1" : "0" }')
+    if [[ "${ok}" != "1" ]]; then
+        local diff
+        diff=$(awk -v a="${got}" -v b="${ref}" \
+            'BEGIN { d = a - b; if (d < 0) d = -d; print d / (b < 0 ? -b : b) }')
+        echo "FAIL: ${label}: got ${got}, ref ${ref}, rel_err=${diff} > tol=${tol}" >&2
+        return 1
+    fi
+}
+
+# Config A: same outer cutoff (0.1+0.2=0.3) and same rebuild schedule as baseline
+# → prune does not alter any non-zero force pair; expect near-identical dynamics.
+TIGHT_T="1e-4"
+TIGHT_P="1e-3"
+
+# Config B: wider outer cutoff, different rebuild interval (40 vs 20 steps)
+# → physical divergence from different rebuild times; loose tolerance.
+LOOSE_T="2e-2"
+LOOSE_P="5e-2"
+
+pass=1
+check_rel "Config A temperature" "${a_T}" "${base_T}" "${TIGHT_T}" || pass=0
+check_rel "Config A pressure"    "${a_P}" "${base_P}" "${TIGHT_P}" || pass=0
+check_rel "Config B temperature" "${b_T}" "${base_T}" "${LOOSE_T}" || pass=0
+check_rel "Config B pressure"    "${b_P}" "${base_P}" "${LOOSE_P}" || pass=0
+
+if [[ "${pass}" != "1" ]]; then
+    echo "Logs: ${LOG_BASE}  ${LOG_A}  ${LOG_B}" >&2
+    exit 1
+fi
+
+cleanup
+echo "Double-cutoff regression PASSED."


### PR DESCRIPTION
This branch covers the following:
- Proper adjustments to memory management calls like allocate() vs malloc()
- Adjustments and evaluation of GPU kernels in AMD GPUs
- Introduction of double cutoff/neighbor-lists scheme to significantly reduce the neighbor-lists time contribution when running kernels on the GPU (specially for the Cluster Pair cases)